### PR TITLE
Validate and return hash and size from signed root

### DIFF
--- a/cmd/cli/app/log_info.go
+++ b/cmd/cli/app/log_info.go
@@ -118,7 +118,7 @@ var logInfoCmd = &cobra.Command{
 			return nil, errors.New("tree size in signed tree head does not match value returned in API call")
 		}
 
-		if strings.ToLower(hex.EncodeToString(lr.RootHash)) != strings.ToLower(*logInfo.RootHash) {
+		if !strings.EqualFold(hex.EncodeToString(lr.RootHash), *logInfo.RootHash) {
 			return nil, errors.New("root hash in signed tree head does not match value returned in API call")
 		}
 


### PR DESCRIPTION
The loginfo API returns both the current size, root hash, as well as the
signed tree head that callers can verify if they wish. The CLI does a
check to verify the signature on the tree head returned, but was
reporting the unsigned size and hash. This change ensures that the
values match and prints the values from the signed tree head.

Fixes #200

Signed-off-by: Bob Callaway <bcallawa@redhat.com>