### PR TITLE
Add security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,14 @@ These entries contain the tree length, tree root hash as well as the timestamp.
 The (signed) timestamp and index of a (signed) tree hash may be used as an attestation that any entries in the log
 prior to this index were witnessed by Rekor before this time.
 
-## Extensibility 
+## Extensibility
 
 Rekor allows customized manifests (which term them as types), [type customization is outlined here](https://github.com/sigstore/rekor/tree/main/pkg/types).
+
+## Security
+
+Should you discover any security issues, please refer to sigstores [security
+process](https://github.com/sigstore/community/blob/main/SECURITY.md)
 
 ## Contributions
 


### PR DESCRIPTION
I will perform a 'lazy consensus' and self-merge this if not
approved by 07/05/2021

The idea is to point to one file in community where we can
add to the security handling process without updating all repos.

Signed-off-by: Luke Hinds <lhinds@redhat.com>
