### PR TITLE
Refactor of org name

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you're interesting in integration with rekor, we have an [OpenAPI swagger edi
 
 A public instance of rekor can be found at [api.rekor.dev](https://api.rekor.dev/api/v1/log/)
 
-Rekor allows customized manifests (which term them as types), [type customization is outlined here](https://github.com/projectrekor/rekor/tree/main/pkg/types).
+Rekor allows customized manifests (which term them as types), [type customization is outlined here](https://github.com/SigStore/rekor/tree/main/pkg/types).
 
 ## Contributions
 

--- a/cmd/cli/app/get.go
+++ b/cmd/cli/app/get.go
@@ -22,10 +22,10 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/projectrekor/rekor/cmd/cli/app/format"
-	"github.com/projectrekor/rekor/pkg/generated/client/entries"
-	"github.com/projectrekor/rekor/pkg/generated/models"
-	"github.com/projectrekor/rekor/pkg/log"
+	"github.com/SigStore/rekor/cmd/cli/app/format"
+	"github.com/SigStore/rekor/pkg/generated/client/entries"
+	"github.com/SigStore/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/log"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/cmd/cli/app/log_info.go
+++ b/cmd/cli/app/log_info.go
@@ -25,7 +25,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/projectrekor/rekor/cmd/cli/app/state"
+	"github.com/SigStore/rekor/cmd/cli/app/state"
 
 	"github.com/google/trillian"
 	tclient "github.com/google/trillian/client"
@@ -33,9 +33,9 @@ import (
 	"github.com/google/trillian/merkle/logverifier"
 	rfc6962 "github.com/google/trillian/merkle/rfc6962/hasher"
 
-	"github.com/projectrekor/rekor/cmd/cli/app/format"
-	"github.com/projectrekor/rekor/pkg/generated/client/tlog"
-	"github.com/projectrekor/rekor/pkg/log"
+	"github.com/SigStore/rekor/cmd/cli/app/format"
+	"github.com/SigStore/rekor/pkg/generated/client/tlog"
+	"github.com/SigStore/rekor/pkg/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/cmd/cli/app/log_proof.go
+++ b/cmd/cli/app/log_proof.go
@@ -19,9 +19,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/projectrekor/rekor/cmd/cli/app/format"
-	"github.com/projectrekor/rekor/pkg/generated/client/tlog"
-	"github.com/projectrekor/rekor/pkg/log"
+	"github.com/SigStore/rekor/cmd/cli/app/format"
+	"github.com/SigStore/rekor/pkg/generated/client/tlog"
+	"github.com/SigStore/rekor/pkg/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/cmd/cli/app/pflags.go
+++ b/cmd/cli/app/pflags.go
@@ -30,9 +30,9 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
-	"github.com/projectrekor/rekor/pkg/generated/models"
-	rekord_v001 "github.com/projectrekor/rekor/pkg/types/rekord/v0.0.1"
-	rpm_v001 "github.com/projectrekor/rekor/pkg/types/rpm/v0.0.1"
+	"github.com/SigStore/rekor/pkg/generated/models"
+	rekord_v001 "github.com/SigStore/rekor/pkg/types/rekord/v0.0.1"
+	rpm_v001 "github.com/SigStore/rekor/pkg/types/rpm/v0.0.1"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/cmd/cli/app/pflags_test.go
+++ b/cmd/cli/app/pflags_test.go
@@ -23,7 +23,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 	"github.com/spf13/viper"
 
 	"github.com/spf13/cobra"

--- a/cmd/cli/app/root.go
+++ b/cmd/cli/app/root.go
@@ -25,8 +25,8 @@ import (
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
-	"github.com/projectrekor/rekor/pkg/generated/client"
-	"github.com/projectrekor/rekor/pkg/util"
+	"github.com/SigStore/rekor/pkg/generated/client"
+	"github.com/SigStore/rekor/pkg/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 

--- a/cmd/cli/app/search.go
+++ b/cmd/cli/app/search.go
@@ -30,10 +30,10 @@ import (
 
 	"github.com/go-openapi/strfmt"
 
-	"github.com/projectrekor/rekor/cmd/cli/app/format"
-	"github.com/projectrekor/rekor/pkg/generated/client/index"
-	"github.com/projectrekor/rekor/pkg/generated/models"
-	"github.com/projectrekor/rekor/pkg/log"
+	"github.com/SigStore/rekor/cmd/cli/app/format"
+	"github.com/SigStore/rekor/pkg/generated/client/index"
+	"github.com/SigStore/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/log"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/cmd/cli/app/upload.go
+++ b/cmd/cli/app/upload.go
@@ -21,10 +21,10 @@ import (
 	"os"
 
 	"github.com/go-openapi/swag"
-	"github.com/projectrekor/rekor/cmd/cli/app/format"
-	"github.com/projectrekor/rekor/pkg/generated/client/entries"
-	"github.com/projectrekor/rekor/pkg/generated/models"
-	"github.com/projectrekor/rekor/pkg/log"
+	"github.com/SigStore/rekor/cmd/cli/app/format"
+	"github.com/SigStore/rekor/pkg/generated/client/entries"
+	"github.com/SigStore/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/cmd/cli/app/verify.go
+++ b/cmd/cli/app/verify.go
@@ -25,10 +25,10 @@ import (
 
 	"github.com/google/trillian/merkle/logverifier"
 	rfc6962 "github.com/google/trillian/merkle/rfc6962/hasher"
-	"github.com/projectrekor/rekor/cmd/cli/app/format"
-	"github.com/projectrekor/rekor/pkg/generated/client/entries"
-	"github.com/projectrekor/rekor/pkg/generated/models"
-	"github.com/projectrekor/rekor/pkg/log"
+	"github.com/SigStore/rekor/cmd/cli/app/format"
+	"github.com/SigStore/rekor/pkg/generated/client/entries"
+	"github.com/SigStore/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/log"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 package main
 
-import "github.com/projectrekor/rekor/cmd/cli/app"
+import "github.com/SigStore/rekor/cmd/cli/app"
 
 func main() {
 	app.Execute()

--- a/cmd/server/app/root.go
+++ b/cmd/server/app/root.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/projectrekor/rekor/pkg/log"
+	"github.com/SigStore/rekor/pkg/log"
 	"github.com/spf13/cobra"
 
 	homedir "github.com/mitchellh/go-homedir"

--- a/cmd/server/app/serve.go
+++ b/cmd/server/app/serve.go
@@ -21,15 +21,15 @@ import (
 	"net/http"
 
 	"github.com/go-openapi/loads"
-	"github.com/projectrekor/rekor/pkg/api"
-	"github.com/projectrekor/rekor/pkg/generated/restapi/operations"
-	"github.com/projectrekor/rekor/pkg/log"
-	"github.com/projectrekor/rekor/pkg/types/rekord"
-	rekord_v001 "github.com/projectrekor/rekor/pkg/types/rekord/v0.0.1"
-	"github.com/projectrekor/rekor/pkg/types/rpm"
-	rpm_v001 "github.com/projectrekor/rekor/pkg/types/rpm/v0.0.1"
+	"github.com/SigStore/rekor/pkg/api"
+	"github.com/SigStore/rekor/pkg/generated/restapi/operations"
+	"github.com/SigStore/rekor/pkg/log"
+	"github.com/SigStore/rekor/pkg/types/rekord"
+	rekord_v001 "github.com/SigStore/rekor/pkg/types/rekord/v0.0.1"
+	"github.com/SigStore/rekor/pkg/types/rpm"
+	rpm_v001 "github.com/SigStore/rekor/pkg/types/rpm/v0.0.1"
 
-	"github.com/projectrekor/rekor/pkg/generated/restapi"
+	"github.com/SigStore/rekor/pkg/generated/restapi"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -45,7 +45,7 @@ var serveCmd = &cobra.Command{
 		// Setup the logger to dev/prod
 		log.ConfigureLogger(viper.GetString("log_type"))
 
-		// workaround for https://github.com/projectrekor/rekor/issues/68
+		// workaround for https://github.com/SigStore/rekor/issues/68
 		// from https://github.com/golang/glog/commit/fca8c8854093a154ff1eb580aae10276ad6b1b5f
 		_ = flag.CommandLine.Parse([]string{})
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package main
 
-import "github.com/projectrekor/rekor/cmd/server/app"
+import "github.com/SigStore/rekor/cmd/server/app"
 
 func main() {
 	app.Execute()

--- a/config/rekor.yaml
+++ b/config/rekor.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: rekor-server
-        image: ko://github.com/projectrekor/rekor/cmd/server
+        image: ko://github.com/SigStore/rekor/cmd/server
         ports:
         - containerPort: 3000
         - containerPort: 2112 # metrics

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/projectrekor/rekor
+module github.com/SigStore/rekor
 
 go 1.14
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -25,7 +25,7 @@ import (
 	"github.com/google/trillian/client"
 	"github.com/google/trillian/crypto/keyspb"
 	radix "github.com/mediocregopher/radix/v4"
-	"github.com/projectrekor/rekor/pkg/log"
+	"github.com/SigStore/rekor/pkg/log"
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 )

--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -33,17 +33,17 @@ import (
 	"google.golang.org/genproto/googleapis/rpc/code"
 	"google.golang.org/grpc/codes"
 
-	"github.com/projectrekor/rekor/pkg/log"
-	"github.com/projectrekor/rekor/pkg/types"
+	"github.com/SigStore/rekor/pkg/log"
+	"github.com/SigStore/rekor/pkg/types"
 
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
 	tclient "github.com/google/trillian/client"
 	tcrypto "github.com/google/trillian/crypto"
 	rfc6962 "github.com/google/trillian/merkle/rfc6962/hasher"
-	"github.com/projectrekor/rekor/pkg/generated/restapi/operations/entries"
+	"github.com/SigStore/rekor/pkg/generated/restapi/operations/entries"
 )
 
 func GetLogEntryByIndexHandler(params entries.GetLogEntryByIndexParams) middleware.Responder {

--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -22,11 +22,11 @@ import (
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/mitchellh/mapstructure"
-	"github.com/projectrekor/rekor/pkg/generated/models"
-	"github.com/projectrekor/rekor/pkg/generated/restapi/operations/entries"
-	"github.com/projectrekor/rekor/pkg/generated/restapi/operations/index"
-	"github.com/projectrekor/rekor/pkg/generated/restapi/operations/tlog"
-	"github.com/projectrekor/rekor/pkg/log"
+	"github.com/SigStore/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/restapi/operations/entries"
+	"github.com/SigStore/rekor/pkg/generated/restapi/operations/index"
+	"github.com/SigStore/rekor/pkg/generated/restapi/operations/tlog"
+	"github.com/SigStore/rekor/pkg/log"
 )
 
 const (

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -24,16 +24,16 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/projectrekor/rekor/pkg/pki"
+	"github.com/SigStore/rekor/pkg/pki"
 
 	radix "github.com/mediocregopher/radix/v4"
 
 	"github.com/asaskevich/govalidator"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/swag"
-	"github.com/projectrekor/rekor/pkg/generated/models"
-	"github.com/projectrekor/rekor/pkg/generated/restapi/operations/index"
-	"github.com/projectrekor/rekor/pkg/util"
+	"github.com/SigStore/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/restapi/operations/index"
+	"github.com/SigStore/rekor/pkg/util"
 )
 
 func SearchIndexHandler(params index.SearchIndexParams) middleware.Responder {

--- a/pkg/api/tlog.go
+++ b/pkg/api/tlog.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 	"google.golang.org/grpc/codes"
 
 	"github.com/go-openapi/runtime/middleware"
@@ -33,7 +33,7 @@ import (
 	tclient "github.com/google/trillian/client"
 	tcrypto "github.com/google/trillian/crypto"
 	rfc6962 "github.com/google/trillian/merkle/rfc6962/hasher"
-	"github.com/projectrekor/rekor/pkg/generated/restapi/operations/tlog"
+	"github.com/SigStore/rekor/pkg/generated/restapi/operations/tlog"
 )
 
 func GetLogInfoHandler(params tlog.GetLogInfoParams) middleware.Responder {

--- a/pkg/generated/client/entries/create_log_entry_parameters.go
+++ b/pkg/generated/client/entries/create_log_entry_parameters.go
@@ -32,7 +32,7 @@ import (
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 )
 
 // NewCreateLogEntryParams creates a new CreateLogEntryParams object

--- a/pkg/generated/client/entries/create_log_entry_responses.go
+++ b/pkg/generated/client/entries/create_log_entry_responses.go
@@ -30,7 +30,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 )
 
 // CreateLogEntryReader is a Reader for the CreateLogEntry structure.

--- a/pkg/generated/client/entries/get_log_entry_by_index_responses.go
+++ b/pkg/generated/client/entries/get_log_entry_by_index_responses.go
@@ -29,7 +29,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 )
 
 // GetLogEntryByIndexReader is a Reader for the GetLogEntryByIndex structure.

--- a/pkg/generated/client/entries/get_log_entry_by_uuid_responses.go
+++ b/pkg/generated/client/entries/get_log_entry_by_uuid_responses.go
@@ -29,7 +29,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 )
 
 // GetLogEntryByUUIDReader is a Reader for the GetLogEntryByUUID structure.

--- a/pkg/generated/client/entries/get_log_entry_proof_responses.go
+++ b/pkg/generated/client/entries/get_log_entry_proof_responses.go
@@ -29,7 +29,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 )
 
 // GetLogEntryProofReader is a Reader for the GetLogEntryProof structure.

--- a/pkg/generated/client/entries/search_log_query_parameters.go
+++ b/pkg/generated/client/entries/search_log_query_parameters.go
@@ -32,7 +32,7 @@ import (
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 )
 
 // NewSearchLogQueryParams creates a new SearchLogQueryParams object

--- a/pkg/generated/client/entries/search_log_query_responses.go
+++ b/pkg/generated/client/entries/search_log_query_responses.go
@@ -29,7 +29,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 )
 
 // SearchLogQueryReader is a Reader for the SearchLogQuery structure.

--- a/pkg/generated/client/index/search_index_parameters.go
+++ b/pkg/generated/client/index/search_index_parameters.go
@@ -32,7 +32,7 @@ import (
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 )
 
 // NewSearchIndexParams creates a new SearchIndexParams object

--- a/pkg/generated/client/index/search_index_responses.go
+++ b/pkg/generated/client/index/search_index_responses.go
@@ -29,7 +29,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 )
 
 // SearchIndexReader is a Reader for the SearchIndex structure.

--- a/pkg/generated/client/rekor_client.go
+++ b/pkg/generated/client/rekor_client.go
@@ -27,9 +27,9 @@ import (
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/projectrekor/rekor/pkg/generated/client/entries"
-	"github.com/projectrekor/rekor/pkg/generated/client/index"
-	"github.com/projectrekor/rekor/pkg/generated/client/tlog"
+	"github.com/SigStore/rekor/pkg/generated/client/entries"
+	"github.com/SigStore/rekor/pkg/generated/client/index"
+	"github.com/SigStore/rekor/pkg/generated/client/tlog"
 )
 
 // Default rekor HTTP client.

--- a/pkg/generated/client/tlog/get_log_info_responses.go
+++ b/pkg/generated/client/tlog/get_log_info_responses.go
@@ -29,7 +29,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 )
 
 // GetLogInfoReader is a Reader for the GetLogInfo structure.

--- a/pkg/generated/client/tlog/get_log_proof_responses.go
+++ b/pkg/generated/client/tlog/get_log_proof_responses.go
@@ -29,7 +29,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 )
 
 // GetLogProofReader is a Reader for the GetLogProof structure.

--- a/pkg/generated/client/tlog/get_public_key_responses.go
+++ b/pkg/generated/client/tlog/get_public_key_responses.go
@@ -29,7 +29,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 )
 
 // GetPublicKeyReader is a Reader for the GetPublicKey structure.

--- a/pkg/generated/restapi/configure_rekor_server.go
+++ b/pkg/generated/restapi/configure_rekor_server.go
@@ -30,14 +30,14 @@ import (
 	"github.com/rs/cors"
 	"github.com/spf13/viper"
 
-	"github.com/projectrekor/rekor/pkg/api"
-	pkgapi "github.com/projectrekor/rekor/pkg/api"
-	"github.com/projectrekor/rekor/pkg/generated/restapi/operations"
-	"github.com/projectrekor/rekor/pkg/generated/restapi/operations/entries"
-	"github.com/projectrekor/rekor/pkg/generated/restapi/operations/index"
-	"github.com/projectrekor/rekor/pkg/generated/restapi/operations/tlog"
-	"github.com/projectrekor/rekor/pkg/log"
-	"github.com/projectrekor/rekor/pkg/util"
+	"github.com/SigStore/rekor/pkg/api"
+	pkgapi "github.com/SigStore/rekor/pkg/api"
+	"github.com/SigStore/rekor/pkg/generated/restapi/operations"
+	"github.com/SigStore/rekor/pkg/generated/restapi/operations/entries"
+	"github.com/SigStore/rekor/pkg/generated/restapi/operations/index"
+	"github.com/SigStore/rekor/pkg/generated/restapi/operations/tlog"
+	"github.com/SigStore/rekor/pkg/log"
+	"github.com/SigStore/rekor/pkg/util"
 
 	"github.com/urfave/negroni"
 )

--- a/pkg/generated/restapi/operations/entries/create_log_entry_parameters.go
+++ b/pkg/generated/restapi/operations/entries/create_log_entry_parameters.go
@@ -30,7 +30,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 )
 
 // NewCreateLogEntryParams creates a new CreateLogEntryParams object

--- a/pkg/generated/restapi/operations/entries/create_log_entry_responses.go
+++ b/pkg/generated/restapi/operations/entries/create_log_entry_responses.go
@@ -28,7 +28,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 )
 
 // CreateLogEntryCreatedCode is the HTTP code returned for type CreateLogEntryCreated

--- a/pkg/generated/restapi/operations/entries/get_log_entry_by_index_responses.go
+++ b/pkg/generated/restapi/operations/entries/get_log_entry_by_index_responses.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/go-openapi/runtime"
 
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 )
 
 // GetLogEntryByIndexOKCode is the HTTP code returned for type GetLogEntryByIndexOK

--- a/pkg/generated/restapi/operations/entries/get_log_entry_by_uuid_responses.go
+++ b/pkg/generated/restapi/operations/entries/get_log_entry_by_uuid_responses.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/go-openapi/runtime"
 
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 )
 
 // GetLogEntryByUUIDOKCode is the HTTP code returned for type GetLogEntryByUUIDOK

--- a/pkg/generated/restapi/operations/entries/get_log_entry_proof_responses.go
+++ b/pkg/generated/restapi/operations/entries/get_log_entry_proof_responses.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/go-openapi/runtime"
 
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 )
 
 // GetLogEntryProofOKCode is the HTTP code returned for type GetLogEntryProofOK

--- a/pkg/generated/restapi/operations/entries/search_log_query_parameters.go
+++ b/pkg/generated/restapi/operations/entries/search_log_query_parameters.go
@@ -30,7 +30,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 )
 
 // NewSearchLogQueryParams creates a new SearchLogQueryParams object

--- a/pkg/generated/restapi/operations/entries/search_log_query_responses.go
+++ b/pkg/generated/restapi/operations/entries/search_log_query_responses.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/go-openapi/runtime"
 
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 )
 
 // SearchLogQueryOKCode is the HTTP code returned for type SearchLogQueryOK

--- a/pkg/generated/restapi/operations/index/search_index_parameters.go
+++ b/pkg/generated/restapi/operations/index/search_index_parameters.go
@@ -30,7 +30,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 )
 
 // NewSearchIndexParams creates a new SearchIndexParams object

--- a/pkg/generated/restapi/operations/index/search_index_responses.go
+++ b/pkg/generated/restapi/operations/index/search_index_responses.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/go-openapi/runtime"
 
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 )
 
 // SearchIndexOKCode is the HTTP code returned for type SearchIndexOK

--- a/pkg/generated/restapi/operations/rekor_server_api.go
+++ b/pkg/generated/restapi/operations/rekor_server_api.go
@@ -38,9 +38,9 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 
-	"github.com/projectrekor/rekor/pkg/generated/restapi/operations/entries"
-	"github.com/projectrekor/rekor/pkg/generated/restapi/operations/index"
-	"github.com/projectrekor/rekor/pkg/generated/restapi/operations/tlog"
+	"github.com/SigStore/rekor/pkg/generated/restapi/operations/entries"
+	"github.com/SigStore/rekor/pkg/generated/restapi/operations/index"
+	"github.com/SigStore/rekor/pkg/generated/restapi/operations/tlog"
 )
 
 // NewRekorServerAPI creates a new RekorServer instance

--- a/pkg/generated/restapi/operations/tlog/get_log_info_responses.go
+++ b/pkg/generated/restapi/operations/tlog/get_log_info_responses.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/go-openapi/runtime"
 
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 )
 
 // GetLogInfoOKCode is the HTTP code returned for type GetLogInfoOK

--- a/pkg/generated/restapi/operations/tlog/get_log_proof_responses.go
+++ b/pkg/generated/restapi/operations/tlog/get_log_proof_responses.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/go-openapi/runtime"
 
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 )
 
 // GetLogProofOKCode is the HTTP code returned for type GetLogProofOK

--- a/pkg/generated/restapi/operations/tlog/get_public_key_responses.go
+++ b/pkg/generated/restapi/operations/tlog/get_public_key_responses.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/go-openapi/runtime"
 
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 )
 
 // GetPublicKeyOKCode is the HTTP code returned for type GetPublicKeyOK

--- a/pkg/generated/restapi/server.go
+++ b/pkg/generated/restapi/server.go
@@ -42,7 +42,7 @@ import (
 	flag "github.com/spf13/pflag"
 	"golang.org/x/net/netutil"
 
-	"github.com/projectrekor/rekor/pkg/generated/restapi/operations"
+	"github.com/SigStore/rekor/pkg/generated/restapi/operations"
 )
 
 const (

--- a/pkg/pki/pki.go
+++ b/pkg/pki/pki.go
@@ -21,11 +21,11 @@ import (
 	"io"
 	"strings"
 
-	"github.com/projectrekor/rekor/pkg/pki/minisign"
-	"github.com/projectrekor/rekor/pkg/pki/ssh"
-	"github.com/projectrekor/rekor/pkg/pki/x509"
+	"github.com/SigStore/rekor/pkg/pki/minisign"
+	"github.com/SigStore/rekor/pkg/pki/ssh"
+	"github.com/SigStore/rekor/pkg/pki/x509"
 
-	"github.com/projectrekor/rekor/pkg/pki/pgp"
+	"github.com/SigStore/rekor/pkg/pki/pgp"
 )
 
 // PublicKey Generic object representing a public key (regardless of format & algorithm)

--- a/pkg/types/README.md
+++ b/pkg/types/README.md
@@ -90,7 +90,7 @@ type EntryImpl interface {
   - `Unmarshal` will be called with a pointer to a struct that was automatically generated for the type defined in `openapi.yaml` by the [go-swagger](http://github.com/go-swagger/go-swagger) tool used by Rekor
     - This method should validate the contents of the struct to ensure any string or cross-field dependencies are met to successfully insert an entry of this type into the transparency log
 
-5. In the Go package you have created for the new type, be sure to add an entry in the `TypeMap` in `github.com/projectrekor/rekor/pkg/types` for your new type in the `init` method for your package. The key for the map is the unique string used to define your type in `openapi.yaml` (e.g. `newType`), and the value for the map is the name of a factory function for an instance of `TypeImpl`.
+5. In the Go package you have created for the new type, be sure to add an entry in the `TypeMap` in `github.com/SigStore/rekor/pkg/types` for your new type in the `init` method for your package. The key for the map is the unique string used to define your type in `openapi.yaml` (e.g. `newType`), and the value for the map is the name of a factory function for an instance of `TypeImpl`.
 
 ```go
 func init() {
@@ -100,7 +100,7 @@ func init() {
 
 6. Add an entry to `pluggableTypeMap` in `cmd/server/app/serve.go` that provides a reference to your package. This ensures that the `init` function of your type (and optionally, your version implementation) will be called before the server starts to process incoming requests and therefore will be added to the map that is used to route request processing for different types.
 
-7. After adding sufficient unit & integration tests, submit a pull request to `projectrekor/rekor` for review and addition to the codebase.
+7. After adding sufficient unit & integration tests, submit a pull request to `SigStore/rekor` for review and addition to the codebase.
 
 ## Adding a New Version of the `Rekord` type
 
@@ -116,4 +116,4 @@ To add new version of the default `Rekord` type:
 
 5. Add an entry to `pluggableTypeMap` in `cmd/server/app/serve.go` that provides a reference to the Go package implementing the new version. This ensures that the `init` function will be called before the server starts to process incoming requests and therefore will be added to the map that is used to route request processing for different types.
 
-6. After adding sufficient unit & integration tests, submit a pull request to `projectrekor/rekor` for review and addition to the codebase.
+6. After adding sufficient unit & integration tests, submit a pull request to `SigStore/rekor` for review and addition to the codebase.

--- a/pkg/types/rekord/rekord.go
+++ b/pkg/types/rekord/rekord.go
@@ -19,11 +19,11 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/projectrekor/rekor/pkg/types"
-	"github.com/projectrekor/rekor/pkg/util"
+	"github.com/SigStore/rekor/pkg/types"
+	"github.com/SigStore/rekor/pkg/util"
 
 	"github.com/go-openapi/swag"
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 )
 
 const (

--- a/pkg/types/rekord/rekord_test.go
+++ b/pkg/types/rekord/rekord_test.go
@@ -22,8 +22,8 @@ import (
 	"testing"
 
 	"github.com/go-openapi/swag"
-	"github.com/projectrekor/rekor/pkg/generated/models"
-	"github.com/projectrekor/rekor/pkg/types"
+	"github.com/SigStore/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/types"
 )
 
 type UnmarshalTester struct {

--- a/pkg/types/rekord/v0.0.1/entry.go
+++ b/pkg/types/rekord/v0.0.1/entry.go
@@ -27,20 +27,20 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/projectrekor/rekor/pkg/log"
-	"github.com/projectrekor/rekor/pkg/types"
-	"github.com/projectrekor/rekor/pkg/util"
+	"github.com/SigStore/rekor/pkg/log"
+	"github.com/SigStore/rekor/pkg/types"
+	"github.com/SigStore/rekor/pkg/util"
 
 	"github.com/asaskevich/govalidator"
 
 	"github.com/go-openapi/strfmt"
 
-	"github.com/projectrekor/rekor/pkg/pki"
-	"github.com/projectrekor/rekor/pkg/types/rekord"
+	"github.com/SigStore/rekor/pkg/pki"
+	"github.com/SigStore/rekor/pkg/types/rekord"
 
 	"github.com/go-openapi/swag"
 	"github.com/mitchellh/mapstructure"
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/pkg/types/rekord/v0.0.1/entry_test.go
+++ b/pkg/types/rekord/v0.0.1/entry_test.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 	"go.uber.org/goleak"
 )
 

--- a/pkg/types/rpm/rpm.go
+++ b/pkg/types/rpm/rpm.go
@@ -19,11 +19,11 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/projectrekor/rekor/pkg/types"
-	"github.com/projectrekor/rekor/pkg/util"
+	"github.com/SigStore/rekor/pkg/types"
+	"github.com/SigStore/rekor/pkg/util"
 
 	"github.com/go-openapi/swag"
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 )
 
 const (

--- a/pkg/types/rpm/rpm_test.go
+++ b/pkg/types/rpm/rpm_test.go
@@ -22,8 +22,8 @@ import (
 	"testing"
 
 	"github.com/go-openapi/swag"
-	"github.com/projectrekor/rekor/pkg/generated/models"
-	"github.com/projectrekor/rekor/pkg/types"
+	"github.com/SigStore/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/types"
 )
 
 type UnmarshalTester struct {

--- a/pkg/types/rpm/v0.0.1/entry.go
+++ b/pkg/types/rpm/v0.0.1/entry.go
@@ -29,22 +29,22 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/projectrekor/rekor/pkg/log"
-	"github.com/projectrekor/rekor/pkg/pki/pgp"
-	"github.com/projectrekor/rekor/pkg/types"
-	"github.com/projectrekor/rekor/pkg/types/rpm"
-	"github.com/projectrekor/rekor/pkg/util"
+	"github.com/SigStore/rekor/pkg/log"
+	"github.com/SigStore/rekor/pkg/pki/pgp"
+	"github.com/SigStore/rekor/pkg/types"
+	"github.com/SigStore/rekor/pkg/types/rpm"
+	"github.com/SigStore/rekor/pkg/util"
 
 	"github.com/asaskevich/govalidator"
 
 	"github.com/go-openapi/strfmt"
 
-	"github.com/projectrekor/rekor/pkg/pki"
+	"github.com/SigStore/rekor/pkg/pki"
 
 	rpmutils "github.com/cavaliercoder/go-rpm"
 	"github.com/go-openapi/swag"
 	"github.com/mitchellh/mapstructure"
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/pkg/types/rpm/v0.0.1/entry_test.go
+++ b/pkg/types/rpm/v0.0.1/entry_test.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 	"go.uber.org/goleak"
 )
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 )
 
 type TypeImpl interface {

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/go-openapi/strfmt"
-	"github.com/projectrekor/rekor/pkg/generated/models"
+	"github.com/SigStore/rekor/pkg/generated/models"
 	"go.uber.org/goleak"
 )
 

--- a/pkg/util/types.go
+++ b/pkg/util/types.go
@@ -19,8 +19,8 @@ import (
 	"sync"
 
 	"github.com/blang/semver"
-	"github.com/projectrekor/rekor/pkg/log"
-	"github.com/projectrekor/rekor/pkg/types"
+	"github.com/SigStore/rekor/pkg/log"
+	"github.com/SigStore/rekor/pkg/types"
 )
 
 type VersionFactory func() types.EntryImpl

--- a/tests/rekor.json
+++ b/tests/rekor.json
@@ -10,7 +10,7 @@
              }
         },
         "data": {
-            "url": "https://raw.githubusercontent.com/projectrekor/rekor/main/tests/test_file.txt",
+            "url": "https://raw.githubusercontent.com/SigStore/rekor/main/tests/test_file.txt",
             "hash": {
                 "algorithm": "sha256",
                 "value": "45c7b11fcbf07dec1694adecd8c5b85770a12a6c8dfdcf2580a2db0c47c31779"

--- a/tests/ssh.go
+++ b/tests/ssh.go
@@ -8,7 +8,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/projectrekor/rekor/pkg/pki/ssh"
+	"github.com/SigStore/rekor/pkg/pki/ssh"
 )
 
 var (


### PR DESCRIPTION
All instances of projectrekor are now renamed to SigStore

This includes:

* Import paths
* Tests
* Readme's

Signed-off-by: Luke Hinds <lhinds@redhat.com>