### PR TITLE
Stop exposing the redis server port on the host.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,6 @@ services:
       "--appendonly",
       "yes"
     ]
-    ports:
-      - "6379:6379"
     restart: always # keep the redis server running
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]


### PR DESCRIPTION
This was triggering some internal security scans we have, everything still works
with it only exposed locally.

cc @asraali