### PR TITLE
bump swagger to v0.27.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,16 +1,14 @@
 # This is a basic workflow to help you get started with Actions
 
 name: CI
-env:
-  GOVERSION: 1.16.2
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the main branch
 on:
   push:
-    branches: [ main, openapi ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, openapi ]
+    branches: [ main ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -22,13 +20,16 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+      # Extract version of Go to use
+      - name: Extract version of Go to use
+        run: echo "GOVERSION=$(cat Dockerfile|grep golang | awk ' { print $2 } ' | sed -r 's/^.*://g'| uniq)" >> $GITHUB_ENV
       # Setup Go
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GOVERSION }}
       # Download go-swagger
       - name: download go-swagger
-        run : go install github.com/go-swagger/go-swagger/cmd/swagger@v0.25.0
+        run : go install github.com/go-swagger/go-swagger/cmd/swagger@v0.27.0
       - name: Validate OpenAPI with Swagger
         run: swagger validate openapi.yaml
       # Make it

--- a/pkg/generated/client/entries/create_log_entry_parameters.go
+++ b/pkg/generated/client/entries/create_log_entry_parameters.go
@@ -35,56 +35,70 @@ import (
 	"github.com/sigstore/rekor/pkg/generated/models"
 )
 
-// NewCreateLogEntryParams creates a new CreateLogEntryParams object
-// with the default values initialized.
+// NewCreateLogEntryParams creates a new CreateLogEntryParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewCreateLogEntryParams() *CreateLogEntryParams {
-	var ()
 	return &CreateLogEntryParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewCreateLogEntryParamsWithTimeout creates a new CreateLogEntryParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewCreateLogEntryParamsWithTimeout(timeout time.Duration) *CreateLogEntryParams {
-	var ()
 	return &CreateLogEntryParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewCreateLogEntryParamsWithContext creates a new CreateLogEntryParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewCreateLogEntryParamsWithContext(ctx context.Context) *CreateLogEntryParams {
-	var ()
 	return &CreateLogEntryParams{
-
 		Context: ctx,
 	}
 }
 
 // NewCreateLogEntryParamsWithHTTPClient creates a new CreateLogEntryParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewCreateLogEntryParamsWithHTTPClient(client *http.Client) *CreateLogEntryParams {
-	var ()
 	return &CreateLogEntryParams{
 		HTTPClient: client,
 	}
 }
 
-/*CreateLogEntryParams contains all the parameters to send to the API endpoint
-for the create log entry operation typically these are written to a http.Request
+/* CreateLogEntryParams contains all the parameters to send to the API endpoint
+   for the create log entry operation.
+
+   Typically these are written to a http.Request.
 */
 type CreateLogEntryParams struct {
 
-	/*ProposedEntry*/
+	// ProposedEntry.
 	ProposedEntry models.ProposedEntry
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the create log entry params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *CreateLogEntryParams) WithDefaults() *CreateLogEntryParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the create log entry params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *CreateLogEntryParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the create log entry params
@@ -138,7 +152,6 @@ func (o *CreateLogEntryParams) WriteToRequest(r runtime.ClientRequest, reg strfm
 		return err
 	}
 	var res []error
-
 	if err := r.SetBodyParam(o.ProposedEntry); err != nil {
 		return err
 	}

--- a/pkg/generated/client/entries/create_log_entry_responses.go
+++ b/pkg/generated/client/entries/create_log_entry_responses.go
@@ -76,16 +76,20 @@ func NewCreateLogEntryCreated() *CreateLogEntryCreated {
 	return &CreateLogEntryCreated{}
 }
 
-/*CreateLogEntryCreated handles this case with default header values.
+/* CreateLogEntryCreated describes a response with status code 201, with default header values.
 
 Returns the entry created in the transparency log
 */
 type CreateLogEntryCreated struct {
-	/*UUID of log entry
+
+	/* UUID of log entry
 	 */
 	ETag string
-	/*URI location of log entry
-	 */
+
+	/* URI location of log entry
+
+	   Format: uri
+	*/
 	Location strfmt.URI
 
 	Payload models.LogEntry
@@ -94,23 +98,29 @@ type CreateLogEntryCreated struct {
 func (o *CreateLogEntryCreated) Error() string {
 	return fmt.Sprintf("[POST /api/v1/log/entries][%d] createLogEntryCreated  %+v", 201, o.Payload)
 }
-
 func (o *CreateLogEntryCreated) GetPayload() models.LogEntry {
 	return o.Payload
 }
 
 func (o *CreateLogEntryCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
-	// response header ETag
-	o.ETag = response.GetHeader("ETag")
+	// hydrates response header ETag
+	hdrETag := response.GetHeader("ETag")
 
-	// response header Location
-
-	location, err := formats.Parse("uri", response.GetHeader("Location"))
-	if err != nil {
-		return errors.InvalidType("Location", "header", "strfmt.URI", response.GetHeader("Location"))
+	if hdrETag != "" {
+		o.ETag = hdrETag
 	}
-	o.Location = *(location.(*strfmt.URI))
+
+	// hydrates response header Location
+	hdrLocation := response.GetHeader("Location")
+
+	if hdrLocation != "" {
+		vallocation, err := formats.Parse("uri", hdrLocation)
+		if err != nil {
+			return errors.InvalidType("Location", "header", "strfmt.URI", hdrLocation)
+		}
+		o.Location = *(vallocation.(*strfmt.URI))
+	}
 
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
@@ -125,7 +135,7 @@ func NewCreateLogEntryBadRequest() *CreateLogEntryBadRequest {
 	return &CreateLogEntryBadRequest{}
 }
 
-/*CreateLogEntryBadRequest handles this case with default header values.
+/* CreateLogEntryBadRequest describes a response with status code 400, with default header values.
 
 The content supplied to the server was invalid
 */
@@ -136,7 +146,6 @@ type CreateLogEntryBadRequest struct {
 func (o *CreateLogEntryBadRequest) Error() string {
 	return fmt.Sprintf("[POST /api/v1/log/entries][%d] createLogEntryBadRequest  %+v", 400, o.Payload)
 }
-
 func (o *CreateLogEntryBadRequest) GetPayload() *models.Error {
 	return o.Payload
 }
@@ -158,7 +167,7 @@ func NewCreateLogEntryConflict() *CreateLogEntryConflict {
 	return &CreateLogEntryConflict{}
 }
 
-/*CreateLogEntryConflict handles this case with default header values.
+/* CreateLogEntryConflict describes a response with status code 409, with default header values.
 
 The request conflicts with the current state of the transparency log
 */
@@ -171,20 +180,22 @@ type CreateLogEntryConflict struct {
 func (o *CreateLogEntryConflict) Error() string {
 	return fmt.Sprintf("[POST /api/v1/log/entries][%d] createLogEntryConflict  %+v", 409, o.Payload)
 }
-
 func (o *CreateLogEntryConflict) GetPayload() *models.Error {
 	return o.Payload
 }
 
 func (o *CreateLogEntryConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
-	// response header Location
+	// hydrates response header Location
+	hdrLocation := response.GetHeader("Location")
 
-	location, err := formats.Parse("uri", response.GetHeader("Location"))
-	if err != nil {
-		return errors.InvalidType("Location", "header", "strfmt.URI", response.GetHeader("Location"))
+	if hdrLocation != "" {
+		vallocation, err := formats.Parse("uri", hdrLocation)
+		if err != nil {
+			return errors.InvalidType("Location", "header", "strfmt.URI", hdrLocation)
+		}
+		o.Location = *(vallocation.(*strfmt.URI))
 	}
-	o.Location = *(location.(*strfmt.URI))
 
 	o.Payload = new(models.Error)
 
@@ -203,7 +214,7 @@ func NewCreateLogEntryDefault(code int) *CreateLogEntryDefault {
 	}
 }
 
-/*CreateLogEntryDefault handles this case with default header values.
+/* CreateLogEntryDefault describes a response with status code -1, with default header values.
 
 There was an internal error in the server while processing the request
 */
@@ -221,7 +232,6 @@ func (o *CreateLogEntryDefault) Code() int {
 func (o *CreateLogEntryDefault) Error() string {
 	return fmt.Sprintf("[POST /api/v1/log/entries][%d] createLogEntry default  %+v", o._statusCode, o.Payload)
 }
-
 func (o *CreateLogEntryDefault) GetPayload() *models.Error {
 	return o.Payload
 }

--- a/pkg/generated/client/entries/entries_client.go
+++ b/pkg/generated/client/entries/entries_client.go
@@ -40,17 +40,20 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	CreateLogEntry(params *CreateLogEntryParams) (*CreateLogEntryCreated, error)
+	CreateLogEntry(params *CreateLogEntryParams, opts ...ClientOption) (*CreateLogEntryCreated, error)
 
-	GetLogEntryByIndex(params *GetLogEntryByIndexParams) (*GetLogEntryByIndexOK, error)
+	GetLogEntryByIndex(params *GetLogEntryByIndexParams, opts ...ClientOption) (*GetLogEntryByIndexOK, error)
 
-	GetLogEntryByUUID(params *GetLogEntryByUUIDParams) (*GetLogEntryByUUIDOK, error)
+	GetLogEntryByUUID(params *GetLogEntryByUUIDParams, opts ...ClientOption) (*GetLogEntryByUUIDOK, error)
 
-	GetLogEntryProof(params *GetLogEntryProofParams) (*GetLogEntryProofOK, error)
+	GetLogEntryProof(params *GetLogEntryProofParams, opts ...ClientOption) (*GetLogEntryProofOK, error)
 
-	SearchLogQuery(params *SearchLogQueryParams) (*SearchLogQueryOK, error)
+	SearchLogQuery(params *SearchLogQueryParams, opts ...ClientOption) (*SearchLogQueryOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -61,13 +64,12 @@ type ClientService interface {
   Creates an entry in the transparency log for a detached signature, public key, and content. Items can be included in the request or fetched by the server when URLs are specified.
 
 */
-func (a *Client) CreateLogEntry(params *CreateLogEntryParams) (*CreateLogEntryCreated, error) {
+func (a *Client) CreateLogEntry(params *CreateLogEntryParams, opts ...ClientOption) (*CreateLogEntryCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewCreateLogEntryParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "createLogEntry",
 		Method:             "POST",
 		PathPattern:        "/api/v1/log/entries",
@@ -78,7 +80,12 @@ func (a *Client) CreateLogEntry(params *CreateLogEntryParams) (*CreateLogEntryCr
 		Reader:             &CreateLogEntryReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -94,13 +101,12 @@ func (a *Client) CreateLogEntry(params *CreateLogEntryParams) (*CreateLogEntryCr
 /*
   GetLogEntryByIndex retrieves an entry from the transparency log if it exists by index
 */
-func (a *Client) GetLogEntryByIndex(params *GetLogEntryByIndexParams) (*GetLogEntryByIndexOK, error) {
+func (a *Client) GetLogEntryByIndex(params *GetLogEntryByIndexParams, opts ...ClientOption) (*GetLogEntryByIndexOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetLogEntryByIndexParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "getLogEntryByIndex",
 		Method:             "GET",
 		PathPattern:        "/api/v1/log/entries",
@@ -111,7 +117,12 @@ func (a *Client) GetLogEntryByIndex(params *GetLogEntryByIndexParams) (*GetLogEn
 		Reader:             &GetLogEntryByIndexReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -127,13 +138,12 @@ func (a *Client) GetLogEntryByIndex(params *GetLogEntryByIndexParams) (*GetLogEn
 /*
   GetLogEntryByUUID retrieves an entry from the transparency log if it exists by UUID
 */
-func (a *Client) GetLogEntryByUUID(params *GetLogEntryByUUIDParams) (*GetLogEntryByUUIDOK, error) {
+func (a *Client) GetLogEntryByUUID(params *GetLogEntryByUUIDParams, opts ...ClientOption) (*GetLogEntryByUUIDOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetLogEntryByUUIDParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "getLogEntryByUUID",
 		Method:             "GET",
 		PathPattern:        "/api/v1/log/entries/{entryUUID}",
@@ -144,7 +154,12 @@ func (a *Client) GetLogEntryByUUID(params *GetLogEntryByUUIDParams) (*GetLogEntr
 		Reader:             &GetLogEntryByUUIDReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -162,13 +177,12 @@ func (a *Client) GetLogEntryByUUID(params *GetLogEntryByUUIDParams) (*GetLogEntr
 
   Returns root hash, tree size, and a list of hashes that can be used to calculate proof of an entry being included in the transparency log
 */
-func (a *Client) GetLogEntryProof(params *GetLogEntryProofParams) (*GetLogEntryProofOK, error) {
+func (a *Client) GetLogEntryProof(params *GetLogEntryProofParams, opts ...ClientOption) (*GetLogEntryProofOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetLogEntryProofParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "getLogEntryProof",
 		Method:             "GET",
 		PathPattern:        "/api/v1/log/entries/{entryUUID}/proof",
@@ -179,7 +193,12 @@ func (a *Client) GetLogEntryProof(params *GetLogEntryProofParams) (*GetLogEntryP
 		Reader:             &GetLogEntryProofReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -195,13 +214,12 @@ func (a *Client) GetLogEntryProof(params *GetLogEntryProofParams) (*GetLogEntryP
 /*
   SearchLogQuery searches transparency log for one or more log entries
 */
-func (a *Client) SearchLogQuery(params *SearchLogQueryParams) (*SearchLogQueryOK, error) {
+func (a *Client) SearchLogQuery(params *SearchLogQueryParams, opts ...ClientOption) (*SearchLogQueryOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewSearchLogQueryParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "searchLogQuery",
 		Method:             "POST",
 		PathPattern:        "/api/v1/log/entries/retrieve",
@@ -212,7 +230,12 @@ func (a *Client) SearchLogQuery(params *SearchLogQueryParams) (*SearchLogQueryOK
 		Reader:             &SearchLogQueryReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/generated/client/entries/get_log_entry_by_index_parameters.go
+++ b/pkg/generated/client/entries/get_log_entry_by_index_parameters.go
@@ -34,59 +34,73 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-// NewGetLogEntryByIndexParams creates a new GetLogEntryByIndexParams object
-// with the default values initialized.
+// NewGetLogEntryByIndexParams creates a new GetLogEntryByIndexParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewGetLogEntryByIndexParams() *GetLogEntryByIndexParams {
-	var ()
 	return &GetLogEntryByIndexParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewGetLogEntryByIndexParamsWithTimeout creates a new GetLogEntryByIndexParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewGetLogEntryByIndexParamsWithTimeout(timeout time.Duration) *GetLogEntryByIndexParams {
-	var ()
 	return &GetLogEntryByIndexParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewGetLogEntryByIndexParamsWithContext creates a new GetLogEntryByIndexParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewGetLogEntryByIndexParamsWithContext(ctx context.Context) *GetLogEntryByIndexParams {
-	var ()
 	return &GetLogEntryByIndexParams{
-
 		Context: ctx,
 	}
 }
 
 // NewGetLogEntryByIndexParamsWithHTTPClient creates a new GetLogEntryByIndexParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewGetLogEntryByIndexParamsWithHTTPClient(client *http.Client) *GetLogEntryByIndexParams {
-	var ()
 	return &GetLogEntryByIndexParams{
 		HTTPClient: client,
 	}
 }
 
-/*GetLogEntryByIndexParams contains all the parameters to send to the API endpoint
-for the get log entry by index operation typically these are written to a http.Request
+/* GetLogEntryByIndexParams contains all the parameters to send to the API endpoint
+   for the get log entry by index operation.
+
+   Typically these are written to a http.Request.
 */
 type GetLogEntryByIndexParams struct {
 
-	/*LogIndex
-	  specifies the index of the entry in the transparency log to be retrieved
+	/* LogIndex.
 
+	   specifies the index of the entry in the transparency log to be retrieved
 	*/
 	LogIndex int64
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the get log entry by index params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetLogEntryByIndexParams) WithDefaults() *GetLogEntryByIndexParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the get log entry by index params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetLogEntryByIndexParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the get log entry by index params
@@ -145,6 +159,7 @@ func (o *GetLogEntryByIndexParams) WriteToRequest(r runtime.ClientRequest, reg s
 	qrLogIndex := o.LogIndex
 	qLogIndex := swag.FormatInt64(qrLogIndex)
 	if qLogIndex != "" {
+
 		if err := r.SetQueryParam("logIndex", qLogIndex); err != nil {
 			return err
 		}

--- a/pkg/generated/client/entries/get_log_entry_by_index_responses.go
+++ b/pkg/generated/client/entries/get_log_entry_by_index_responses.go
@@ -69,7 +69,7 @@ func NewGetLogEntryByIndexOK() *GetLogEntryByIndexOK {
 	return &GetLogEntryByIndexOK{}
 }
 
-/*GetLogEntryByIndexOK handles this case with default header values.
+/* GetLogEntryByIndexOK describes a response with status code 200, with default header values.
 
 the entry in the transparency log requested
 */
@@ -80,7 +80,6 @@ type GetLogEntryByIndexOK struct {
 func (o *GetLogEntryByIndexOK) Error() string {
 	return fmt.Sprintf("[GET /api/v1/log/entries][%d] getLogEntryByIndexOK  %+v", 200, o.Payload)
 }
-
 func (o *GetLogEntryByIndexOK) GetPayload() models.LogEntry {
 	return o.Payload
 }
@@ -100,7 +99,7 @@ func NewGetLogEntryByIndexNotFound() *GetLogEntryByIndexNotFound {
 	return &GetLogEntryByIndexNotFound{}
 }
 
-/*GetLogEntryByIndexNotFound handles this case with default header values.
+/* GetLogEntryByIndexNotFound describes a response with status code 404, with default header values.
 
 The content requested could not be found
 */
@@ -123,7 +122,7 @@ func NewGetLogEntryByIndexDefault(code int) *GetLogEntryByIndexDefault {
 	}
 }
 
-/*GetLogEntryByIndexDefault handles this case with default header values.
+/* GetLogEntryByIndexDefault describes a response with status code -1, with default header values.
 
 There was an internal error in the server while processing the request
 */
@@ -141,7 +140,6 @@ func (o *GetLogEntryByIndexDefault) Code() int {
 func (o *GetLogEntryByIndexDefault) Error() string {
 	return fmt.Sprintf("[GET /api/v1/log/entries][%d] getLogEntryByIndex default  %+v", o._statusCode, o.Payload)
 }
-
 func (o *GetLogEntryByIndexDefault) GetPayload() *models.Error {
 	return o.Payload
 }

--- a/pkg/generated/client/entries/get_log_entry_by_uuid_parameters.go
+++ b/pkg/generated/client/entries/get_log_entry_by_uuid_parameters.go
@@ -33,59 +33,73 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewGetLogEntryByUUIDParams creates a new GetLogEntryByUUIDParams object
-// with the default values initialized.
+// NewGetLogEntryByUUIDParams creates a new GetLogEntryByUUIDParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewGetLogEntryByUUIDParams() *GetLogEntryByUUIDParams {
-	var ()
 	return &GetLogEntryByUUIDParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewGetLogEntryByUUIDParamsWithTimeout creates a new GetLogEntryByUUIDParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewGetLogEntryByUUIDParamsWithTimeout(timeout time.Duration) *GetLogEntryByUUIDParams {
-	var ()
 	return &GetLogEntryByUUIDParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewGetLogEntryByUUIDParamsWithContext creates a new GetLogEntryByUUIDParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewGetLogEntryByUUIDParamsWithContext(ctx context.Context) *GetLogEntryByUUIDParams {
-	var ()
 	return &GetLogEntryByUUIDParams{
-
 		Context: ctx,
 	}
 }
 
 // NewGetLogEntryByUUIDParamsWithHTTPClient creates a new GetLogEntryByUUIDParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewGetLogEntryByUUIDParamsWithHTTPClient(client *http.Client) *GetLogEntryByUUIDParams {
-	var ()
 	return &GetLogEntryByUUIDParams{
 		HTTPClient: client,
 	}
 }
 
-/*GetLogEntryByUUIDParams contains all the parameters to send to the API endpoint
-for the get log entry by UUID operation typically these are written to a http.Request
+/* GetLogEntryByUUIDParams contains all the parameters to send to the API endpoint
+   for the get log entry by UUID operation.
+
+   Typically these are written to a http.Request.
 */
 type GetLogEntryByUUIDParams struct {
 
-	/*EntryUUID
-	  the UUID of the entry to be retrieved from the log. The UUID is also the merkle tree hash of the entry.
+	/* EntryUUID.
 
+	   the UUID of the entry to be retrieved from the log. The UUID is also the merkle tree hash of the entry.
 	*/
 	EntryUUID string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the get log entry by UUID params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetLogEntryByUUIDParams) WithDefaults() *GetLogEntryByUUIDParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the get log entry by UUID params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetLogEntryByUUIDParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the get log entry by UUID params

--- a/pkg/generated/client/entries/get_log_entry_by_uuid_responses.go
+++ b/pkg/generated/client/entries/get_log_entry_by_uuid_responses.go
@@ -69,7 +69,7 @@ func NewGetLogEntryByUUIDOK() *GetLogEntryByUUIDOK {
 	return &GetLogEntryByUUIDOK{}
 }
 
-/*GetLogEntryByUUIDOK handles this case with default header values.
+/* GetLogEntryByUUIDOK describes a response with status code 200, with default header values.
 
 the entry in the transparency log requested
 */
@@ -80,7 +80,6 @@ type GetLogEntryByUUIDOK struct {
 func (o *GetLogEntryByUUIDOK) Error() string {
 	return fmt.Sprintf("[GET /api/v1/log/entries/{entryUUID}][%d] getLogEntryByUuidOK  %+v", 200, o.Payload)
 }
-
 func (o *GetLogEntryByUUIDOK) GetPayload() models.LogEntry {
 	return o.Payload
 }
@@ -100,7 +99,7 @@ func NewGetLogEntryByUUIDNotFound() *GetLogEntryByUUIDNotFound {
 	return &GetLogEntryByUUIDNotFound{}
 }
 
-/*GetLogEntryByUUIDNotFound handles this case with default header values.
+/* GetLogEntryByUUIDNotFound describes a response with status code 404, with default header values.
 
 The content requested could not be found
 */
@@ -123,7 +122,7 @@ func NewGetLogEntryByUUIDDefault(code int) *GetLogEntryByUUIDDefault {
 	}
 }
 
-/*GetLogEntryByUUIDDefault handles this case with default header values.
+/* GetLogEntryByUUIDDefault describes a response with status code -1, with default header values.
 
 There was an internal error in the server while processing the request
 */
@@ -141,7 +140,6 @@ func (o *GetLogEntryByUUIDDefault) Code() int {
 func (o *GetLogEntryByUUIDDefault) Error() string {
 	return fmt.Sprintf("[GET /api/v1/log/entries/{entryUUID}][%d] getLogEntryByUUID default  %+v", o._statusCode, o.Payload)
 }
-
 func (o *GetLogEntryByUUIDDefault) GetPayload() *models.Error {
 	return o.Payload
 }

--- a/pkg/generated/client/entries/get_log_entry_proof_parameters.go
+++ b/pkg/generated/client/entries/get_log_entry_proof_parameters.go
@@ -33,59 +33,73 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewGetLogEntryProofParams creates a new GetLogEntryProofParams object
-// with the default values initialized.
+// NewGetLogEntryProofParams creates a new GetLogEntryProofParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewGetLogEntryProofParams() *GetLogEntryProofParams {
-	var ()
 	return &GetLogEntryProofParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewGetLogEntryProofParamsWithTimeout creates a new GetLogEntryProofParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewGetLogEntryProofParamsWithTimeout(timeout time.Duration) *GetLogEntryProofParams {
-	var ()
 	return &GetLogEntryProofParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewGetLogEntryProofParamsWithContext creates a new GetLogEntryProofParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewGetLogEntryProofParamsWithContext(ctx context.Context) *GetLogEntryProofParams {
-	var ()
 	return &GetLogEntryProofParams{
-
 		Context: ctx,
 	}
 }
 
 // NewGetLogEntryProofParamsWithHTTPClient creates a new GetLogEntryProofParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewGetLogEntryProofParamsWithHTTPClient(client *http.Client) *GetLogEntryProofParams {
-	var ()
 	return &GetLogEntryProofParams{
 		HTTPClient: client,
 	}
 }
 
-/*GetLogEntryProofParams contains all the parameters to send to the API endpoint
-for the get log entry proof operation typically these are written to a http.Request
+/* GetLogEntryProofParams contains all the parameters to send to the API endpoint
+   for the get log entry proof operation.
+
+   Typically these are written to a http.Request.
 */
 type GetLogEntryProofParams struct {
 
-	/*EntryUUID
-	  the UUID of the entry for which the inclusion proof information should be returned
+	/* EntryUUID.
 
+	   the UUID of the entry for which the inclusion proof information should be returned
 	*/
 	EntryUUID string
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the get log entry proof params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetLogEntryProofParams) WithDefaults() *GetLogEntryProofParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the get log entry proof params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetLogEntryProofParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the get log entry proof params

--- a/pkg/generated/client/entries/get_log_entry_proof_responses.go
+++ b/pkg/generated/client/entries/get_log_entry_proof_responses.go
@@ -69,7 +69,7 @@ func NewGetLogEntryProofOK() *GetLogEntryProofOK {
 	return &GetLogEntryProofOK{}
 }
 
-/*GetLogEntryProofOK handles this case with default header values.
+/* GetLogEntryProofOK describes a response with status code 200, with default header values.
 
 Information needed for a client to compute the inclusion proof
 */
@@ -80,7 +80,6 @@ type GetLogEntryProofOK struct {
 func (o *GetLogEntryProofOK) Error() string {
 	return fmt.Sprintf("[GET /api/v1/log/entries/{entryUUID}/proof][%d] getLogEntryProofOK  %+v", 200, o.Payload)
 }
-
 func (o *GetLogEntryProofOK) GetPayload() *models.InclusionProof {
 	return o.Payload
 }
@@ -102,7 +101,7 @@ func NewGetLogEntryProofNotFound() *GetLogEntryProofNotFound {
 	return &GetLogEntryProofNotFound{}
 }
 
-/*GetLogEntryProofNotFound handles this case with default header values.
+/* GetLogEntryProofNotFound describes a response with status code 404, with default header values.
 
 The content requested could not be found
 */
@@ -125,7 +124,7 @@ func NewGetLogEntryProofDefault(code int) *GetLogEntryProofDefault {
 	}
 }
 
-/*GetLogEntryProofDefault handles this case with default header values.
+/* GetLogEntryProofDefault describes a response with status code -1, with default header values.
 
 There was an internal error in the server while processing the request
 */
@@ -143,7 +142,6 @@ func (o *GetLogEntryProofDefault) Code() int {
 func (o *GetLogEntryProofDefault) Error() string {
 	return fmt.Sprintf("[GET /api/v1/log/entries/{entryUUID}/proof][%d] getLogEntryProof default  %+v", o._statusCode, o.Payload)
 }
-
 func (o *GetLogEntryProofDefault) GetPayload() *models.Error {
 	return o.Payload
 }

--- a/pkg/generated/client/entries/search_log_query_parameters.go
+++ b/pkg/generated/client/entries/search_log_query_parameters.go
@@ -35,56 +35,70 @@ import (
 	"github.com/sigstore/rekor/pkg/generated/models"
 )
 
-// NewSearchLogQueryParams creates a new SearchLogQueryParams object
-// with the default values initialized.
+// NewSearchLogQueryParams creates a new SearchLogQueryParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewSearchLogQueryParams() *SearchLogQueryParams {
-	var ()
 	return &SearchLogQueryParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewSearchLogQueryParamsWithTimeout creates a new SearchLogQueryParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewSearchLogQueryParamsWithTimeout(timeout time.Duration) *SearchLogQueryParams {
-	var ()
 	return &SearchLogQueryParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewSearchLogQueryParamsWithContext creates a new SearchLogQueryParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewSearchLogQueryParamsWithContext(ctx context.Context) *SearchLogQueryParams {
-	var ()
 	return &SearchLogQueryParams{
-
 		Context: ctx,
 	}
 }
 
 // NewSearchLogQueryParamsWithHTTPClient creates a new SearchLogQueryParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewSearchLogQueryParamsWithHTTPClient(client *http.Client) *SearchLogQueryParams {
-	var ()
 	return &SearchLogQueryParams{
 		HTTPClient: client,
 	}
 }
 
-/*SearchLogQueryParams contains all the parameters to send to the API endpoint
-for the search log query operation typically these are written to a http.Request
+/* SearchLogQueryParams contains all the parameters to send to the API endpoint
+   for the search log query operation.
+
+   Typically these are written to a http.Request.
 */
 type SearchLogQueryParams struct {
 
-	/*Entry*/
+	// Entry.
 	Entry *models.SearchLogQuery
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the search log query params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *SearchLogQueryParams) WithDefaults() *SearchLogQueryParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the search log query params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *SearchLogQueryParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the search log query params
@@ -138,7 +152,6 @@ func (o *SearchLogQueryParams) WriteToRequest(r runtime.ClientRequest, reg strfm
 		return err
 	}
 	var res []error
-
 	if o.Entry != nil {
 		if err := r.SetBodyParam(o.Entry); err != nil {
 			return err

--- a/pkg/generated/client/entries/search_log_query_responses.go
+++ b/pkg/generated/client/entries/search_log_query_responses.go
@@ -69,7 +69,7 @@ func NewSearchLogQueryOK() *SearchLogQueryOK {
 	return &SearchLogQueryOK{}
 }
 
-/*SearchLogQueryOK handles this case with default header values.
+/* SearchLogQueryOK describes a response with status code 200, with default header values.
 
 Returns zero or more entries from the transparency log, according to how many were included in request query
 */
@@ -80,7 +80,6 @@ type SearchLogQueryOK struct {
 func (o *SearchLogQueryOK) Error() string {
 	return fmt.Sprintf("[POST /api/v1/log/entries/retrieve][%d] searchLogQueryOK  %+v", 200, o.Payload)
 }
-
 func (o *SearchLogQueryOK) GetPayload() []models.LogEntry {
 	return o.Payload
 }
@@ -100,7 +99,7 @@ func NewSearchLogQueryBadRequest() *SearchLogQueryBadRequest {
 	return &SearchLogQueryBadRequest{}
 }
 
-/*SearchLogQueryBadRequest handles this case with default header values.
+/* SearchLogQueryBadRequest describes a response with status code 400, with default header values.
 
 The content supplied to the server was invalid
 */
@@ -111,7 +110,6 @@ type SearchLogQueryBadRequest struct {
 func (o *SearchLogQueryBadRequest) Error() string {
 	return fmt.Sprintf("[POST /api/v1/log/entries/retrieve][%d] searchLogQueryBadRequest  %+v", 400, o.Payload)
 }
-
 func (o *SearchLogQueryBadRequest) GetPayload() *models.Error {
 	return o.Payload
 }
@@ -135,7 +133,7 @@ func NewSearchLogQueryDefault(code int) *SearchLogQueryDefault {
 	}
 }
 
-/*SearchLogQueryDefault handles this case with default header values.
+/* SearchLogQueryDefault describes a response with status code -1, with default header values.
 
 There was an internal error in the server while processing the request
 */
@@ -153,7 +151,6 @@ func (o *SearchLogQueryDefault) Code() int {
 func (o *SearchLogQueryDefault) Error() string {
 	return fmt.Sprintf("[POST /api/v1/log/entries/retrieve][%d] searchLogQuery default  %+v", o._statusCode, o.Payload)
 }
-
 func (o *SearchLogQueryDefault) GetPayload() *models.Error {
 	return o.Payload
 }

--- a/pkg/generated/client/index/search_index_parameters.go
+++ b/pkg/generated/client/index/search_index_parameters.go
@@ -35,56 +35,70 @@ import (
 	"github.com/sigstore/rekor/pkg/generated/models"
 )
 
-// NewSearchIndexParams creates a new SearchIndexParams object
-// with the default values initialized.
+// NewSearchIndexParams creates a new SearchIndexParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewSearchIndexParams() *SearchIndexParams {
-	var ()
 	return &SearchIndexParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewSearchIndexParamsWithTimeout creates a new SearchIndexParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewSearchIndexParamsWithTimeout(timeout time.Duration) *SearchIndexParams {
-	var ()
 	return &SearchIndexParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewSearchIndexParamsWithContext creates a new SearchIndexParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewSearchIndexParamsWithContext(ctx context.Context) *SearchIndexParams {
-	var ()
 	return &SearchIndexParams{
-
 		Context: ctx,
 	}
 }
 
 // NewSearchIndexParamsWithHTTPClient creates a new SearchIndexParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewSearchIndexParamsWithHTTPClient(client *http.Client) *SearchIndexParams {
-	var ()
 	return &SearchIndexParams{
 		HTTPClient: client,
 	}
 }
 
-/*SearchIndexParams contains all the parameters to send to the API endpoint
-for the search index operation typically these are written to a http.Request
+/* SearchIndexParams contains all the parameters to send to the API endpoint
+   for the search index operation.
+
+   Typically these are written to a http.Request.
 */
 type SearchIndexParams struct {
 
-	/*Query*/
+	// Query.
 	Query *models.SearchIndex
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the search index params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *SearchIndexParams) WithDefaults() *SearchIndexParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the search index params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *SearchIndexParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the search index params
@@ -138,7 +152,6 @@ func (o *SearchIndexParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.R
 		return err
 	}
 	var res []error
-
 	if o.Query != nil {
 		if err := r.SetBodyParam(o.Query); err != nil {
 			return err

--- a/pkg/generated/client/index/search_index_responses.go
+++ b/pkg/generated/client/index/search_index_responses.go
@@ -69,7 +69,7 @@ func NewSearchIndexOK() *SearchIndexOK {
 	return &SearchIndexOK{}
 }
 
-/*SearchIndexOK handles this case with default header values.
+/* SearchIndexOK describes a response with status code 200, with default header values.
 
 Returns zero or more entry UUIDs from the transparency log based on search query
 */
@@ -80,7 +80,6 @@ type SearchIndexOK struct {
 func (o *SearchIndexOK) Error() string {
 	return fmt.Sprintf("[POST /api/v1/index/retrieve][%d] searchIndexOK  %+v", 200, o.Payload)
 }
-
 func (o *SearchIndexOK) GetPayload() []string {
 	return o.Payload
 }
@@ -100,7 +99,7 @@ func NewSearchIndexBadRequest() *SearchIndexBadRequest {
 	return &SearchIndexBadRequest{}
 }
 
-/*SearchIndexBadRequest handles this case with default header values.
+/* SearchIndexBadRequest describes a response with status code 400, with default header values.
 
 The content supplied to the server was invalid
 */
@@ -111,7 +110,6 @@ type SearchIndexBadRequest struct {
 func (o *SearchIndexBadRequest) Error() string {
 	return fmt.Sprintf("[POST /api/v1/index/retrieve][%d] searchIndexBadRequest  %+v", 400, o.Payload)
 }
-
 func (o *SearchIndexBadRequest) GetPayload() *models.Error {
 	return o.Payload
 }
@@ -135,7 +133,7 @@ func NewSearchIndexDefault(code int) *SearchIndexDefault {
 	}
 }
 
-/*SearchIndexDefault handles this case with default header values.
+/* SearchIndexDefault describes a response with status code -1, with default header values.
 
 There was an internal error in the server while processing the request
 */
@@ -153,7 +151,6 @@ func (o *SearchIndexDefault) Code() int {
 func (o *SearchIndexDefault) Error() string {
 	return fmt.Sprintf("[POST /api/v1/index/retrieve][%d] searchIndex default  %+v", o._statusCode, o.Payload)
 }
-
 func (o *SearchIndexDefault) GetPayload() *models.Error {
 	return o.Payload
 }

--- a/pkg/generated/client/tlog/get_log_info_parameters.go
+++ b/pkg/generated/client/tlog/get_log_info_parameters.go
@@ -33,52 +33,66 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewGetLogInfoParams creates a new GetLogInfoParams object
-// with the default values initialized.
+// NewGetLogInfoParams creates a new GetLogInfoParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewGetLogInfoParams() *GetLogInfoParams {
-
 	return &GetLogInfoParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewGetLogInfoParamsWithTimeout creates a new GetLogInfoParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewGetLogInfoParamsWithTimeout(timeout time.Duration) *GetLogInfoParams {
-
 	return &GetLogInfoParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewGetLogInfoParamsWithContext creates a new GetLogInfoParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewGetLogInfoParamsWithContext(ctx context.Context) *GetLogInfoParams {
-
 	return &GetLogInfoParams{
-
 		Context: ctx,
 	}
 }
 
 // NewGetLogInfoParamsWithHTTPClient creates a new GetLogInfoParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewGetLogInfoParamsWithHTTPClient(client *http.Client) *GetLogInfoParams {
-
 	return &GetLogInfoParams{
 		HTTPClient: client,
 	}
 }
 
-/*GetLogInfoParams contains all the parameters to send to the API endpoint
-for the get log info operation typically these are written to a http.Request
+/* GetLogInfoParams contains all the parameters to send to the API endpoint
+   for the get log info operation.
+
+   Typically these are written to a http.Request.
 */
 type GetLogInfoParams struct {
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the get log info params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetLogInfoParams) WithDefaults() *GetLogInfoParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the get log info params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetLogInfoParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the get log info params

--- a/pkg/generated/client/tlog/get_log_info_responses.go
+++ b/pkg/generated/client/tlog/get_log_info_responses.go
@@ -63,7 +63,7 @@ func NewGetLogInfoOK() *GetLogInfoOK {
 	return &GetLogInfoOK{}
 }
 
-/*GetLogInfoOK handles this case with default header values.
+/* GetLogInfoOK describes a response with status code 200, with default header values.
 
 A JSON object with the root hash and tree size as properties
 */
@@ -74,7 +74,6 @@ type GetLogInfoOK struct {
 func (o *GetLogInfoOK) Error() string {
 	return fmt.Sprintf("[GET /api/v1/log][%d] getLogInfoOK  %+v", 200, o.Payload)
 }
-
 func (o *GetLogInfoOK) GetPayload() *models.LogInfo {
 	return o.Payload
 }
@@ -98,7 +97,7 @@ func NewGetLogInfoDefault(code int) *GetLogInfoDefault {
 	}
 }
 
-/*GetLogInfoDefault handles this case with default header values.
+/* GetLogInfoDefault describes a response with status code -1, with default header values.
 
 There was an internal error in the server while processing the request
 */
@@ -116,7 +115,6 @@ func (o *GetLogInfoDefault) Code() int {
 func (o *GetLogInfoDefault) Error() string {
 	return fmt.Sprintf("[GET /api/v1/log][%d] getLogInfo default  %+v", o._statusCode, o.Payload)
 }
-
 func (o *GetLogInfoDefault) GetPayload() *models.Error {
 	return o.Payload
 }

--- a/pkg/generated/client/tlog/get_log_proof_parameters.go
+++ b/pkg/generated/client/tlog/get_log_proof_parameters.go
@@ -34,77 +34,93 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-// NewGetLogProofParams creates a new GetLogProofParams object
-// with the default values initialized.
+// NewGetLogProofParams creates a new GetLogProofParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewGetLogProofParams() *GetLogProofParams {
-	var (
-		firstSizeDefault = int64(1)
-	)
 	return &GetLogProofParams{
-		FirstSize: &firstSizeDefault,
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewGetLogProofParamsWithTimeout creates a new GetLogProofParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewGetLogProofParamsWithTimeout(timeout time.Duration) *GetLogProofParams {
-	var (
-		firstSizeDefault = int64(1)
-	)
 	return &GetLogProofParams{
-		FirstSize: &firstSizeDefault,
-
 		timeout: timeout,
 	}
 }
 
 // NewGetLogProofParamsWithContext creates a new GetLogProofParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewGetLogProofParamsWithContext(ctx context.Context) *GetLogProofParams {
-	var (
-		firstSizeDefault = int64(1)
-	)
 	return &GetLogProofParams{
-		FirstSize: &firstSizeDefault,
-
 		Context: ctx,
 	}
 }
 
 // NewGetLogProofParamsWithHTTPClient creates a new GetLogProofParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewGetLogProofParamsWithHTTPClient(client *http.Client) *GetLogProofParams {
-	var (
-		firstSizeDefault = int64(1)
-	)
 	return &GetLogProofParams{
-		FirstSize:  &firstSizeDefault,
 		HTTPClient: client,
 	}
 }
 
-/*GetLogProofParams contains all the parameters to send to the API endpoint
-for the get log proof operation typically these are written to a http.Request
+/* GetLogProofParams contains all the parameters to send to the API endpoint
+   for the get log proof operation.
+
+   Typically these are written to a http.Request.
 */
 type GetLogProofParams struct {
 
-	/*FirstSize
-	  The size of the tree that you wish to prove consistency from (1 means the beginning of the log) Defaults to 1 if not specified
+	/* FirstSize.
+
+	   The size of the tree that you wish to prove consistency from (1 means the beginning of the log) Defaults to 1 if not specified
 
 
+	   Default: 1
 	*/
 	FirstSize *int64
-	/*LastSize
-	  The size of the tree that you wish to prove consistency to
 
+	/* LastSize.
+
+	   The size of the tree that you wish to prove consistency to
 	*/
 	LastSize int64
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the get log proof params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetLogProofParams) WithDefaults() *GetLogProofParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the get log proof params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetLogProofParams) SetDefaults() {
+	var (
+		firstSizeDefault = int64(1)
+	)
+
+	val := GetLogProofParams{
+		FirstSize: &firstSizeDefault,
+	}
+
+	val.timeout = o.timeout
+	val.Context = o.Context
+	val.HTTPClient = o.HTTPClient
+	*o = val
 }
 
 // WithTimeout adds the timeout to the get log proof params
@@ -174,22 +190,24 @@ func (o *GetLogProofParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.R
 
 		// query param firstSize
 		var qrFirstSize int64
+
 		if o.FirstSize != nil {
 			qrFirstSize = *o.FirstSize
 		}
 		qFirstSize := swag.FormatInt64(qrFirstSize)
 		if qFirstSize != "" {
+
 			if err := r.SetQueryParam("firstSize", qFirstSize); err != nil {
 				return err
 			}
 		}
-
 	}
 
 	// query param lastSize
 	qrLastSize := o.LastSize
 	qLastSize := swag.FormatInt64(qrLastSize)
 	if qLastSize != "" {
+
 		if err := r.SetQueryParam("lastSize", qLastSize); err != nil {
 			return err
 		}

--- a/pkg/generated/client/tlog/get_log_proof_responses.go
+++ b/pkg/generated/client/tlog/get_log_proof_responses.go
@@ -69,7 +69,7 @@ func NewGetLogProofOK() *GetLogProofOK {
 	return &GetLogProofOK{}
 }
 
-/*GetLogProofOK handles this case with default header values.
+/* GetLogProofOK describes a response with status code 200, with default header values.
 
 All hashes required to compute the consistency proof
 */
@@ -80,7 +80,6 @@ type GetLogProofOK struct {
 func (o *GetLogProofOK) Error() string {
 	return fmt.Sprintf("[GET /api/v1/log/proof][%d] getLogProofOK  %+v", 200, o.Payload)
 }
-
 func (o *GetLogProofOK) GetPayload() *models.ConsistencyProof {
 	return o.Payload
 }
@@ -102,7 +101,7 @@ func NewGetLogProofBadRequest() *GetLogProofBadRequest {
 	return &GetLogProofBadRequest{}
 }
 
-/*GetLogProofBadRequest handles this case with default header values.
+/* GetLogProofBadRequest describes a response with status code 400, with default header values.
 
 The content supplied to the server was invalid
 */
@@ -113,7 +112,6 @@ type GetLogProofBadRequest struct {
 func (o *GetLogProofBadRequest) Error() string {
 	return fmt.Sprintf("[GET /api/v1/log/proof][%d] getLogProofBadRequest  %+v", 400, o.Payload)
 }
-
 func (o *GetLogProofBadRequest) GetPayload() *models.Error {
 	return o.Payload
 }
@@ -137,7 +135,7 @@ func NewGetLogProofDefault(code int) *GetLogProofDefault {
 	}
 }
 
-/*GetLogProofDefault handles this case with default header values.
+/* GetLogProofDefault describes a response with status code -1, with default header values.
 
 There was an internal error in the server while processing the request
 */
@@ -155,7 +153,6 @@ func (o *GetLogProofDefault) Code() int {
 func (o *GetLogProofDefault) Error() string {
 	return fmt.Sprintf("[GET /api/v1/log/proof][%d] getLogProof default  %+v", o._statusCode, o.Payload)
 }
-
 func (o *GetLogProofDefault) GetPayload() *models.Error {
 	return o.Payload
 }

--- a/pkg/generated/client/tlog/get_public_key_parameters.go
+++ b/pkg/generated/client/tlog/get_public_key_parameters.go
@@ -33,52 +33,66 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// NewGetPublicKeyParams creates a new GetPublicKeyParams object
-// with the default values initialized.
+// NewGetPublicKeyParams creates a new GetPublicKeyParams object,
+// with the default timeout for this client.
+//
+// Default values are not hydrated, since defaults are normally applied by the API server side.
+//
+// To enforce default values in parameter, use SetDefaults or WithDefaults.
 func NewGetPublicKeyParams() *GetPublicKeyParams {
-
 	return &GetPublicKeyParams{
-
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewGetPublicKeyParamsWithTimeout creates a new GetPublicKeyParams object
-// with the default values initialized, and the ability to set a timeout on a request
+// with the ability to set a timeout on a request.
 func NewGetPublicKeyParamsWithTimeout(timeout time.Duration) *GetPublicKeyParams {
-
 	return &GetPublicKeyParams{
-
 		timeout: timeout,
 	}
 }
 
 // NewGetPublicKeyParamsWithContext creates a new GetPublicKeyParams object
-// with the default values initialized, and the ability to set a context for a request
+// with the ability to set a context for a request.
 func NewGetPublicKeyParamsWithContext(ctx context.Context) *GetPublicKeyParams {
-
 	return &GetPublicKeyParams{
-
 		Context: ctx,
 	}
 }
 
 // NewGetPublicKeyParamsWithHTTPClient creates a new GetPublicKeyParams object
-// with the default values initialized, and the ability to set a custom HTTPClient for a request
+// with the ability to set a custom HTTPClient for a request.
 func NewGetPublicKeyParamsWithHTTPClient(client *http.Client) *GetPublicKeyParams {
-
 	return &GetPublicKeyParams{
 		HTTPClient: client,
 	}
 }
 
-/*GetPublicKeyParams contains all the parameters to send to the API endpoint
-for the get public key operation typically these are written to a http.Request
+/* GetPublicKeyParams contains all the parameters to send to the API endpoint
+   for the get public key operation.
+
+   Typically these are written to a http.Request.
 */
 type GetPublicKeyParams struct {
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
+}
+
+// WithDefaults hydrates default values in the get public key params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetPublicKeyParams) WithDefaults() *GetPublicKeyParams {
+	o.SetDefaults()
+	return o
+}
+
+// SetDefaults hydrates default values in the get public key params (not the query body).
+//
+// All values with no default are reset to their zero value.
+func (o *GetPublicKeyParams) SetDefaults() {
+	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the get public key params

--- a/pkg/generated/client/tlog/get_public_key_responses.go
+++ b/pkg/generated/client/tlog/get_public_key_responses.go
@@ -63,7 +63,7 @@ func NewGetPublicKeyOK() *GetPublicKeyOK {
 	return &GetPublicKeyOK{}
 }
 
-/*GetPublicKeyOK handles this case with default header values.
+/* GetPublicKeyOK describes a response with status code 200, with default header values.
 
 The public key
 */
@@ -74,7 +74,6 @@ type GetPublicKeyOK struct {
 func (o *GetPublicKeyOK) Error() string {
 	return fmt.Sprintf("[GET /api/v1/log/publicKey][%d] getPublicKeyOK  %+v", 200, o.Payload)
 }
-
 func (o *GetPublicKeyOK) GetPayload() string {
 	return o.Payload
 }
@@ -96,7 +95,7 @@ func NewGetPublicKeyDefault(code int) *GetPublicKeyDefault {
 	}
 }
 
-/*GetPublicKeyDefault handles this case with default header values.
+/* GetPublicKeyDefault describes a response with status code -1, with default header values.
 
 There was an internal error in the server while processing the request
 */
@@ -114,7 +113,6 @@ func (o *GetPublicKeyDefault) Code() int {
 func (o *GetPublicKeyDefault) Error() string {
 	return fmt.Sprintf("[GET /api/v1/log/publicKey][%d] getPublicKey default  %+v", o._statusCode, o.Payload)
 }
-
 func (o *GetPublicKeyDefault) GetPayload() *models.Error {
 	return o.Payload
 }

--- a/pkg/generated/client/tlog/tlog_client.go
+++ b/pkg/generated/client/tlog/tlog_client.go
@@ -40,13 +40,16 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
+// ClientOption is the option for Client methods
+type ClientOption func(*runtime.ClientOperation)
+
 // ClientService is the interface for Client methods
 type ClientService interface {
-	GetLogInfo(params *GetLogInfoParams) (*GetLogInfoOK, error)
+	GetLogInfo(params *GetLogInfoParams, opts ...ClientOption) (*GetLogInfoOK, error)
 
-	GetLogProof(params *GetLogProofParams) (*GetLogProofOK, error)
+	GetLogProof(params *GetLogProofParams, opts ...ClientOption) (*GetLogProofOK, error)
 
-	GetPublicKey(params *GetPublicKeyParams) (*GetPublicKeyOK, error)
+	GetPublicKey(params *GetPublicKeyParams, opts ...ClientOption) (*GetPublicKeyOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -56,13 +59,12 @@ type ClientService interface {
 
   Returns the current root hash and size of the merkle tree used to store the log entries.
 */
-func (a *Client) GetLogInfo(params *GetLogInfoParams) (*GetLogInfoOK, error) {
+func (a *Client) GetLogInfo(params *GetLogInfoParams, opts ...ClientOption) (*GetLogInfoOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetLogInfoParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "getLogInfo",
 		Method:             "GET",
 		PathPattern:        "/api/v1/log",
@@ -73,7 +75,12 @@ func (a *Client) GetLogInfo(params *GetLogInfoParams) (*GetLogInfoOK, error) {
 		Reader:             &GetLogInfoReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -91,13 +98,12 @@ func (a *Client) GetLogInfo(params *GetLogInfoParams) (*GetLogInfoOK, error) {
 
   Returns a list of hashes for specified tree sizes that can be used to confirm the consistency of the transparency log
 */
-func (a *Client) GetLogProof(params *GetLogProofParams) (*GetLogProofOK, error) {
+func (a *Client) GetLogProof(params *GetLogProofParams, opts ...ClientOption) (*GetLogProofOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetLogProofParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "getLogProof",
 		Method:             "GET",
 		PathPattern:        "/api/v1/log/proof",
@@ -108,7 +114,12 @@ func (a *Client) GetLogProof(params *GetLogProofParams) (*GetLogProofOK, error) 
 		Reader:             &GetLogProofReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}
@@ -126,13 +137,12 @@ func (a *Client) GetLogProof(params *GetLogProofParams) (*GetLogProofOK, error) 
 
   Returns the public key that can be used to validate the signed tree head
 */
-func (a *Client) GetPublicKey(params *GetPublicKeyParams) (*GetPublicKeyOK, error) {
+func (a *Client) GetPublicKey(params *GetPublicKeyParams, opts ...ClientOption) (*GetPublicKeyOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewGetPublicKeyParams()
 	}
-
-	result, err := a.transport.Submit(&runtime.ClientOperation{
+	op := &runtime.ClientOperation{
 		ID:                 "getPublicKey",
 		Method:             "GET",
 		PathPattern:        "/api/v1/log/publicKey",
@@ -143,7 +153,12 @@ func (a *Client) GetPublicKey(params *GetPublicKeyParams) (*GetPublicKeyOK, erro
 		Reader:             &GetPublicKeyReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	})
+	}
+	for _, opt := range opts {
+		opt(op)
+	}
+
+	result, err := a.transport.Submit(op)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/generated/models/consistency_proof.go
+++ b/pkg/generated/models/consistency_proof.go
@@ -23,6 +23,7 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/go-openapi/errors"
@@ -72,7 +73,7 @@ func (m *ConsistencyProof) validateHashes(formats strfmt.Registry) error {
 
 	for i := 0; i < len(m.Hashes); i++ {
 
-		if err := validate.Pattern("hashes"+"."+strconv.Itoa(i), "body", string(m.Hashes[i]), `^[0-9a-fA-F]{64}$`); err != nil {
+		if err := validate.Pattern("hashes"+"."+strconv.Itoa(i), "body", m.Hashes[i], `^[0-9a-fA-F]{64}$`); err != nil {
 			return err
 		}
 
@@ -87,10 +88,15 @@ func (m *ConsistencyProof) validateRootHash(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.Pattern("rootHash", "body", string(*m.RootHash), `^[0-9a-fA-F]{64}$`); err != nil {
+	if err := validate.Pattern("rootHash", "body", *m.RootHash, `^[0-9a-fA-F]{64}$`); err != nil {
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this consistency proof based on context it is used
+func (m *ConsistencyProof) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/pkg/generated/models/error.go
+++ b/pkg/generated/models/error.go
@@ -23,6 +23,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 )
@@ -41,6 +43,11 @@ type Error struct {
 
 // Validate validates this error
 func (m *Error) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this error based on context it is used
+func (m *Error) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/pkg/generated/models/inclusion_proof.go
+++ b/pkg/generated/models/inclusion_proof.go
@@ -23,6 +23,7 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/go-openapi/errors"
@@ -90,7 +91,7 @@ func (m *InclusionProof) validateHashes(formats strfmt.Registry) error {
 
 	for i := 0; i < len(m.Hashes); i++ {
 
-		if err := validate.Pattern("hashes"+"."+strconv.Itoa(i), "body", string(m.Hashes[i]), `^[0-9a-fA-F]{64}$`); err != nil {
+		if err := validate.Pattern("hashes"+"."+strconv.Itoa(i), "body", m.Hashes[i], `^[0-9a-fA-F]{64}$`); err != nil {
 			return err
 		}
 
@@ -105,7 +106,7 @@ func (m *InclusionProof) validateLogIndex(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.MinimumInt("logIndex", "body", int64(*m.LogIndex), 0, false); err != nil {
+	if err := validate.MinimumInt("logIndex", "body", *m.LogIndex, 0, false); err != nil {
 		return err
 	}
 
@@ -118,7 +119,7 @@ func (m *InclusionProof) validateRootHash(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.Pattern("rootHash", "body", string(*m.RootHash), `^[0-9a-fA-F]{64}$`); err != nil {
+	if err := validate.Pattern("rootHash", "body", *m.RootHash, `^[0-9a-fA-F]{64}$`); err != nil {
 		return err
 	}
 
@@ -131,10 +132,15 @@ func (m *InclusionProof) validateTreeSize(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.MinimumInt("treeSize", "body", int64(*m.TreeSize), 1, false); err != nil {
+	if err := validate.MinimumInt("treeSize", "body", *m.TreeSize, 1, false); err != nil {
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this inclusion proof based on context it is used
+func (m *InclusionProof) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/pkg/generated/models/log_entry.go
+++ b/pkg/generated/models/log_entry.go
@@ -23,6 +23,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -45,6 +47,26 @@ func (m LogEntry) Validate(formats strfmt.Registry) error {
 		}
 		if val, ok := m[k]; ok {
 			if err := val.Validate(formats); err != nil {
+				return err
+			}
+		}
+
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+// ContextValidate validate this log entry based on the context it is used
+func (m LogEntry) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	for k := range m {
+
+		if val, ok := m[k]; ok {
+			if err := val.ContextValidate(ctx, formats); err != nil {
 				return err
 			}
 		}
@@ -94,19 +116,27 @@ func (m *LogEntryAnon) Validate(formats strfmt.Registry) error {
 
 func (m *LogEntryAnon) validateBody(formats strfmt.Registry) error {
 
+	if m.Body == nil {
+		return errors.Required("body", "body", nil)
+	}
+
 	return nil
 }
 
 func (m *LogEntryAnon) validateLogIndex(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.LogIndex) { // not required
 		return nil
 	}
 
-	if err := validate.MinimumInt("logIndex", "body", int64(*m.LogIndex), 0, false); err != nil {
+	if err := validate.MinimumInt("logIndex", "body", *m.LogIndex, 0, false); err != nil {
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this log entry anon based on context it is used
+func (m *LogEntryAnon) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/pkg/generated/models/log_info.go
+++ b/pkg/generated/models/log_info.go
@@ -23,6 +23,8 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -77,7 +79,7 @@ func (m *LogInfo) validateRootHash(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.Pattern("rootHash", "body", string(*m.RootHash), `^[0-9a-fA-F]{64}$`); err != nil {
+	if err := validate.Pattern("rootHash", "body", *m.RootHash, `^[0-9a-fA-F]{64}$`); err != nil {
 		return err
 	}
 
@@ -108,8 +110,36 @@ func (m *LogInfo) validateTreeSize(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.MinimumInt("treeSize", "body", int64(*m.TreeSize), 1, false); err != nil {
+	if err := validate.MinimumInt("treeSize", "body", *m.TreeSize, 1, false); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validate this log info based on the context it is used
+func (m *LogInfo) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateSignedTreeHead(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *LogInfo) contextValidateSignedTreeHead(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.SignedTreeHead != nil {
+		if err := m.SignedTreeHead.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("signedTreeHead")
+			}
+			return err
+		}
 	}
 
 	return nil
@@ -200,6 +230,11 @@ func (m *LogInfoSignedTreeHead) validateSignature(formats strfmt.Registry) error
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this log info signed tree head based on context it is used
+func (m *LogInfoSignedTreeHead) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/pkg/generated/models/proposed_entry.go
+++ b/pkg/generated/models/proposed_entry.go
@@ -24,6 +24,7 @@ package models
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"io/ioutil"
@@ -39,6 +40,7 @@ import (
 // swagger:discriminator ProposedEntry kind
 type ProposedEntry interface {
 	runtime.Validatable
+	runtime.ContextValidatable
 
 	// kind
 	// Required: true
@@ -132,5 +134,10 @@ func unmarshalProposedEntry(data []byte, consumer runtime.Consumer) (ProposedEnt
 
 // Validate validates this proposed entry
 func (m *proposedEntry) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this proposed entry based on context it is used
+func (m *proposedEntry) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }

--- a/pkg/generated/models/rekord.go
+++ b/pkg/generated/models/rekord.go
@@ -24,6 +24,7 @@ package models
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 
 	"github.com/go-openapi/errors"
@@ -165,7 +166,7 @@ func (m *Rekord) validateAPIVersion(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.Pattern("apiVersion", "body", string(*m.APIVersion), `^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`); err != nil {
+	if err := validate.Pattern("apiVersion", "body", *m.APIVersion, `^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`); err != nil {
 		return err
 	}
 
@@ -174,10 +175,20 @@ func (m *Rekord) validateAPIVersion(formats strfmt.Registry) error {
 
 func (m *Rekord) validateSpec(formats strfmt.Registry) error {
 
-	if err := validate.Required("spec", "body", m.Spec); err != nil {
-		return err
+	if m.Spec == nil {
+		return errors.Required("spec", "body", nil)
 	}
 
+	return nil
+}
+
+// ContextValidate validate this rekord based on the context it is used
+func (m *Rekord) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
 	return nil
 }
 

--- a/pkg/generated/models/rekord_v001_schema.go
+++ b/pkg/generated/models/rekord_v001_schema.go
@@ -23,6 +23,7 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/go-openapi/errors"
@@ -104,6 +105,52 @@ func (m *RekordV001Schema) validateSignature(formats strfmt.Registry) error {
 	return nil
 }
 
+// ContextValidate validate this rekord v001 schema based on the context it is used
+func (m *RekordV001Schema) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateData(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidateSignature(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *RekordV001Schema) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.Data != nil {
+		if err := m.Data.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("data")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *RekordV001Schema) contextValidateSignature(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.Signature != nil {
+		if err := m.Signature.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("signature")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 // MarshalBinary interface implementation
 func (m *RekordV001Schema) MarshalBinary() ([]byte, error) {
 	if m == nil {
@@ -158,7 +205,6 @@ func (m *RekordV001SchemaData) Validate(formats strfmt.Registry) error {
 }
 
 func (m *RekordV001SchemaData) validateHash(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.Hash) { // not required
 		return nil
 	}
@@ -176,13 +222,40 @@ func (m *RekordV001SchemaData) validateHash(formats strfmt.Registry) error {
 }
 
 func (m *RekordV001SchemaData) validateURL(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.URL) { // not required
 		return nil
 	}
 
 	if err := validate.FormatOf("data"+"."+"url", "body", "uri", m.URL.String(), formats); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validate this rekord v001 schema data based on the context it is used
+func (m *RekordV001SchemaData) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateHash(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *RekordV001SchemaData) contextValidateHash(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.Hash != nil {
+		if err := m.Hash.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("data" + "." + "hash")
+			}
+			return err
+		}
 	}
 
 	return nil
@@ -288,6 +361,11 @@ func (m *RekordV001SchemaDataHash) validateValue(formats strfmt.Registry) error 
 	return nil
 }
 
+// ContextValidate validates this rekord v001 schema data hash based on context it is used
+func (m *RekordV001SchemaDataHash) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
 // MarshalBinary interface implementation
 func (m *RekordV001SchemaDataHash) MarshalBinary() ([]byte, error) {
 	if m == nil {
@@ -385,7 +463,6 @@ func (m *RekordV001SchemaSignature) validateFormatEnum(path, location string, va
 }
 
 func (m *RekordV001SchemaSignature) validateFormat(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.Format) { // not required
 		return nil
 	}
@@ -399,7 +476,6 @@ func (m *RekordV001SchemaSignature) validateFormat(formats strfmt.Registry) erro
 }
 
 func (m *RekordV001SchemaSignature) validatePublicKey(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.PublicKey) { // not required
 		return nil
 	}
@@ -417,13 +493,40 @@ func (m *RekordV001SchemaSignature) validatePublicKey(formats strfmt.Registry) e
 }
 
 func (m *RekordV001SchemaSignature) validateURL(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.URL) { // not required
 		return nil
 	}
 
 	if err := validate.FormatOf("signature"+"."+"url", "body", "uri", m.URL.String(), formats); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validate this rekord v001 schema signature based on the context it is used
+func (m *RekordV001SchemaSignature) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidatePublicKey(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *RekordV001SchemaSignature) contextValidatePublicKey(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.PublicKey != nil {
+		if err := m.PublicKey.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("signature" + "." + "publicKey")
+			}
+			return err
+		}
 	}
 
 	return nil
@@ -476,7 +579,6 @@ func (m *RekordV001SchemaSignaturePublicKey) Validate(formats strfmt.Registry) e
 }
 
 func (m *RekordV001SchemaSignaturePublicKey) validateURL(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.URL) { // not required
 		return nil
 	}
@@ -485,6 +587,11 @@ func (m *RekordV001SchemaSignaturePublicKey) validateURL(formats strfmt.Registry
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this rekord v001 schema signature public key based on context it is used
+func (m *RekordV001SchemaSignaturePublicKey) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/pkg/generated/models/rpm.go
+++ b/pkg/generated/models/rpm.go
@@ -24,6 +24,7 @@ package models
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 
 	"github.com/go-openapi/errors"
@@ -165,7 +166,7 @@ func (m *Rpm) validateAPIVersion(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.Pattern("apiVersion", "body", string(*m.APIVersion), `^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`); err != nil {
+	if err := validate.Pattern("apiVersion", "body", *m.APIVersion, `^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`); err != nil {
 		return err
 	}
 
@@ -174,10 +175,20 @@ func (m *Rpm) validateAPIVersion(formats strfmt.Registry) error {
 
 func (m *Rpm) validateSpec(formats strfmt.Registry) error {
 
-	if err := validate.Required("spec", "body", m.Spec); err != nil {
-		return err
+	if m.Spec == nil {
+		return errors.Required("spec", "body", nil)
 	}
 
+	return nil
+}
+
+// ContextValidate validate this rpm based on the context it is used
+func (m *Rpm) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
 	return nil
 }
 

--- a/pkg/generated/models/rpm_v001_schema.go
+++ b/pkg/generated/models/rpm_v001_schema.go
@@ -23,6 +23,7 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/go-openapi/errors"
@@ -104,6 +105,52 @@ func (m *RpmV001Schema) validatePublicKey(formats strfmt.Registry) error {
 	return nil
 }
 
+// ContextValidate validate this rpm v001 schema based on the context it is used
+func (m *RpmV001Schema) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidatePackage(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.contextValidatePublicKey(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *RpmV001Schema) contextValidatePackage(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.Package != nil {
+		if err := m.Package.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("package")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *RpmV001Schema) contextValidatePublicKey(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.PublicKey != nil {
+		if err := m.PublicKey.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("publicKey")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 // MarshalBinary interface implementation
 func (m *RpmV001Schema) MarshalBinary() ([]byte, error) {
 	if m == nil {
@@ -161,7 +208,6 @@ func (m *RpmV001SchemaPackage) Validate(formats strfmt.Registry) error {
 }
 
 func (m *RpmV001SchemaPackage) validateHash(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.Hash) { // not required
 		return nil
 	}
@@ -179,13 +225,40 @@ func (m *RpmV001SchemaPackage) validateHash(formats strfmt.Registry) error {
 }
 
 func (m *RpmV001SchemaPackage) validateURL(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.URL) { // not required
 		return nil
 	}
 
 	if err := validate.FormatOf("package"+"."+"url", "body", "uri", m.URL.String(), formats); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validate this rpm v001 schema package based on the context it is used
+func (m *RpmV001SchemaPackage) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateHash(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *RpmV001SchemaPackage) contextValidateHash(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.Hash != nil {
+		if err := m.Hash.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("package" + "." + "hash")
+			}
+			return err
+		}
 	}
 
 	return nil
@@ -291,6 +364,11 @@ func (m *RpmV001SchemaPackageHash) validateValue(formats strfmt.Registry) error 
 	return nil
 }
 
+// ContextValidate validates this rpm v001 schema package hash based on context it is used
+func (m *RpmV001SchemaPackageHash) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
 // MarshalBinary interface implementation
 func (m *RpmV001SchemaPackageHash) MarshalBinary() ([]byte, error) {
 	if m == nil {
@@ -338,7 +416,6 @@ func (m *RpmV001SchemaPublicKey) Validate(formats strfmt.Registry) error {
 }
 
 func (m *RpmV001SchemaPublicKey) validateURL(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.URL) { // not required
 		return nil
 	}
@@ -347,6 +424,11 @@ func (m *RpmV001SchemaPublicKey) validateURL(formats strfmt.Registry) error {
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this rpm v001 schema public key based on context it is used
+func (m *RpmV001SchemaPublicKey) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/pkg/generated/models/search_index.go
+++ b/pkg/generated/models/search_index.go
@@ -23,6 +23,7 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/go-openapi/errors"
@@ -63,12 +64,11 @@ func (m *SearchIndex) Validate(formats strfmt.Registry) error {
 }
 
 func (m *SearchIndex) validateHash(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.Hash) { // not required
 		return nil
 	}
 
-	if err := validate.Pattern("hash", "body", string(m.Hash), `^[0-9a-fA-F]{64}$`); err != nil {
+	if err := validate.Pattern("hash", "body", m.Hash, `^[0-9a-fA-F]{64}$`); err != nil {
 		return err
 	}
 
@@ -76,13 +76,40 @@ func (m *SearchIndex) validateHash(formats strfmt.Registry) error {
 }
 
 func (m *SearchIndex) validatePublicKey(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.PublicKey) { // not required
 		return nil
 	}
 
 	if m.PublicKey != nil {
 		if err := m.PublicKey.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("publicKey")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ContextValidate validate this search index based on the context it is used
+func (m *SearchIndex) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidatePublicKey(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *SearchIndex) contextValidatePublicKey(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.PublicKey != nil {
+		if err := m.PublicKey.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("publicKey")
 			}
@@ -198,7 +225,6 @@ func (m *SearchIndexPublicKey) validateFormat(formats strfmt.Registry) error {
 }
 
 func (m *SearchIndexPublicKey) validateURL(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.URL) { // not required
 		return nil
 	}
@@ -207,6 +233,11 @@ func (m *SearchIndexPublicKey) validateURL(formats strfmt.Registry) error {
 		return err
 	}
 
+	return nil
+}
+
+// ContextValidate validates this search index public key based on context it is used
+func (m *SearchIndexPublicKey) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/pkg/generated/restapi/embedded_spec.go
+++ b/pkg/generated/restapi/embedded_spec.go
@@ -1544,7 +1544,6 @@ func init() {
         "entries": {
           "type": "array",
           "items": {
-            "minItems": 1,
             "$ref": "#/definitions/ProposedEntry"
           }
         },
@@ -1552,8 +1551,7 @@ func init() {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[0-9a-fA-F]{64}$",
-            "minItems": 1
+            "pattern": "^[0-9a-fA-F]{64}$"
           }
         },
         "logIndexes": {

--- a/pkg/generated/restapi/operations/entries/create_log_entry.go
+++ b/pkg/generated/restapi/operations/entries/create_log_entry.go
@@ -46,7 +46,7 @@ func NewCreateLogEntry(ctx *middleware.Context, handler CreateLogEntryHandler) *
 	return &CreateLogEntry{Context: ctx, Handler: handler}
 }
 
-/*CreateLogEntry swagger:route POST /api/v1/log/entries entries createLogEntry
+/* CreateLogEntry swagger:route POST /api/v1/log/entries entries createLogEntry
 
 Creates an entry in the transparency log
 
@@ -62,17 +62,15 @@ type CreateLogEntry struct {
 func (o *CreateLogEntry) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewCreateLogEntryParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/pkg/generated/restapi/operations/entries/create_log_entry_parameters.go
+++ b/pkg/generated/restapi/operations/entries/create_log_entry_parameters.go
@@ -23,18 +23,21 @@ package entries
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"io"
 	"net/http"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/validate"
 
 	"github.com/sigstore/rekor/pkg/generated/models"
 )
 
 // NewCreateLogEntryParams creates a new CreateLogEntryParams object
-// no default values defined in spec.
+//
+// There are no default values defined in the spec.
 func NewCreateLogEntryParams() CreateLogEntryParams {
 
 	return CreateLogEntryParams{}
@@ -76,6 +79,11 @@ func (o *CreateLogEntryParams) BindRequest(r *http.Request, route *middleware.Ma
 		} else {
 			// validate body object
 			if err := body.Validate(route.Formats); err != nil {
+				res = append(res, err)
+			}
+
+			ctx := validate.WithOperationRequest(context.Background())
+			if err := body.ContextValidate(ctx, route.Formats); err != nil {
 				res = append(res, err)
 			}
 

--- a/pkg/generated/restapi/operations/entries/get_log_entry_by_index.go
+++ b/pkg/generated/restapi/operations/entries/get_log_entry_by_index.go
@@ -46,7 +46,7 @@ func NewGetLogEntryByIndex(ctx *middleware.Context, handler GetLogEntryByIndexHa
 	return &GetLogEntryByIndex{Context: ctx, Handler: handler}
 }
 
-/*GetLogEntryByIndex swagger:route GET /api/v1/log/entries entries getLogEntryByIndex
+/* GetLogEntryByIndex swagger:route GET /api/v1/log/entries entries getLogEntryByIndex
 
 Retrieves an entry from the transparency log (if it exists) by index
 
@@ -59,17 +59,15 @@ type GetLogEntryByIndex struct {
 func (o *GetLogEntryByIndex) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetLogEntryByIndexParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/pkg/generated/restapi/operations/entries/get_log_entry_by_index_parameters.go
+++ b/pkg/generated/restapi/operations/entries/get_log_entry_by_index_parameters.go
@@ -34,7 +34,8 @@ import (
 )
 
 // NewGetLogEntryByIndexParams creates a new GetLogEntryByIndexParams object
-// no default values defined in spec.
+//
+// There are no default values defined in the spec.
 func NewGetLogEntryByIndexParams() GetLogEntryByIndexParams {
 
 	return GetLogEntryByIndexParams{}
@@ -72,7 +73,6 @@ func (o *GetLogEntryByIndexParams) BindRequest(r *http.Request, route *middlewar
 	if err := o.bindLogIndex(qLogIndex, qhkLogIndex, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -91,6 +91,7 @@ func (o *GetLogEntryByIndexParams) bindLogIndex(rawData []string, hasKey bool, f
 
 	// Required: true
 	// AllowEmptyValue: false
+
 	if err := validate.RequiredString("logIndex", "query", raw); err != nil {
 		return err
 	}
@@ -111,7 +112,7 @@ func (o *GetLogEntryByIndexParams) bindLogIndex(rawData []string, hasKey bool, f
 // validateLogIndex carries on validations for parameter LogIndex
 func (o *GetLogEntryByIndexParams) validateLogIndex(formats strfmt.Registry) error {
 
-	if err := validate.MinimumInt("logIndex", "query", int64(o.LogIndex), 0, false); err != nil {
+	if err := validate.MinimumInt("logIndex", "query", o.LogIndex, 0, false); err != nil {
 		return err
 	}
 

--- a/pkg/generated/restapi/operations/entries/get_log_entry_by_uuid.go
+++ b/pkg/generated/restapi/operations/entries/get_log_entry_by_uuid.go
@@ -46,7 +46,7 @@ func NewGetLogEntryByUUID(ctx *middleware.Context, handler GetLogEntryByUUIDHand
 	return &GetLogEntryByUUID{Context: ctx, Handler: handler}
 }
 
-/*GetLogEntryByUUID swagger:route GET /api/v1/log/entries/{entryUUID} entries getLogEntryByUuid
+/* GetLogEntryByUUID swagger:route GET /api/v1/log/entries/{entryUUID} entries getLogEntryByUuid
 
 Retrieves an entry from the transparency log (if it exists) by UUID
 
@@ -59,17 +59,15 @@ type GetLogEntryByUUID struct {
 func (o *GetLogEntryByUUID) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetLogEntryByUUIDParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/pkg/generated/restapi/operations/entries/get_log_entry_by_uuid_parameters.go
+++ b/pkg/generated/restapi/operations/entries/get_log_entry_by_uuid_parameters.go
@@ -32,7 +32,8 @@ import (
 )
 
 // NewGetLogEntryByUUIDParams creates a new GetLogEntryByUUIDParams object
-// no default values defined in spec.
+//
+// There are no default values defined in the spec.
 func NewGetLogEntryByUUIDParams() GetLogEntryByUUIDParams {
 
 	return GetLogEntryByUUIDParams{}
@@ -68,7 +69,6 @@ func (o *GetLogEntryByUUIDParams) BindRequest(r *http.Request, route *middleware
 	if err := o.bindEntryUUID(rEntryUUID, rhkEntryUUID, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -84,7 +84,6 @@ func (o *GetLogEntryByUUIDParams) bindEntryUUID(rawData []string, hasKey bool, f
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.EntryUUID = raw
 
 	if err := o.validateEntryUUID(formats); err != nil {

--- a/pkg/generated/restapi/operations/entries/get_log_entry_proof.go
+++ b/pkg/generated/restapi/operations/entries/get_log_entry_proof.go
@@ -46,7 +46,7 @@ func NewGetLogEntryProof(ctx *middleware.Context, handler GetLogEntryProofHandle
 	return &GetLogEntryProof{Context: ctx, Handler: handler}
 }
 
-/*GetLogEntryProof swagger:route GET /api/v1/log/entries/{entryUUID}/proof entries getLogEntryProof
+/* GetLogEntryProof swagger:route GET /api/v1/log/entries/{entryUUID}/proof entries getLogEntryProof
 
 Get information required to generate an inclusion proof for a specified entry in the transparency log
 
@@ -61,17 +61,15 @@ type GetLogEntryProof struct {
 func (o *GetLogEntryProof) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetLogEntryProofParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/pkg/generated/restapi/operations/entries/get_log_entry_proof_parameters.go
+++ b/pkg/generated/restapi/operations/entries/get_log_entry_proof_parameters.go
@@ -32,7 +32,8 @@ import (
 )
 
 // NewGetLogEntryProofParams creates a new GetLogEntryProofParams object
-// no default values defined in spec.
+//
+// There are no default values defined in the spec.
 func NewGetLogEntryProofParams() GetLogEntryProofParams {
 
 	return GetLogEntryProofParams{}
@@ -68,7 +69,6 @@ func (o *GetLogEntryProofParams) BindRequest(r *http.Request, route *middleware.
 	if err := o.bindEntryUUID(rEntryUUID, rhkEntryUUID, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -84,7 +84,6 @@ func (o *GetLogEntryProofParams) bindEntryUUID(rawData []string, hasKey bool, fo
 
 	// Required: true
 	// Parameter is provided by construction from the route
-
 	o.EntryUUID = raw
 
 	if err := o.validateEntryUUID(formats); err != nil {

--- a/pkg/generated/restapi/operations/entries/search_log_query.go
+++ b/pkg/generated/restapi/operations/entries/search_log_query.go
@@ -46,7 +46,7 @@ func NewSearchLogQuery(ctx *middleware.Context, handler SearchLogQueryHandler) *
 	return &SearchLogQuery{Context: ctx, Handler: handler}
 }
 
-/*SearchLogQuery swagger:route POST /api/v1/log/entries/retrieve entries searchLogQuery
+/* SearchLogQuery swagger:route POST /api/v1/log/entries/retrieve entries searchLogQuery
 
 Searches transparency log for one or more log entries
 
@@ -59,17 +59,15 @@ type SearchLogQuery struct {
 func (o *SearchLogQuery) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewSearchLogQueryParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/pkg/generated/restapi/operations/entries/search_log_query_parameters.go
+++ b/pkg/generated/restapi/operations/entries/search_log_query_parameters.go
@@ -23,18 +23,21 @@ package entries
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"io"
 	"net/http"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/validate"
 
 	"github.com/sigstore/rekor/pkg/generated/models"
 )
 
 // NewSearchLogQueryParams creates a new SearchLogQueryParams object
-// no default values defined in spec.
+//
+// There are no default values defined in the spec.
 func NewSearchLogQueryParams() SearchLogQueryParams {
 
 	return SearchLogQueryParams{}
@@ -77,6 +80,11 @@ func (o *SearchLogQueryParams) BindRequest(r *http.Request, route *middleware.Ma
 		} else {
 			// validate body object
 			if err := body.Validate(route.Formats); err != nil {
+				res = append(res, err)
+			}
+
+			ctx := validate.WithOperationRequest(context.Background())
+			if err := body.ContextValidate(ctx, route.Formats); err != nil {
 				res = append(res, err)
 			}
 

--- a/pkg/generated/restapi/operations/index/search_index.go
+++ b/pkg/generated/restapi/operations/index/search_index.go
@@ -46,7 +46,7 @@ func NewSearchIndex(ctx *middleware.Context, handler SearchIndexHandler) *Search
 	return &SearchIndex{Context: ctx, Handler: handler}
 }
 
-/*SearchIndex swagger:route POST /api/v1/index/retrieve index searchIndex
+/* SearchIndex swagger:route POST /api/v1/index/retrieve index searchIndex
 
 Searches index by entry metadata
 
@@ -59,17 +59,15 @@ type SearchIndex struct {
 func (o *SearchIndex) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewSearchIndexParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/pkg/generated/restapi/operations/index/search_index_parameters.go
+++ b/pkg/generated/restapi/operations/index/search_index_parameters.go
@@ -23,18 +23,21 @@ package index
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"io"
 	"net/http"
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/validate"
 
 	"github.com/sigstore/rekor/pkg/generated/models"
 )
 
 // NewSearchIndexParams creates a new SearchIndexParams object
-// no default values defined in spec.
+//
+// There are no default values defined in the spec.
 func NewSearchIndexParams() SearchIndexParams {
 
 	return SearchIndexParams{}
@@ -77,6 +80,11 @@ func (o *SearchIndexParams) BindRequest(r *http.Request, route *middleware.Match
 		} else {
 			// validate body object
 			if err := body.Validate(route.Formats); err != nil {
+				res = append(res, err)
+			}
+
+			ctx := validate.WithOperationRequest(context.Background())
+			if err := body.ContextValidate(ctx, route.Formats); err != nil {
 				res = append(res, err)
 			}
 

--- a/pkg/generated/restapi/operations/rekor_server_api.go
+++ b/pkg/generated/restapi/operations/rekor_server_api.go
@@ -116,9 +116,11 @@ type RekorServerAPI struct {
 	// BasicAuthenticator generates a runtime.Authenticator from the supplied basic auth function.
 	// It has a default implementation in the security package, however you can replace it for your particular usage.
 	BasicAuthenticator func(security.UserPassAuthentication) runtime.Authenticator
+
 	// APIKeyAuthenticator generates a runtime.Authenticator from the supplied token auth function.
 	// It has a default implementation in the security package, however you can replace it for your particular usage.
 	APIKeyAuthenticator func(string, string, security.TokenAuthentication) runtime.Authenticator
+
 	// BearerAuthenticator generates a runtime.Authenticator from the supplied bearer token auth function.
 	// It has a default implementation in the security package, however you can replace it for your particular usage.
 	BearerAuthenticator func(string, security.ScopedTokenAuthentication) runtime.Authenticator
@@ -158,6 +160,7 @@ type RekorServerAPI struct {
 	IndexSearchIndexHandler index.SearchIndexHandler
 	// EntriesSearchLogQueryHandler sets the operation handler for the search log query operation
 	EntriesSearchLogQueryHandler entries.SearchLogQueryHandler
+
 	// ServeError is called when an error is received, there is a default handler
 	// but you can set your own with this
 	ServeError func(http.ResponseWriter, *http.Request, error)

--- a/pkg/generated/restapi/operations/tlog/get_log_info.go
+++ b/pkg/generated/restapi/operations/tlog/get_log_info.go
@@ -46,7 +46,7 @@ func NewGetLogInfo(ctx *middleware.Context, handler GetLogInfoHandler) *GetLogIn
 	return &GetLogInfo{Context: ctx, Handler: handler}
 }
 
-/*GetLogInfo swagger:route GET /api/v1/log tlog getLogInfo
+/* GetLogInfo swagger:route GET /api/v1/log tlog getLogInfo
 
 Get information about the current state of the transparency log
 
@@ -61,17 +61,15 @@ type GetLogInfo struct {
 func (o *GetLogInfo) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetLogInfoParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/pkg/generated/restapi/operations/tlog/get_log_info_parameters.go
+++ b/pkg/generated/restapi/operations/tlog/get_log_info_parameters.go
@@ -30,7 +30,8 @@ import (
 )
 
 // NewGetLogInfoParams creates a new GetLogInfoParams object
-// no default values defined in spec.
+//
+// There are no default values defined in the spec.
 func NewGetLogInfoParams() GetLogInfoParams {
 
 	return GetLogInfoParams{}

--- a/pkg/generated/restapi/operations/tlog/get_log_proof.go
+++ b/pkg/generated/restapi/operations/tlog/get_log_proof.go
@@ -46,7 +46,7 @@ func NewGetLogProof(ctx *middleware.Context, handler GetLogProofHandler) *GetLog
 	return &GetLogProof{Context: ctx, Handler: handler}
 }
 
-/*GetLogProof swagger:route GET /api/v1/log/proof tlog getLogProof
+/* GetLogProof swagger:route GET /api/v1/log/proof tlog getLogProof
 
 Get information required to generate a consistency proof for the transparency log
 
@@ -61,17 +61,15 @@ type GetLogProof struct {
 func (o *GetLogProof) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetLogProofParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/pkg/generated/restapi/operations/tlog/get_log_proof_parameters.go
+++ b/pkg/generated/restapi/operations/tlog/get_log_proof_parameters.go
@@ -92,7 +92,6 @@ func (o *GetLogProofParams) BindRequest(r *http.Request, route *middleware.Match
 	if err := o.bindLastSize(qLastSize, qhkLastSize, route.Formats); err != nil {
 		res = append(res, err)
 	}
-
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -108,6 +107,7 @@ func (o *GetLogProofParams) bindFirstSize(rawData []string, hasKey bool, formats
 
 	// Required: false
 	// AllowEmptyValue: false
+
 	if raw == "" { // empty values pass all other validations
 		// Default values have been previously initialized by NewGetLogProofParams()
 		return nil
@@ -129,7 +129,7 @@ func (o *GetLogProofParams) bindFirstSize(rawData []string, hasKey bool, formats
 // validateFirstSize carries on validations for parameter FirstSize
 func (o *GetLogProofParams) validateFirstSize(formats strfmt.Registry) error {
 
-	if err := validate.MinimumInt("firstSize", "query", int64(*o.FirstSize), 1, false); err != nil {
+	if err := validate.MinimumInt("firstSize", "query", *o.FirstSize, 1, false); err != nil {
 		return err
 	}
 
@@ -148,6 +148,7 @@ func (o *GetLogProofParams) bindLastSize(rawData []string, hasKey bool, formats 
 
 	// Required: true
 	// AllowEmptyValue: false
+
 	if err := validate.RequiredString("lastSize", "query", raw); err != nil {
 		return err
 	}
@@ -168,7 +169,7 @@ func (o *GetLogProofParams) bindLastSize(rawData []string, hasKey bool, formats 
 // validateLastSize carries on validations for parameter LastSize
 func (o *GetLogProofParams) validateLastSize(formats strfmt.Registry) error {
 
-	if err := validate.MinimumInt("lastSize", "query", int64(o.LastSize), 1, false); err != nil {
+	if err := validate.MinimumInt("lastSize", "query", o.LastSize, 1, false); err != nil {
 		return err
 	}
 

--- a/pkg/generated/restapi/operations/tlog/get_public_key.go
+++ b/pkg/generated/restapi/operations/tlog/get_public_key.go
@@ -46,7 +46,7 @@ func NewGetPublicKey(ctx *middleware.Context, handler GetPublicKeyHandler) *GetP
 	return &GetPublicKey{Context: ctx, Handler: handler}
 }
 
-/*GetPublicKey swagger:route GET /api/v1/log/publicKey tlog getPublicKey
+/* GetPublicKey swagger:route GET /api/v1/log/publicKey tlog getPublicKey
 
 Retrieve the public key that can be used to validate the signed tree head
 
@@ -61,17 +61,15 @@ type GetPublicKey struct {
 func (o *GetPublicKey) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	route, rCtx, _ := o.Context.RouteInfo(r)
 	if rCtx != nil {
-		r = rCtx
+		*r = *rCtx
 	}
 	var Params = NewGetPublicKeyParams()
-
 	if err := o.Context.BindValidRequest(r, route, &Params); err != nil { // bind params
 		o.Context.Respond(rw, r, route.Produces, route, err)
 		return
 	}
 
 	res := o.Handler.Handle(Params) // actually handle the request
-
 	o.Context.Respond(rw, r, route.Produces, route, res)
 
 }

--- a/pkg/generated/restapi/operations/tlog/get_public_key_parameters.go
+++ b/pkg/generated/restapi/operations/tlog/get_public_key_parameters.go
@@ -30,7 +30,8 @@ import (
 )
 
 // NewGetPublicKeyParams creates a new GetPublicKeyParams object
-// no default values defined in spec.
+//
+// There are no default values defined in the spec.
 func NewGetPublicKeyParams() GetPublicKeyParams {
 
 	return GetPublicKeyParams{}


### PR DESCRIPTION
we should make sure that rekor & fulcio stay in sync if at all possible on swagger versions; bumping to v0.27.0 since v0.26.1 has https://github.com/go-swagger/go-swagger/issues/2544 which affects Rekor's codebase.

Also sets GOVERSION from Dockerfile rather than having a separate variable in GitHub actions definition.

Signed-off-by: Bob Callaway <bob.callaway@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
