### PR TITLE
Return location of existing entry if upload tried

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -432,6 +432,10 @@ responses:
     description: The request conflicts with the current state of the transparency log
     schema:
       $ref: "#/definitions/Error"
+    headers:
+      Location:
+        type: string
+        format: uri
   NotFound:
     description: The content requested could not be found
   InternalServerError:

--- a/pkg/generated/client/entries/create_log_entry_responses.go
+++ b/pkg/generated/client/entries/create_log_entry_responses.go
@@ -163,6 +163,8 @@ func NewCreateLogEntryConflict() *CreateLogEntryConflict {
 The request conflicts with the current state of the transparency log
 */
 type CreateLogEntryConflict struct {
+	Location strfmt.URI
+
 	Payload *models.Error
 }
 
@@ -175,6 +177,14 @@ func (o *CreateLogEntryConflict) GetPayload() *models.Error {
 }
 
 func (o *CreateLogEntryConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	// response header Location
+
+	location, err := formats.Parse("uri", response.GetHeader("Location"))
+	if err != nil {
+		return errors.InvalidType("Location", "header", "strfmt.URI", response.GetHeader("Location"))
+	}
+	o.Location = *(location.(*strfmt.URI))
 
 	o.Payload = new(models.Error)
 

--- a/pkg/generated/restapi/embedded_spec.go
+++ b/pkg/generated/restapi/embedded_spec.go
@@ -633,6 +633,12 @@ func init() {
       "description": "The request conflicts with the current state of the transparency log",
       "schema": {
         "$ref": "#/definitions/Error"
+      },
+      "headers": {
+        "Location": {
+          "type": "string",
+          "format": "uri"
+        }
       }
     },
     "InternalServerError": {
@@ -814,6 +820,12 @@ func init() {
             "description": "The request conflicts with the current state of the transparency log",
             "schema": {
               "$ref": "#/definitions/Error"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "format": "uri"
+              }
             }
           },
           "default": {
@@ -1879,6 +1891,12 @@ func init() {
       "description": "The request conflicts with the current state of the transparency log",
       "schema": {
         "$ref": "#/definitions/Error"
+      },
+      "headers": {
+        "Location": {
+          "type": "string",
+          "format": "uri"
+        }
       }
     },
     "InternalServerError": {

--- a/pkg/generated/restapi/operations/entries/create_log_entry_responses.go
+++ b/pkg/generated/restapi/operations/entries/create_log_entry_responses.go
@@ -174,6 +174,10 @@ const CreateLogEntryConflictCode int = 409
 swagger:response createLogEntryConflict
 */
 type CreateLogEntryConflict struct {
+	/*
+
+	 */
+	Location strfmt.URI `json:"Location"`
 
 	/*
 	  In: Body
@@ -185,6 +189,17 @@ type CreateLogEntryConflict struct {
 func NewCreateLogEntryConflict() *CreateLogEntryConflict {
 
 	return &CreateLogEntryConflict{}
+}
+
+// WithLocation adds the location to the create log entry conflict response
+func (o *CreateLogEntryConflict) WithLocation(location strfmt.URI) *CreateLogEntryConflict {
+	o.Location = location
+	return o
+}
+
+// SetLocation sets the location to the create log entry conflict response
+func (o *CreateLogEntryConflict) SetLocation(location strfmt.URI) {
+	o.Location = location
 }
 
 // WithPayload adds the payload to the create log entry conflict response
@@ -200,6 +215,13 @@ func (o *CreateLogEntryConflict) SetPayload(payload *models.Error) {
 
 // WriteResponse to the client
 func (o *CreateLogEntryConflict) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	// response header Location
+
+	location := o.Location.String()
+	if location != "" {
+		rw.Header().Set("Location", location)
+	}
 
 	rw.WriteHeader(409)
 	if o.Payload != nil {


### PR DESCRIPTION
Adds a Location response header when a 409 Conflict error is returned
from the server when a duplicate entry is sent for insertion into the
log. Also changes message printed by CLI to improve usability.

Fixes #222

Signed-off-by: Bob Callaway <bcallawa@redhat.com>