### PR TITLE
Fix broken link pointing to rekord_schema

### DIFF
--- a/pkg/types/README.md
+++ b/pkg/types/README.md
@@ -6,7 +6,7 @@ Rekor supports pluggable types (aka different schemas) for entries stored in the
 
 ### Currently supported types
 
-- Rekord (default type) [schema](rekord/rekord_schema.md)
+- Rekord (default type) [schema](rekord/rekord_schema.json)
   - Versions: 0.0.1 
 
 


### PR DESCRIPTION
This is a tiny change to fix the broken link which pointed to `rekord_schema.md` and not `rekord_schema.json`.