### PR TITLE
Stick the generated RPM in a tmpdir.

### DIFF
--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -70,7 +70,8 @@ func TestUploadVerifyRekord(t *testing.T) {
 func TestUploadVerifyRpm(t *testing.T) {
 
 	// Create a random rpm and sign it.
-	rpmPath := filepath.Join("rpm")
+	td := t.TempDir()
+	rpmPath := filepath.Join(td, "rpm")
 
 	createSignedRpm(t, rpmPath)
 


### PR DESCRIPTION
I noticed this when running some tests locally.