### PR TITLE
Refactor unmarshal/validation in order to make it easier for clients to parse log entries.

### DIFF
--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -244,6 +244,9 @@ func SearchLogQueryHandler(params entries.SearchLogQueryParams) middleware.Respo
 				if err != nil {
 					return err
 				}
+				if err := entry.Validate(); err != nil {
+					return err
+				}
 
 				if entry.HasExternalEntities() {
 					if err := entry.FetchExternalEntities(httpReqCtx); err != nil {

--- a/pkg/types/rekord/rekord_test.go
+++ b/pkg/types/rekord/rekord_test.go
@@ -34,6 +34,10 @@ func (u UnmarshalTester) NewEntry() types.EntryImpl {
 	return &UnmarshalTester{}
 }
 
+func (u UnmarshalTester) Validate() error {
+	return nil
+}
+
 func (u UnmarshalTester) APIVersion() string {
 	return "2.0.1"
 }

--- a/pkg/types/rekord/v0.0.1/entry.go
+++ b/pkg/types/rekord/v0.0.1/entry.go
@@ -134,7 +134,7 @@ func (v *V001Entry) Unmarshal(pe models.ProposedEntry) error {
 		return err
 	}
 	// cross field validation
-	return v.Validate()
+	return nil
 
 }
 

--- a/pkg/types/rekord/v0.0.1/entry_test.go
+++ b/pkg/types/rekord/v0.0.1/entry_test.go
@@ -529,7 +529,18 @@ func TestCrossFieldValidation(t *testing.T) {
 			APIVersion: swag.String(tc.entry.APIVersion()),
 			Spec:       tc.entry.RekordObj,
 		}
-		if err := v.Unmarshal(&r); (err == nil) != tc.expectUnmarshalSuccess {
+
+		unmarshalAndValidate := func() error {
+			if err := v.Unmarshal(&r); err != nil {
+				return err
+			}
+			if err := v.Validate(); err != nil {
+				return err
+			}
+			return nil
+		}
+
+		if err := unmarshalAndValidate(); (err == nil) != tc.expectUnmarshalSuccess {
 			t.Errorf("unexpected result in '%v': %v", tc.caseDesc, err)
 		}
 

--- a/pkg/types/rpm/rpm_test.go
+++ b/pkg/types/rpm/rpm_test.go
@@ -58,6 +58,10 @@ func (u UnmarshalTester) Unmarshal(pe models.ProposedEntry) error {
 	return nil
 }
 
+func (u UnmarshalTester) Validate() error {
+	return nil
+}
+
 type UnmarshalFailsTester struct {
 	UnmarshalTester
 }

--- a/pkg/types/rpm/v0.0.1/entry.go
+++ b/pkg/types/rpm/v0.0.1/entry.go
@@ -137,8 +137,7 @@ func (v *V001Entry) Unmarshal(pe models.ProposedEntry) error {
 	if err := v.RPMModel.Validate(strfmt.Default); err != nil {
 		return err
 	}
-	// cross field validation
-	return v.Validate()
+	return nil
 
 }
 

--- a/pkg/types/rpm/v0.0.1/entry_test.go
+++ b/pkg/types/rpm/v0.0.1/entry_test.go
@@ -373,7 +373,14 @@ func TestCrossFieldValidation(t *testing.T) {
 			APIVersion: swag.String(tc.entry.APIVersion()),
 			Spec:       tc.entry.RPMModel,
 		}
-		if err := v.Unmarshal(&r); (err == nil) != tc.expectUnmarshalSuccess {
+
+		unmarshalAndValidate := func() error {
+			if err := v.Unmarshal(&r); err != nil {
+				return err
+			}
+			return v.Validate()
+		}
+		if err := unmarshalAndValidate(); (err == nil) != tc.expectUnmarshalSuccess {
 			t.Errorf("unexpected result in '%v': %v", tc.caseDesc, err)
 		}
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -36,6 +36,7 @@ type EntryImpl interface {
 	FetchExternalEntities(ctx context.Context) error
 	HasExternalEntities() bool
 	Unmarshal(e models.ProposedEntry) error
+	Validate() error
 }
 
 type TypeFactory func() TypeImpl

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -130,9 +130,10 @@ func TestGet(t *testing.T) {
 	uuid := getUUIDFromUploadOutput(t, out)
 
 	out = runCli(t, "get", "--format=json", "--uuid", uuid)
+
 	// The output here should be in JSON with this structure:
 	g := struct {
-		Body           string
+		Body           interface{}
 		LogIndex       int
 		IntegratedTime int64
 	}{}


### PR DESCRIPTION
The output now looks like this:

```
$ ./cli get --uuid=079dc3e26b8a060d0ed21533aa0f43e3ae8d6426e9610c7213169d4b5c8c325d --format=json | jq .
{
  "Body": {
    "RekordObj": {
      "data": {
        "hash": {
          "algorithm": "sha256",
          "value": "326963a0be7e0325bf2c95f67d242326a456666b0ea9cac352ce41f3139f4a2d"
        }
      },
      "signature": {
        "content": "vH0k2lcgqD4RU6KDFv+kVBuf+9HuoThNcMEhZqW/IX4VtIT4guJ3LL5/9cfGH+1VNmRSpHHo/Im6lt91RB4kDg==",
        "format": "x509",
        "publicKey": {
          "content": "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUNvd0JRWURLMlZ3QXlFQVZhUVZuS3lvQ0VnZ01MbjZOdWhGcDVRZEJhSGI2TXA5S1lmOHBvUVVrUnc9Ci0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo="
        }
      }
    }
  },
  "LogIndex": 0,
  "IntegratedTime": 1614907036,
  "UUID": "079dc3e26b8a060d0ed21533aa0f43e3ae8d6426e9610c7213169d4b5c8c325d"
}
```

Rather than:
```
$ rekor-cli get --uuid=079dc3e26b8a060d0ed21533aa0f43e3ae8d6426e9610c7213169d4b5c8c325d --format=json | jq .
{
  "Body": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJzcGVjIjp7ImRhdGEiOnsiaGFzaCI6eyJhbGdvcml0aG0iOiJzaGEyNTYiLCJ2YWx1ZSI6IjMyNjk2M2EwYmU3ZTAzMjViZjJjOTVmNjdkMjQyMzI2YTQ1NjY2NmIwZWE5Y2FjMzUyY2U0MWYzMTM5ZjRhMmQifX0sInNpZ25hdHVyZSI6eyJjb250ZW50IjoidkgwazJsY2dxRDRSVTZLREZ2K2tWQnVmKzlIdW9UaE5jTUVoWnFXL0lYNFZ0SVQ0Z3VKM0xMNS85Y2ZHSCsxVk5tUlNwSEhvL0ltNmx0OTFSQjRrRGc9PSIsImZvcm1hdCI6Ing1MDkiLCJwdWJsaWNLZXkiOnsiY29udGVudCI6IkxTMHRMUzFDUlVkSlRpQlFWVUpNU1VNZ1MwVlpMUzB0TFMwS1RVTnZkMEpSV1VSTE1sWjNRWGxGUVZaaFVWWnVTM2x2UTBWblowMU1ialpPZFdoR2NEVlJaRUpoU0dJMlRYQTVTMWxtT0hCdlVWVnJVbmM5Q2kwdExTMHRSVTVFSUZCVlFreEpReUJMUlZrdExTMHRMUW89In19fSwia2luZCI6InJla29yZCJ9",
  "LogIndex": 928,
  "IntegratedTime": 1614907036,
  "UUID": "079dc3e26b8a060d0ed21533aa0f43e3ae8d6426e9610c7213169d4b5c8c325d"
}
```