### PR TITLE
Return 400 error if requested tree size > reality

### DIFF
--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -34,12 +34,13 @@ const (
 	trillianUnexpectedResult       = "Unexpected result from transparency log"
 	failedToGenerateCanonicalEntry = "Error generating canonicalized entry"
 	entryAlreadyExists             = "An equivalent entry already exists in the transparency log"
-	firstSizeLessThanLastSize      = "firstSize(%v) must be less than lastSize(%v)"
+	firstSizeLessThanLastSize      = "firstSize(%d) must be less than lastSize(%d)"
 	malformedUUID                  = "UUID must be a 64-character hexadecimal string"
 	malformedHash                  = "Hash must be a 64-character hexadecimal string created from SHA256 algorithm"
 	malformedPublicKey             = "Public key provided could not be parsed"
 	failedToGenerateCanonicalKey   = "Error generating canonicalized public key"
 	redisUnexpectedResult          = "Unexpected result from searching index"
+	lastSizeGreaterThanKnown       = "The tree size requested(%d) was greater than what is currently observable(%d)"
 )
 
 func errorMsg(message string, code int) *models.Error {


### PR DESCRIPTION
Currently we return a 500 error if a consistency proof is requested for
a size that exceeds the current state of the log. This change causes a
400 "Bad Request" error with a more descriptive error message to be
returned.

Fixes #199

Signed-off-by: Bob Callaway <bcallawa@redhat.com>