### PR TITLE
One more small tweak to our zap logging config.

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -21,6 +21,8 @@ func ConfigureLogger(logType string) {
 	var cfg zap.Config
 	if logType == "prod" {
 		cfg = zap.NewProductionConfig()
+		cfg.EncoderConfig.LevelKey = "severity"
+		cfg.EncoderConfig.MessageKey = "message"
 	} else {
 		cfg = zap.NewDevelopmentConfig()
 		cfg.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder


### PR DESCRIPTION
The special keys "message" and "severity" are used to filter by default in the UI.