### PR TITLE
Drop signature verification in rekor server.

### DIFF
--- a/cmd/rekor-server/app/watch.go
+++ b/cmd/rekor-server/app/watch.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/google/trillian"
 	tclient "github.com/google/trillian/client"
-	tcrypto "github.com/google/trillian/crypto"
 	"github.com/google/trillian/merkle/rfc6962/hasher"
 	"github.com/google/trillian/types"
 
@@ -158,8 +157,9 @@ func doCheck(c *client.Rekor, v *tclient.LogVerifier) (*SignedAndUnsignedLogRoot
 		LogRoot:          logRoot,
 		LogRootSignature: signature,
 	}
-	lr, err := tcrypto.VerifySignedLogRoot(v.PubKey, v.SigHash, &sth)
-	if err != nil {
+
+	lr := &types.LogRootV1{}
+	if err := lr.UnmarshalBinary(sth.LogRoot); err != nil {
 		return nil, err
 	}
 	return &SignedAndUnsignedLogRoot{

--- a/pkg/api/tlog.go
+++ b/pkg/api/tlog.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
-	tcrypto "github.com/google/trillian/crypto"
+	"github.com/google/trillian/types"
 	"github.com/sigstore/rekor/pkg/generated/restapi/operations/tlog"
 )
 
@@ -41,9 +41,8 @@ func GetLogInfoHandler(params tlog.GetLogInfoParams) middleware.Responder {
 	}
 	result := resp.getLatestResult
 
-	// validate result is signed with the key we're aware of
-	root, err := tcrypto.VerifySignedLogRoot(tc.verifier.PubKey, tc.verifier.SigHash, result.SignedLogRoot)
-	if err != nil {
+	root := &types.LogRootV1{}
+	if err := root.UnmarshalBinary(result.SignedLogRoot.LogRoot); err != nil {
 		return handleRekorAPIError(params, http.StatusInternalServerError, err, trillianUnexpectedResult)
 	}
 
@@ -80,9 +79,8 @@ func GetLogProofHandler(params tlog.GetLogProofParams) middleware.Responder {
 	}
 	result := resp.getConsistencyProofResult
 
-	// validate result is signed with the key we're aware of
-	root, err := tcrypto.VerifySignedLogRoot(tc.verifier.PubKey, tc.verifier.SigHash, result.SignedLogRoot)
-	if err != nil {
+	var root types.LogRootV1
+	if err := root.UnmarshalBinary(result.SignedLogRoot.LogRoot); err != nil {
 		return handleRekorAPIError(params, http.StatusInternalServerError, err, trillianUnexpectedResult)
 	}
 


### PR DESCRIPTION
This is changing as part of the general trillian signature changes.
The trust model is still client -> database, our server trusts our
database so we can pass signed messages on directly to users without
double verification.

Signed-off-by: Dan Lorenc <dlorenc@google.com>
