### PR TITLE
Bring back URL into manifest

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -36,12 +36,12 @@ import (
 // RekorEntry is the API request.
 type RekorEntry struct {
 	Data      []byte
-	URL       string
 	RekorLeaf `json:"-"`
 }
 
 // RekorLeaf is the type we store in the log.
 type RekorLeaf struct {
+	URL       string
 	SHA       string
 	Signature []byte
 	PublicKey []byte
@@ -57,6 +57,7 @@ func (r *RekorLeaf) MarshalJSON() ([]byte, error) {
 	}
 	var cLeaf canonicalLeaf
 	cLeaf.SHA = r.SHA
+	cLeaf.URL = r.URL
 
 	var err error
 	cLeaf.Signature, err = r.sigObject.CanonicalValue()


### PR DESCRIPTION
The URL was not being stored and subsequently returned when
performing getLeaf by Index calls.

We should includes this information as its useful for monitors
who may want to query for the this dataset.