### PR TITLE
Enforce validation logic on values from config file and/or env vars

### DIFF
--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -5,6 +5,7 @@ package e2e
 import (
 	"encoding/json"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -18,6 +19,13 @@ func getUUIDFromUploadOutput(t *testing.T, out string) string {
 	url := urlTokens[len(urlTokens)-1]
 	splitUrl := strings.Split(url, "/")
 	return splitUrl[len(splitUrl)-1]
+}
+
+func TestEnvVariableValidation(t *testing.T) {
+	os.Setenv("REKOR_FORMAT", "bogus")
+	defer os.Unsetenv("REKOR_FORMAT")
+
+	runCliErr(t, "loginfo")
 }
 
 func TestDuplicates(t *testing.T) {


### PR DESCRIPTION
By using viper.GetString(flag), viper will return the values of that
argument from a precedence order (including CLI arguments). However, if
a value was passed in through an environment variable or as a value in
the config file, it would skip the validation step since that logic was
defined against the FlagSet for command line arguments.

This change causes validation to be done across all input methods.

Fixes #157

Signed-off-by: Bob Callaway <bcallawa@redhat.com>