### PR TITLE
[api] Add max 32 mb on content data

### DIFF
--- a/pkg/generated/models/rekord_v001_schema.go
+++ b/pkg/generated/models/rekord_v001_schema.go
@@ -175,6 +175,7 @@ func (m *RekordV001Schema) UnmarshalBinary(b []byte) error {
 type RekordV001SchemaData struct {
 
 	// Specifies the content inline within the document
+	// Max Length: 32000000
 	// Format: byte
 	Content strfmt.Base64 `json:"content,omitempty"`
 
@@ -190,6 +191,10 @@ type RekordV001SchemaData struct {
 func (m *RekordV001SchemaData) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateContent(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateHash(formats); err != nil {
 		res = append(res, err)
 	}
@@ -201,6 +206,18 @@ func (m *RekordV001SchemaData) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *RekordV001SchemaData) validateContent(formats strfmt.Registry) error {
+	if swag.IsZero(m.Content) { // not required
+		return nil
+	}
+
+	if err := validate.MaxLength("data"+"."+"content", "body", m.Content.String(), 32000000); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/generated/models/rpm_v001_schema.go
+++ b/pkg/generated/models/rpm_v001_schema.go
@@ -175,6 +175,7 @@ func (m *RpmV001Schema) UnmarshalBinary(b []byte) error {
 type RpmV001SchemaPackage struct {
 
 	// Specifies the package inline within the document
+	// Max Length: 32000000
 	// Format: byte
 	Content strfmt.Base64 `json:"content,omitempty"`
 
@@ -193,6 +194,10 @@ type RpmV001SchemaPackage struct {
 func (m *RpmV001SchemaPackage) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateContent(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateHash(formats); err != nil {
 		res = append(res, err)
 	}
@@ -204,6 +209,18 @@ func (m *RpmV001SchemaPackage) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *RpmV001SchemaPackage) validateContent(formats strfmt.Registry) error {
+	if swag.IsZero(m.Content) { // not required
+		return nil
+	}
+
+	if err := validate.MaxLength("package"+"."+"content", "body", m.Content.String(), 32000000); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/generated/restapi/embedded_spec.go
+++ b/pkg/generated/restapi/embedded_spec.go
@@ -1164,7 +1164,8 @@ func init() {
         "content": {
           "description": "Specifies the content inline within the document",
           "type": "string",
-          "format": "byte"
+          "format": "byte",
+          "maxLength": 32000000
         },
         "hash": {
           "description": "Specifies the hash algorithm and value for the content",
@@ -1332,7 +1333,8 @@ func init() {
         "content": {
           "description": "Specifies the package inline within the document",
           "type": "string",
-          "format": "byte"
+          "format": "byte",
+          "maxLength": 32000000
         },
         "hash": {
           "description": "Specifies the hash algorithm and value for the package",
@@ -1568,7 +1570,8 @@ func init() {
             "content": {
               "description": "Specifies the content inline within the document",
               "type": "string",
-              "format": "byte"
+              "format": "byte",
+              "maxLength": 32000000
             },
             "hash": {
               "description": "Specifies the hash algorithm and value for the content",
@@ -1747,7 +1750,8 @@ func init() {
             "content": {
               "description": "Specifies the package inline within the document",
               "type": "string",
-              "format": "byte"
+              "format": "byte",
+              "maxLength": 32000000
             },
             "hash": {
               "description": "Specifies the hash algorithm and value for the package",

--- a/pkg/types/rekord/v0.0.1/rekord_v0_0_1_schema.json
+++ b/pkg/types/rekord/v0.0.1/rekord_v0_0_1_schema.json
@@ -86,7 +86,8 @@
                 "content": {
                     "description": "Specifies the content inline within the document",
                     "type": "string",
-                    "format": "byte"
+                    "format": "byte",
+                    "maxLength" : 32000000
                 }
             },
             "oneOf": [

--- a/pkg/types/rpm/v0.0.1/rpm_v0_0_1_schema.json
+++ b/pkg/types/rpm/v0.0.1/rpm_v0_0_1_schema.json
@@ -64,7 +64,8 @@
                 "content": {
                     "description": "Specifies the package inline within the document",
                     "type": "string",
-                    "format": "byte"
+                    "format": "byte",
+                    "maxLength" : 32000000
                 }
             },
             "oneOf": [


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Fixes https://github.com/sigstore/rekor/issues/220
Adds a max of 32 MB to content data to avoid hitting ingress max size.

Not sure I particularly like this since the error is sorta opaque, but at the same time it's defined in the schema. Otherwise, I can add to `Validate` for each type and return a more verbose error message on expected/actual size.
