### PR TITLE
Add a helper to wrap Cobbra functions to make them easier to test.

### DIFF
--- a/cmd/cli/app/format/wrap.go
+++ b/cmd/cli/app/format/wrap.go
@@ -1,0 +1,33 @@
+package format
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/spf13/cobra"
+)
+
+type cobraCmd func(cmd *cobra.Command, args []string)
+
+type formatCmd func(args []string) (interface{}, error)
+
+func WrapCmd(f formatCmd) cobraCmd {
+	return func(cmd *cobra.Command, args []string) {
+		obj, err := f(args)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// TODO: add flags to control output formatting (JSON, plaintext, etc.)
+		if s, ok := obj.(fmt.Stringer); ok {
+			fmt.Print(s.String())
+		} else {
+			b, err := json.Marshal(obj)
+			if err != nil {
+				log.Fatal(err)
+			}
+			fmt.Println(string(b))
+		}
+	}
+}


### PR DESCRIPTION
This switches out cobra commands to return obj, err. This should make it
easier to test them, and also keep formatting across the commands consistent.

Formatting should happen in one place, instead of having each command print directly.

cc @bobcallaway let me know what you think of this approach before I add it to the other commands.