### PR TITLE
Create a "cli" directory under cmd.

### DIFF
--- a/cmd/cli/app/root.go
+++ b/cmd/cli/app/root.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package app
 
 import (
 	"fmt"

--- a/cmd/cli/app/upload.go
+++ b/cmd/cli/app/upload.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package app
 
 import (
 	"bytes"
@@ -32,8 +32,8 @@ import (
 
 	"github.com/google/trillian"
 	homedir "github.com/mitchellh/go-homedir"
-	"github.com/projectrekor/rekor-cli/app"
-	"github.com/projectrekor/rekor-cli/log"
+	"github.com/projectrekor/rekor/log"
+	"github.com/projectrekor/rekor/pkg"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/crypto/openpgp"
@@ -122,13 +122,13 @@ of the release artifact and uploads it to the rekor server.`,
 		// Let's check the formatting is correct, if not we
 		// exit and allow the user to resolve their corrupted
 		// GPG files.
-		sig, err := app.FormatSignature(signature)
+		sig, err := pkg.FormatSignature(signature)
 		if err != nil {
 			log.Error("Signature validation failed: ", err)
 			os.Exit(1)
 		}
 
-		pub_key, err := app.FormatPubKey(publicKey)
+		pub_key, err := pkg.FormatPubKey(publicKey)
 		if err != nil {
 			log.Error("Pubic key validation failed: ", err)
 			os.Exit(1)
@@ -249,7 +249,7 @@ of the release artifact and uploads it to the rekor server.`,
 			log.Fatal(err)
 		}
 
-		if err := app.AddFileToRequest(request, f); err != nil {
+		if err := pkg.AddFileToRequest(request, f); err != nil {
 			log.Fatal(err)
 		}
 		client := &http.Client{}

--- a/cmd/cli/app/verify.go
+++ b/cmd/cli/app/verify.go
@@ -13,16 +13,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cmd
+package app
 
 import (
 	"encoding/json"
 	"io/ioutil"
 	"os"
 
-	"github.com/projectrekor/rekor-cli/app"
-	"github.com/projectrekor/rekor-cli/log"
 	"github.com/projectrekor/rekor-server/types"
+	"github.com/projectrekor/rekor/log"
+	"github.com/projectrekor/rekor/pkg"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -79,7 +79,7 @@ var verifyCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		app.DoGet(url, b)
+		pkg.DoGet(url, b)
 	},
 }
 

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 package main
 
-import "github.com/projectrekor/rekor-cli/cmd"
+import "github.com/projectrekor/rekor/cmd/cli/app"
 
 func main() {
-	cmd.Execute()
+	app.Execute()
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/projectrekor/rekor-cli
+module github.com/projectrekor/rekor
 
 go 1.14
 

--- a/pkg/client.go
+++ b/pkg/client.go
@@ -1,4 +1,4 @@
-package app
+package pkg
 
 import (
 	"bytes"
@@ -15,7 +15,7 @@ import (
 	tcrypto "github.com/google/trillian/crypto"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/merkle/rfc6962"
-	"github.com/projectrekor/rekor-cli/log"
+	"github.com/projectrekor/rekor/log"
 )
 
 type getProofResponse struct {

--- a/pkg/file.go
+++ b/pkg/file.go
@@ -1,4 +1,4 @@
-package app
+package pkg
 
 import (
 	"bytes"

--- a/pkg/gpg.go
+++ b/pkg/gpg.go
@@ -1,4 +1,4 @@
-package app
+package pkg
 
 import (
 	"bytes"


### PR DESCRIPTION
This is the first step in code reorganization. This follows the patterns
from kubernetes/kubernetes - each binary gets a directory under cmd/.
The main.go file for each binary lives there.
The commands live under cmd/<binary name>/app.