### PR TITLE
Move API initialization to the package init, and access to a package …

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,8 +64,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: Docker Build
         run: docker-compose build
-      - name: Docker Compose Start
-        run: docker-compose up -d
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GOVERSION }}

--- a/cmd/server/app/serve.go
+++ b/cmd/server/app/serve.go
@@ -18,6 +18,7 @@ package app
 
 import (
 	"github.com/go-openapi/loads"
+	"github.com/projectrekor/rekor/pkg/api"
 	"github.com/projectrekor/rekor/pkg/generated/restapi/operations"
 	"github.com/projectrekor/rekor/pkg/log"
 	"github.com/projectrekor/rekor/pkg/types/rekord"
@@ -58,6 +59,8 @@ var serveCmd = &cobra.Command{
 
 		server.Host = viper.GetString("rekor_server.address")
 		server.Port = int(viper.GetUint("rekor_server.port"))
+
+		api.ConfigureAPI()
 		server.ConfigureAPI()
 		if err := server.Serve(); err != nil {
 			log.Logger.Fatal(err)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.1'
 services:
   mysql:
-    image: gcr.io/trillian-opensource-ci/db_server
+    image: gcr.io/trillian-opensource-ci/db_server:3c8193ebb2d7fedb44d18e9c810d0d2e4dbb7e4d
     environment:
       - MYSQL_ROOT_PASSWORD=zaphod
       - MYSQL_DATABASE=test

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -81,21 +81,20 @@ func NewAPI() (*API, error) {
 	}, nil
 }
 
-type ctxKeyRekorAPI int
+var (
+	api *API
+)
 
-const rekorAPILookupKey ctxKeyRekorAPI = 0
-
-func AddAPIToContext(ctx context.Context, api *API) context.Context {
-	return context.WithValue(ctx, rekorAPILookupKey, api)
+func ConfigureAPI() {
+	var err error
+	api, err = NewAPI()
+	if err != nil {
+		log.Logger.Panic(err)
+	}
 }
 
-func NewTrillianClient(ctx context.Context) *TrillianClient {
-	api := ctx.Value(rekorAPILookupKey).(*API)
-	if api == nil {
-		return nil
-	}
-
-	return &TrillianClient{
+func NewTrillianClient(ctx context.Context) TrillianClient {
+	return TrillianClient{
 		client:  api.logClient,
 		logID:   api.logID,
 		context: ctx,

--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -43,9 +43,6 @@ import (
 
 func GetLogEntryByIndexHandler(params entries.GetLogEntryByIndexParams) middleware.Responder {
 	tc := NewTrillianClient(params.HTTPRequest.Context())
-	if tc == nil {
-		return handleRekorAPIError(params, http.StatusInternalServerError, errors.New("unable to get client from request context"), trillianCommunicationError)
-	}
 
 	resp := tc.getLeafByIndex(params.LogIndex)
 	switch resp.status {
@@ -86,9 +83,6 @@ func CreateLogEntryHandler(params entries.CreateLogEntryParams) middleware.Respo
 	}
 
 	tc := NewTrillianClient(httpReq.Context())
-	if tc == nil {
-		return handleRekorAPIError(params, http.StatusInternalServerError, errors.New("unable to get client from request context"), trillianCommunicationError)
-	}
 
 	resp := tc.addLeaf(leaf)
 	switch resp.status {
@@ -119,9 +113,6 @@ func GetLogEntryByUUIDHandler(params entries.GetLogEntryByUUIDParams) middleware
 	hashes := [][]byte{hashValue}
 
 	tc := NewTrillianClient(params.HTTPRequest.Context())
-	if tc == nil {
-		return handleRekorAPIError(params, http.StatusInternalServerError, errors.New("unable to get client from request context"), trillianCommunicationError)
-	}
 
 	resp := tc.getLeafByHash(hashes) // TODO: if this API is deprecated, we need to ask for inclusion proof and then use index in proof result to get leaf
 	switch resp.status {
@@ -154,9 +145,6 @@ func GetLogEntryByUUIDHandler(params entries.GetLogEntryByUUIDParams) middleware
 func GetLogEntryProofHandler(params entries.GetLogEntryProofParams) middleware.Responder {
 	hashValue, _ := hex.DecodeString(params.EntryUUID)
 	tc := NewTrillianClient(params.HTTPRequest.Context())
-	if tc == nil {
-		return handleRekorAPIError(params, http.StatusInternalServerError, errors.New("unable to get client from request context"), trillianCommunicationError)
-	}
 
 	resp := tc.getProofByHash(hashValue)
 	switch resp.status {
@@ -202,9 +190,6 @@ func SearchLogQueryHandler(params entries.SearchLogQueryParams) middleware.Respo
 	httpReqCtx := params.HTTPRequest.Context()
 	resultPayload := []models.LogEntry{}
 	tc := NewTrillianClient(httpReqCtx)
-	if tc == nil {
-		return handleRekorAPIError(params, http.StatusInternalServerError, errors.New("unable to get client from request context"), trillianCommunicationError)
-	}
 
 	//TODO: parallelize this into different goroutines to speed up search
 	searchHashes := [][]byte{}

--- a/pkg/api/tlog.go
+++ b/pkg/api/tlog.go
@@ -35,9 +35,6 @@ import (
 
 func GetLogInfoHandler(params tlog.GetLogInfoParams) middleware.Responder {
 	tc := NewTrillianClient(params.HTTPRequest.Context())
-	if tc == nil {
-		return handleRekorAPIError(params, http.StatusInternalServerError, errors.New("unable to get client from request context"), trillianCommunicationError)
-	}
 
 	resp := tc.getLatest(0)
 	if resp.status != codes.OK {
@@ -71,9 +68,6 @@ func GetLogProofHandler(params tlog.GetLogProofParams) middleware.Responder {
 		return handleRekorAPIError(params, http.StatusBadRequest, nil, fmt.Sprintf(firstSizeLessThanLastSize, *params.FirstSize, params.LastSize))
 	}
 	tc := NewTrillianClient(params.HTTPRequest.Context())
-	if tc == nil {
-		return handleRekorAPIError(params, http.StatusInternalServerError, errors.New("unable to get client from request context"), trillianCommunicationError)
-	}
 
 	resp := tc.getConsistencyProof(*params.FirstSize, params.LastSize)
 	if resp.status != codes.OK {

--- a/pkg/generated/restapi/configure_rekor_server.go
+++ b/pkg/generated/restapi/configure_rekor_server.go
@@ -113,8 +113,6 @@ func setupGlobalMiddleware(handler http.Handler) http.Handler {
 	returnHandler = middleware.Logger(returnHandler)
 	returnHandler = middleware.Heartbeat("/ping")(returnHandler)
 
-	// add the Trillian API object in context for all endpoints
-	returnHandler = addTrillianAPI(handler)
 	return middleware.RequestID(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		r = r.WithContext(log.WithRequestID(ctx, middleware.GetReqID(ctx)))
@@ -135,17 +133,6 @@ func cacheForever(handler http.Handler) http.Handler {
 			}
 		})
 		handler.ServeHTTP(ww, r)
-	})
-}
-
-func addTrillianAPI(handler http.Handler) http.Handler {
-	api, err := pkgapi.NewAPI()
-	if err != nil {
-		log.Logger.Panic(err)
-	}
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		apiCtx := pkgapi.AddAPIToContext(r.Context(), api)
-		handler.ServeHTTP(w, r.WithContext(apiCtx))
 	})
 }
 

--- a/tests/e2e-test.sh
+++ b/tests/e2e-test.sh
@@ -2,6 +2,8 @@
 set -ex
 testdir=$(dirname "$0")
 
+docker-compose up -d
+
 # Node
 nodedir=${testdir}/node
 go run ./cmd/cli/ upload \


### PR DESCRIPTION
…variable.

This allows us to skip sticking it onto each request context and retrieving it.

Signed-off-by: Dan Lorenc <dlorenc@google.com>