### PR TITLE
Feature - enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "go:modules" 
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Enable dependabot. https://dependabot.com/

To enable this setting it has to be turned on here  https://github.com/projectrekor/rekor/security similar to this

![image](https://user-images.githubusercontent.com/172697/106544223-2c5c7300-64d5-11eb-8522-841f219a481d.png)

https://github.com/naveensrinivasan/rekor/pulls

![image](https://user-images.githubusercontent.com/172697/107124918-89a94900-6874-11eb-85d7-f670af5c807a.png)
