### PR TITLE
add version commands

### DIFF
--- a/cmd/rekor-cli/app/version.go
+++ b/cmd/rekor-cli/app/version.go
@@ -1,0 +1,38 @@
+/*
+Copyright © 2021 The Rekor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package app
+
+import (
+	"fmt"
+
+	"github.com/sigstore/rekor/internal/version"
+
+	"github.com/spf13/cobra"
+)
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version information",
+	Long:  `Print rekor client version information`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(version.BuildString())
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/cmd/rekor-server/app/version.go
+++ b/cmd/rekor-server/app/version.go
@@ -1,0 +1,38 @@
+/*
+Copyright © 2021 The Rekor Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package app
+
+import (
+	"fmt"
+
+	"github.com/sigstore/rekor/internal/version"
+
+	"github.com/spf13/cobra"
+)
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version information",
+	Long:  `Print rekor server version information`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(version.BuildString())
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,25 @@
+package version
+
+import (
+	"fmt"
+)
+
+var (
+	version = "main"
+	commit  = "unknown"
+)
+
+// BuildString returns full version information.
+func BuildString() string {
+	return fmt.Sprintf("%s (from commit %s)", version, commit)
+}
+
+// Commit return current commit value.
+func Commit() string {
+	return commit
+}
+
+// Version return current version value.
+func Version() string {
+	return version
+}


### PR DESCRIPTION

Implement version command for `rekor-cli` and `rekor-server`. Close #212.

I'm submitting this PR as a Draft, to present a solution for feedback.

The `version` package contains hard-coded version string; is then imported in `rekor-cli` and `rekor-server`, and the hard coded string is replaced at build time using the `-X` `ldflags` option.

I'm using `internal` to conform to https://github.com/golang-standards/project-layout#internal, as the `version` package is not expected to be used externally.

The version format is `<version> (from commit <commit hash>[-dirty])`.

- `<version>` defaults to `main` and is by default overridden by the current branch name. It can be overridden manually by setting `VERSION` environment variable.  
- `<commit hash>` is the hash of the last commit in the git history the build is being run from.  
- `[-dirty]` is added if the current folder is in a dirty state (based on `git status --porcelain`).

The result (taken from this branch) is:

```
$ ./rekor-cli version 
add-version-subcommand (from commit 856f681-dirty)

$ ./rekor-server version                                                                                                                                             
add-version-subcommand (from commit 856f681-dirty)
```

This version number allows to distribute any built binary from any branch with relevant information for testing.

Feedback welcome!