### PR TITLE
Remove API key from path to new log entry

### DIFF
--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -131,8 +131,13 @@ func CreateLogEntryHandler(params entries.CreateLogEntryParams) middleware.Respo
 		}()
 	}
 
-	location := strfmt.URI(fmt.Sprintf("%v/%v", httpReq.URL, uuid))
-	return entries.NewCreateLogEntryCreated().WithPayload(logEntry).WithLocation(location).WithETag(uuid)
+	locationURL := httpReq.URL
+	// remove API key from output
+	query := locationURL.Query()
+	query.Del("apiKey")
+	locationURL.RawQuery = query.Encode()
+	locationURL.Path = fmt.Sprintf("%v/%v", locationURL.Path, uuid)
+	return entries.NewCreateLogEntryCreated().WithPayload(logEntry).WithLocation(strfmt.URI(locationURL.String())).WithETag(uuid)
 }
 
 func GetLogEntryByUUIDHandler(params entries.GetLogEntryByUUIDParams) middleware.Responder {

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -262,3 +262,24 @@ func TestX509(t *testing.T) {
 	outputContains(t, out, "Entry already exists")
 
 }
+
+func TestUploadNoAPIKeyInOutput(t *testing.T) {
+	// Create a random artifact and sign it.
+	artifactPath := filepath.Join(t.TempDir(), "artifact")
+	sigPath := filepath.Join(t.TempDir(), "signature.asc")
+
+	createdPGPSignedArtifact(t, artifactPath, sigPath)
+
+	// Write the public key to a file
+	pubPath := filepath.Join(t.TempDir(), "pubKey.asc")
+	if err := ioutil.WriteFile(pubPath, []byte(publicKey), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// It should upload successfully.
+	out := runCli(t, "upload", "--artifact", artifactPath, "--signature", sigPath, "--public-key", pubPath, "--api-key", "foobar")
+	outputContains(t, out, "Created entry at")
+	if strings.Contains(out, "foobar") {
+		t.Errorf("CLI output contained API key when it should have squelched it")
+	}
+}


### PR DESCRIPTION
Since the API key can be specified as an environment variable and could
be thought of as an authentication credential, it should not be included
in the path to the created entry in the log.

Previously we simply appended the new entry's UUID to the full URL,
which was incorrect if an API key was specified as a query parameter.

Fixes #182

Signed-off-by: Bob Callaway <bcallawa@redhat.com>