### PR TITLE
Move the API context to a global middleware.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/google/martian v2.1.0+incompatible
 	github.com/google/trillian v1.3.10
 	github.com/gorilla/handlers v1.5.1 // indirect
+	github.com/jessevdk/go-flags v1.4.0
 	github.com/kr/pretty v0.2.1 // indirect
 	github.com/magiconair/properties v1.8.4 // indirect
 	github.com/mitchellh/go-homedir v1.1.0

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -83,11 +83,7 @@ type ctxKeyRekorAPI int
 
 const rekorAPILookupKey ctxKeyRekorAPI = 0
 
-func AddAPIToContext(ctx context.Context) (context.Context, error) {
-	api, err := NewAPI(ctx)
-	if err != nil {
-		return nil, err
-	}
+func AddAPIToContext(ctx context.Context, api *API) (context.Context, error) {
 	return context.WithValue(ctx, rekorAPILookupKey, api), nil
 }
 

--- a/pkg/api/tlog.go
+++ b/pkg/api/tlog.go
@@ -35,7 +35,7 @@ import (
 
 func GetLogInfoHandler(params tlog.GetLogInfoParams) middleware.Responder {
 	httpReq := params.HTTPRequest
-	api, _ := NewAPI(httpReq.Context())
+	api := apiFromRequest(httpReq)
 
 	resp := api.client.getLatest(0)
 	if resp.status != codes.OK {
@@ -69,7 +69,7 @@ func GetLogProofHandler(params tlog.GetLogProofParams) middleware.Responder {
 	if *params.FirstSize > params.LastSize {
 		return handleRekorAPIError(params, http.StatusBadRequest, nil, fmt.Sprintf(firstSizeLessThanLastSize, *params.FirstSize, params.LastSize))
 	}
-	api, _ := NewAPI(httpReq.Context())
+	api := apiFromRequest(httpReq)
 
 	resp := api.client.getConsistencyProof(*params.FirstSize, params.LastSize)
 	if resp.status != codes.OK {


### PR DESCRIPTION
I think this is the same thing as registering it on each handler, not
100% sure though.