### PR TITLE
Fix exception for missing entry and status handlers

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -17,7 +17,7 @@ package cmd
 
 import (
 	"context"
-	"fmt"
+	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"time"
@@ -26,40 +26,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
-
-//type LeafData struct {
-//	File string `json:"file"`
-//	Hash string `json:"hash"`
-//}
-
-//type LeafData struct {
-//	Signatures []struct {
-//		Keyid string `json:"keyid"`
-//		Sig   string `json:"sig"`
-//	} `json:"signatures"`
-//	Signed struct {
-//		Type       string `json:"_type"`
-//		Byproducts struct {
-//			ReturnValue int    `json:"return-value"`
-//			Stderr      string `json:"stderr"`
-//			Stdout      string `json:"stdout"`
-//		} `json:"byproducts"`
-//		Command     []string `json:"command"`
-//		Environment struct {
-//		} `json:"environment"`
-//		Materials struct {
-//			FooPy struct {
-//				Sha256 string `json:"sha256"`
-//			} `json:"foo.py"`
-//		} `json:"materials"`
-//		Name     string `json:"name"`
-//		Products struct {
-//			FooTarGz struct {
-//				Sha256 string `json:"sha256"`
-//			} `json:"foo.tar.gz"`
-//		} `json:"products"`
-//	} `json:"signed"`
-//}
 
 // addCmd represents the add command
 var addCmd = &cobra.Command{
@@ -98,7 +64,15 @@ then hash the file into the transparency log`,
 		if err != nil {
 			log.Fatal(err)
 		}
-		fmt.Println(string(content))
+
+		resp := getLeafResponse{}
+
+		if err := json.Unmarshal(content, &resp); err != nil {
+			log.Fatal(err)
+		}
+
+		log.Info("Status: ", resp.Status)
+
 	},
 }
 

--- a/cmd/getleaf.go
+++ b/cmd/getleaf.go
@@ -36,17 +36,18 @@ import (
 	"github.com/spf13/viper"
 )
 
+type getLeafResponse struct {
+	Status RespStatusCode
+	Leaf   *trillian.GetLeavesByIndexResponse
+	Key    []byte
+}
+
 func GenerateRand(length int) string {
 	b := make([]byte, length)
 	if _, err := rand.Read(b); err != nil {
 		return ""
 	}
 	return hex.EncodeToString(b)
-}
-
-type getLeafResponse struct {
-	Leaf *trillian.GetLeavesByIndexResponse
-	Key  []byte
 }
 
 var getleafCmd = &cobra.Command{
@@ -87,6 +88,8 @@ var getleafCmd = &cobra.Command{
 		if err := json.Unmarshal(content, &resp); err != nil {
 			log.Fatal(err)
 		}
+
+		log.Info("Status: ", resp.Status)
 
 		pub, err := x509.ParsePKIXPublicKey(resp.Key)
 		if err != nil {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -43,9 +43,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type RespStatusCode struct {
+	Code string `json:"file_recieved"`
+}
+
 type latestResponse struct {
-	Proof *trillian.GetLatestSignedLogRootResponse
-	Key   []byte
+	Status RespStatusCode
+	Proof  *trillian.GetLatestSignedLogRootResponse
+	Key    []byte
 }
 
 type state struct {
@@ -150,12 +155,12 @@ var updateCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		fmt.Println(string(content))
-
 		resp := latestResponse{}
 		if err := json.Unmarshal(content, &resp); err != nil {
 			log.Fatal(err)
 		}
+
+		log.Info("Status: ", resp.Status)
 
 		pub, err := x509.ParsePKIXPublicKey(resp.Key)
 		if err != nil {


### PR DESCRIPTION
This fixes an issue where a getproof call against a missing entry caused an exception, this is now captured gracefully. 

There is also a rig in of status captuing to make all functions shown an GPRC status code.

This patch needs the mapped PR in rekor-server as well 

https://github.com/projectrekor/rekor-server/pull/37