### PR TITLE
Update version of docker-compose.yml

### DIFF
--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -1,4 +1,4 @@
-version: '3.1'
+version: '3.4'
 services:
   rekor-server-debug:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.1'
+version: '3.4'
 services:
   mysql:
     image: gcr.io/trillian-opensource-ci/db_server:3c8193ebb2d7fedb44d18e9c810d0d2e4dbb7e4d


### PR DESCRIPTION
start_period in healthcheck and target in build are properties that are not supported for docker-compose versions <3.4. This change fixes #204.