### PR TITLE
Checks correct response code to prevent duplicate insertion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d // indirect
 	golang.org/x/tools v0.0.0-20201208062317-e652b2f42cc7 // indirect
 	google.golang.org/appengine v1.6.7
+	google.golang.org/genproto v0.0.0-20200825200019-8632dd797987
 	google.golang.org/grpc v1.32.0
 	gopkg.in/ini.v1 v1.62.0 // indirect
 )

--- a/pkg/generated/restapi/configure_rekor_server.go
+++ b/pkg/generated/restapi/configure_rekor_server.go
@@ -113,11 +113,6 @@ func setupGlobalMiddleware(handler http.Handler) http.Handler {
 	returnHandler = middleware.Recoverer(returnHandler)
 	returnHandler = middleware.Heartbeat("/ping")(returnHandler)
 
-<<<<<<< HEAD
-	// add the Trillian API object in context for all endpoints
-	returnHandler = addTrillianAPI(returnHandler)
-=======
->>>>>>> 3c1d3dcffd67e28016997424572f67f222424bed
 	return middleware.RequestID(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		r = r.WithContext(log.WithRequestID(ctx, middleware.GetReqID(ctx)))

--- a/pkg/generated/restapi/configure_rekor_server.go
+++ b/pkg/generated/restapi/configure_rekor_server.go
@@ -109,12 +109,12 @@ func setupMiddlewares(handler http.Handler) http.Handler {
 // The middleware configuration happens before anything, this middleware also applies to serving the swagger.json document.
 // So this is a good place to plug in a panic handling middleware, logging and metrics
 func setupGlobalMiddleware(handler http.Handler) http.Handler {
-	returnHandler := middleware.Recoverer(handler)
-	returnHandler = middleware.Logger(returnHandler)
+	returnHandler := middleware.Logger(handler)
+	returnHandler = middleware.Recoverer(returnHandler)
 	returnHandler = middleware.Heartbeat("/ping")(returnHandler)
 
 	// add the Trillian API object in context for all endpoints
-	returnHandler = addTrillianAPI(handler)
+	returnHandler = addTrillianAPI(returnHandler)
 	return middleware.RequestID(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		r = r.WithContext(log.WithRequestID(ctx, middleware.GetReqID(ctx)))


### PR DESCRIPTION
QueuedLeafResponse holds the actual insertion response code, so check that instead of just the base GRPC status code.

Signed-off-by: Bob Callaway <bcallawa@redhat.com>