### PR TITLE
no longer require SHA to upload artifacts to log

### DIFF
--- a/cmd/cli/app/pflags_test.go
+++ b/cmd/cli/app/pflags_test.go
@@ -37,7 +37,6 @@ func TestArtifactPFlags(t *testing.T) {
 		artifact              string
 		signature             string
 		publicKey             string
-		sha                   string
 		uuid                  string
 		uuidRequired          bool
 		logIndex              string
@@ -148,24 +147,6 @@ func TestArtifactPFlags(t *testing.T) {
 			expectValidateSuccess: true,
 		},
 		{
-			caseDesc:              "valid local artifact with incorrect length hex SHA value",
-			artifact:              "../../../tests/test_file.txt",
-			sha:                   "12345abcde",
-			signature:             "../../../tests/test_file.sig",
-			publicKey:             "../../../tests/test_public_key.key",
-			expectParseSuccess:    false,
-			expectValidateSuccess: false,
-		},
-		{
-			caseDesc:              "valid rekord - remote artifact with incorrect length hex SHA value",
-			artifact:              testServer.URL + "/artifact",
-			sha:                   "12345abcde",
-			signature:             "../../../tests/test_file.sig",
-			publicKey:             "../../../tests/test_public_key.key",
-			expectParseSuccess:    false,
-			expectValidateSuccess: false,
-		},
-		{
 			caseDesc:              "nonexistant local artifact",
 			artifact:              "../../../tests/not_a_file",
 			signature:             "../../../tests/test_file.sig",
@@ -238,7 +219,6 @@ func TestArtifactPFlags(t *testing.T) {
 		{
 			caseDesc:              "valid rekord - remote artifact with required flags",
 			artifact:              testServer.URL + "/artifact",
-			sha:                   "45c7b11fcbf07dec1694adecd8c5b85770a12a6c8dfdcf2580a2db0c47c31779",
 			signature:             "../../../tests/test_file.sig",
 			publicKey:             "../../../tests/test_public_key.key",
 			expectParseSuccess:    true,
@@ -248,7 +228,6 @@ func TestArtifactPFlags(t *testing.T) {
 			caseDesc:              "valid rpm - remote artifact with required flags",
 			typeStr:               "rpm",
 			artifact:              testServer.URL + "/rpm",
-			sha:                   "c8b0bc59708d74f53aab0089ac587d5c348d6ead143dab9f6d9c4b48c973bfd8",
 			publicKey:             "../../../tests/test_rpm_public_key.key",
 			expectParseSuccess:    true,
 			expectValidateSuccess: true,
@@ -256,24 +235,6 @@ func TestArtifactPFlags(t *testing.T) {
 		{
 			caseDesc:              "remote artifact with invalid URL",
 			artifact:              "hteeteep%**/test_file.txt",
-			sha:                   "45c7b11fcbf07dec1694adecd8c5b85770a12a6c8dfdcf2580a2db0c47c31779",
-			signature:             "../../../tests/test_file.sig",
-			publicKey:             "../../../tests/test_public_key.key",
-			expectParseSuccess:    false,
-			expectValidateSuccess: false,
-		},
-		{
-			caseDesc:              "remote artifact without required sha",
-			artifact:              testServer.URL + "/artifact",
-			signature:             "../../../tests/test_file.sig",
-			publicKey:             "../../../tests/test_public_key.key",
-			expectParseSuccess:    true,
-			expectValidateSuccess: false,
-		},
-		{
-			caseDesc:              "remote artifact with invalid sha",
-			artifact:              testServer.URL + "/artifact",
-			sha:                   "1345not%hash%",
 			signature:             "../../../tests/test_file.sig",
 			publicKey:             "../../../tests/test_public_key.key",
 			expectParseSuccess:    false,
@@ -376,9 +337,6 @@ func TestArtifactPFlags(t *testing.T) {
 		}
 		if tc.publicKey != "" {
 			args = append(args, "--public-key", tc.publicKey)
-		}
-		if tc.sha != "" {
-			args = append(args, "--sha", tc.sha)
 		}
 		if tc.uuid != "" {
 			args = append(args, "--uuid", tc.uuid)

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/google/trillian v1.3.13
 	github.com/jedisct1/go-minisign v0.0.0-20210106175330-e54e81d562c7
 	github.com/magiconair/properties v1.8.4 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mediocregopher/radix/v4 v4.0.0-beta.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.4.1
@@ -41,10 +42,10 @@ require (
 	go.uber.org/zap v1.16.0
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
 	golang.org/x/mod v0.4.1 // indirect
-	golang.org/x/net v0.0.0-20210119194325-5f4716e94777
+	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
-	golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78 // indirect
-	golang.org/x/tools v0.0.0-20210115202250-e0d201561e39 // indirect
+	golang.org/x/sys v0.0.0-20210301091718-77cc2087c03b // indirect
+	golang.org/x/tools v0.1.0 // indirect
 	google.golang.org/genproto v0.0.0-20200825200019-8632dd797987
 	google.golang.org/grpc v1.36.0
 	gopkg.in/ini.v1 v1.62.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -514,8 +514,9 @@ github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.1/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
-github.com/mailru/easyjson v0.7.6 h1:8yTIVnZgCoiM1TgqoeTl+LfU5Jg6/xL3QhGQnimLYnA=
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
+github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsIW75CHf65OeIOkyKbteujpZVXDpWK6YGZbxE=
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
@@ -898,8 +899,9 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
-golang.org/x/net v0.0.0-20210119194325-5f4716e94777 h1:003p0dJM77cxMSyCPFphvZf/Y5/NXf5fzg6ufd1/Oew=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 h1:qWPm9rbaAMKs8Bq/9LRpbMqxWRVUAQwMI9fVrssnTfw=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -967,8 +969,9 @@ golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78 h1:nVuTkr9L6Bq62qpUqKo/RnZCFfzDBL0bYo6w9OJUqZY=
-golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210301091718-77cc2087c03b h1:kHlr0tATeLRMEiZJu5CknOw/E8V6h69sXXQFGoPtjcc=
+golang.org/x/sys v0.0.0-20210301091718-77cc2087c03b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -1048,8 +1051,8 @@ golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200626171337-aa94e735be7f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200630154851-b2d8b0336632/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200706234117-b22de6825cf7/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
-golang.org/x/tools v0.0.0-20210115202250-e0d201561e39 h1:BTs2GMGSMWpgtCpv1CE7vkJTv7XcHdcLLnAMu7UbgTY=
-golang.org/x/tools v0.0.0-20210115202250-e0d201561e39/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
+golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/generated/restapi/embedded_spec.go
+++ b/pkg/generated/restapi/embedded_spec.go
@@ -1200,7 +1200,6 @@ func init() {
       "oneOf": [
         {
           "required": [
-            "hash",
             "url"
           ]
         },
@@ -1369,7 +1368,6 @@ func init() {
       "oneOf": [
         {
           "required": [
-            "hash",
             "url"
           ]
         },
@@ -1608,7 +1606,6 @@ func init() {
           "oneOf": [
             {
               "required": [
-                "hash",
                 "url"
               ]
             },
@@ -1788,7 +1785,6 @@ func init() {
           "oneOf": [
             {
               "required": [
-                "hash",
                 "url"
               ]
             },

--- a/pkg/types/rekord/v0.0.1/entry.go
+++ b/pkg/types/rekord/v0.0.1/entry.go
@@ -399,10 +399,6 @@ func (v V001Entry) Validate() error {
 	}
 
 	hash := data.Hash
-	if data.URL.String() != "" && hash == nil {
-		return errors.New("hash must be specified if 'url' is present for data")
-	}
-
 	if hash != nil {
 		if !govalidator.IsHash(swag.StringValue(hash.Value), swag.StringValue(hash.Algorithm)) {
 			return errors.New("invalid value for hash")

--- a/pkg/types/rekord/v0.0.1/entry_test.go
+++ b/pkg/types/rekord/v0.0.1/entry_test.go
@@ -178,8 +178,9 @@ func TestCrossFieldValidation(t *testing.T) {
 					},
 				},
 			},
-			hasExtEntities:         true,
-			expectUnmarshalSuccess: false,
+			hasExtEntities:            true,
+			expectUnmarshalSuccess:    true,
+			expectCanonicalizeSuccess: true,
 		},
 		{
 			caseDesc: "signature with data & url and empty hash",

--- a/pkg/types/rekord/v0.0.1/rekord_v0_0_1_schema.json
+++ b/pkg/types/rekord/v0.0.1/rekord_v0_0_1_schema.json
@@ -91,7 +91,7 @@
             },
             "oneOf": [
                 {
-                    "required": [ "hash", "url" ]
+                    "required": [ "url" ]
                 },
                 {
                     "required": [ "content" ]

--- a/pkg/types/rpm/v0.0.1/entry.go
+++ b/pkg/types/rpm/v0.0.1/entry.go
@@ -380,10 +380,6 @@ func (v V001Entry) Validate() error {
 	}
 
 	hash := pkg.Hash
-	if pkg.URL.String() != "" && hash == nil {
-		return errors.New("hash must be specified if 'url' is present for package")
-	}
-
 	if hash != nil {
 		if !govalidator.IsHash(swag.StringValue(hash.Value), swag.StringValue(hash.Algorithm)) {
 			return errors.New("invalid value for hash")

--- a/pkg/types/rpm/v0.0.1/entry_test.go
+++ b/pkg/types/rpm/v0.0.1/entry_test.go
@@ -134,8 +134,9 @@ func TestCrossFieldValidation(t *testing.T) {
 					},
 				},
 			},
-			hasExtEntities:         true,
-			expectUnmarshalSuccess: false,
+			hasExtEntities:            true,
+			expectUnmarshalSuccess:    true,
+			expectCanonicalizeSuccess: true,
 		},
 		{
 			caseDesc: "public key with data & url and empty hash",

--- a/pkg/types/rpm/v0.0.1/rpm_v0_0_1_schema.json
+++ b/pkg/types/rpm/v0.0.1/rpm_v0_0_1_schema.json
@@ -69,7 +69,7 @@
             },
             "oneOf": [
                 {
-                    "required": [ "hash", "url" ]
+                    "required": [ "url" ]
                 },
                 {
                     "required": [ "content" ]


### PR DESCRIPTION
Since the verification of a signature will, by definition, include
verifying the content has not been altered, it is unnecessary to require
users of the CLI or REST API to specify the SHA256 hash of the content
when creating a new entry into the log.

Note that the server will still compute the hash and store it in the log
for ease of comparison.

Fixes #180

Signed-off-by: Bob Callaway <bcallawa@redhat.com>