### PR TITLE
GRPC calls now use request-specific context

### DIFF
--- a/pkg/api/trillian_client.go
+++ b/pkg/api/trillian_client.go
@@ -37,6 +37,7 @@ type TrillianClient struct {
 	client  trillian.TrillianLogClient
 	logID   int64
 	context context.Context
+	pubkey  *keyspb.PublicKey
 }
 
 type Response struct {
@@ -48,14 +49,6 @@ type Response struct {
 	getLeafByRangeResult      *trillian.GetLeavesByRangeResponse
 	getLatestResult           *trillian.GetLatestSignedLogRootResponse
 	getConsistencyProofResult *trillian.GetConsistencyProofResponse
-}
-
-func TrillianClientInstance(client trillian.TrillianLogClient, tLogID int64, ctx context.Context) *TrillianClient {
-	return &TrillianClient{
-		client:  client,
-		logID:   tLogID,
-		context: ctx,
-	}
 }
 
 func (t *TrillianClient) root() (types.LogRootV1, error) {

--- a/pkg/generated/restapi/configure_rekor_server.go
+++ b/pkg/generated/restapi/configure_rekor_server.go
@@ -18,9 +18,7 @@ limitations under the License.
 package restapi
 
 import (
-	"context"
 	"crypto/tls"
-	"fmt"
 	"net/http"
 
 	"github.com/go-chi/chi/middleware"
@@ -141,17 +139,13 @@ func cacheForever(handler http.Handler) http.Handler {
 }
 
 func addTrillianAPI(handler http.Handler) http.Handler {
-	api, err := pkgapi.NewAPI(context.Background())
+	api, err := pkgapi.NewAPI()
 	if err != nil {
 		log.Logger.Panic(err)
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		apiCtx, err := pkgapi.AddAPIToContext(r.Context(), api)
-		if err != nil {
-			logAndServeError(w, r, fmt.Errorf("error adding trillian API object to request context: %v", err))
-		} else {
-			handler.ServeHTTP(w, r.WithContext(apiCtx))
-		}
+		apiCtx := pkgapi.AddAPIToContext(r.Context(), api)
+		handler.ServeHTTP(w, r.WithContext(apiCtx))
 	})
 }
 


### PR DESCRIPTION
After #77, we have one global GRPC channel for the entire process. This
change causes each GRPC call to be made on the incoming HTTP request's
context such that if an HTTP client cancels prematurely, we will handle
the GRPC cleanup appropriately.

Signed-off-by: Bob Callaway <bcallawa@redhat.com>