### PR TITLE
Refactor to allow shared components

### DIFF
--- a/app/client.go
+++ b/app/client.go
@@ -1,4 +1,4 @@
-package cmd
+package app
 
 import (
 	"bytes"
@@ -10,15 +10,22 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/google/trillian"
 	tclient "github.com/google/trillian/client"
 	tcrypto "github.com/google/trillian/crypto"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/merkle/rfc6962"
-	"github.com/prometheus/common/log"
+	"github.com/projectrekor/rekor-cli/log"
 )
 
-func DoGet(url string, rekorEntry []byte) {
+type getProofResponse struct {
+	Status string
+	Proof  *trillian.GetInclusionProofByHashResponse
+	Key    []byte
+}
 
+func DoGet(url string, rekorEntry []byte) {
+	log := log.Logger
 	// Set Context with Timeout for connects to thde log rpc server
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -28,7 +35,7 @@ func DoGet(url string, rekorEntry []byte) {
 		log.Fatal(err)
 	}
 
-	if err := addFileToRequest(request, bytes.NewReader(rekorEntry)); err != nil {
+	if err := AddFileToRequest(request, bytes.NewReader(rekorEntry)); err != nil {
 		log.Fatal(err)
 	}
 

--- a/app/file.go
+++ b/app/file.go
@@ -1,4 +1,4 @@
-package cmd
+package app
 
 import (
 	"bytes"
@@ -8,7 +8,7 @@ import (
 	"net/http"
 )
 
-func addFileToRequest(request *http.Request, r io.Reader) error {
+func AddFileToRequest(request *http.Request, r io.Reader) error {
 
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/projectrekor/rekor-cli/app"
 	"github.com/projectrekor/rekor-cli/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -53,7 +54,7 @@ then hash the file into the transparency log`,
 		if err != nil {
 			log.Fatal(err)
 		}
-		if err := addFileToRequest(request, f); err != nil {
+		if err := app.AddFileToRequest(request, f); err != nil {
 			log.Fatal(err)
 		}
 		client := &http.Client{}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -18,18 +18,12 @@ package cmd
 import (
 	"io/ioutil"
 
-	"github.com/google/trillian"
+	"github.com/projectrekor/rekor-cli/app"
 	"github.com/projectrekor/rekor-cli/log"
 	"github.com/spf13/viper"
 
 	"github.com/spf13/cobra"
 )
-
-type getProofResponse struct {
-	Status string
-	Proof  *trillian.GetInclusionProofByHashResponse
-	Key    []byte
-}
 
 // getCmd represents the get command
 var getCmd = &cobra.Command{
@@ -48,7 +42,7 @@ exists within the transparency log`,
 		if err != nil {
 			log.Fatal(err)
 		}
-		DoGet(url, rekorEntry)
+		app.DoGet(url, rekorEntry)
 	},
 }
 

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -1,0 +1,45 @@
+/*
+Copyright © 2020 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// rekor upload --signature=acme.sig --public-key=acme.pub --artifact=https://acmeproject/acme123.tar.gz | ./acme123.tar.gz --sha
+package cmd
+
+import (
+	"github.com/projectrekor/rekor-cli/log"
+	"github.com/spf13/cobra"
+)
+
+// uploadCmd represents the upload command
+var uploadCmd = &cobra.Command{
+	Use:   "upload",
+	Short: "Upload a rekord to rekor",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		log := log.Logger
+		log.Info("Upload Called")
+		// rekorServer := viper.GetString("rekor_server")
+		// url := rekorServer + "/api/v1/upload"
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(uploadCmd)
+}

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/projectrekor/rekor-cli/app"
 	"github.com/projectrekor/rekor-cli/log"
 	"github.com/projectrekor/rekor-server/types"
 
@@ -78,7 +79,7 @@ var verifyCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		DoGet(url, b)
+		app.DoGet(url, b)
 	},
 }
 


### PR DESCRIPTION
This change refactors client.go and file.go into an `app` package.

This will make it more easily consumed by rekor-ctl

Once this change is in, I will push rekor-ctl up and then look to
further refactor use of code already duped in rekor-server

Relates-to: #29 