### PR TITLE
Add sha256 prefix to index keys for artifact hashes

### DIFF
--- a/cmd/rekor-cli/app/search.go
+++ b/cmd/rekor-cli/app/search.go
@@ -116,7 +116,7 @@ var searchCmd = &cobra.Command{
 			}
 
 			hashVal := strings.ToLower(hex.EncodeToString(hasher.Sum(nil)))
-			params.Query.Hash = hashVal
+			params.Query.Hash = "sha256:" + hashVal
 		}
 
 		publicKeyStr := viper.GetString("public-key")

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -338,7 +338,7 @@ definitions:
           - "format"
       hash:
         type: string
-        pattern: '^[0-9a-fA-F]{64}$'
+        pattern: '^(sha256:)?[0-9a-fA-F]{64}$'
 
   SearchLogQuery:
     type: object

--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -296,12 +296,14 @@ func SearchLogQueryHandler(params entries.SearchLogQueryParams) middleware.Respo
 		}
 
 		for _, leafResp := range searchByHashResults {
-			logEntry, err := logEntryFromLeaf(tc, leafResp.Leaf, leafResp.SignedLogRoot, leafResp.Proof)
-			if err != nil {
-				return handleRekorAPIError(params, code, err, err.Error())
-			}
+			if leafResp != nil {
+				logEntry, err := logEntryFromLeaf(tc, leafResp.Leaf, leafResp.SignedLogRoot, leafResp.Proof)
+				if err != nil {
+					return handleRekorAPIError(params, code, err, err.Error())
+				}
 
-			resultPayload = append(resultPayload, logEntry)
+				resultPayload = append(resultPayload, logEntry)
+			}
 		}
 	}
 

--- a/pkg/generated/models/search_index.go
+++ b/pkg/generated/models/search_index.go
@@ -41,7 +41,7 @@ type SearchIndex struct {
 	Email strfmt.Email `json:"email,omitempty"`
 
 	// hash
-	// Pattern: ^[0-9a-fA-F]{64}$
+	// Pattern: ^(sha256:)?[0-9a-fA-F]{64}$
 	Hash string `json:"hash,omitempty"`
 
 	// public key
@@ -87,7 +87,7 @@ func (m *SearchIndex) validateHash(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.Pattern("hash", "body", m.Hash, `^[0-9a-fA-F]{64}$`); err != nil {
+	if err := validate.Pattern("hash", "body", m.Hash, `^(sha256:)?[0-9a-fA-F]{64}$`); err != nil {
 		return err
 	}
 

--- a/pkg/generated/restapi/embedded_spec.go
+++ b/pkg/generated/restapi/embedded_spec.go
@@ -497,7 +497,7 @@ func init() {
         },
         "hash": {
           "type": "string",
-          "pattern": "^[0-9a-fA-F]{64}$"
+          "pattern": "^(sha256:)?[0-9a-fA-F]{64}$"
         },
         "publicKey": {
           "type": "object",
@@ -1602,7 +1602,7 @@ func init() {
         },
         "hash": {
           "type": "string",
-          "pattern": "^[0-9a-fA-F]{64}$"
+          "pattern": "^(sha256:)?[0-9a-fA-F]{64}$"
         },
         "publicKey": {
           "type": "object",

--- a/pkg/types/jar/v0.0.1/entry.go
+++ b/pkg/types/jar/v0.0.1/entry.go
@@ -93,7 +93,8 @@ func (v V001Entry) IndexKeys() []string {
 	}
 
 	if v.JARModel.Archive.Hash != nil {
-		result = append(result, strings.ToLower(swag.StringValue(v.JARModel.Archive.Hash.Value)))
+		hashKey := strings.ToLower(fmt.Sprintf("%s:%s", *v.JARModel.Archive.Hash.Algorithm, *v.JARModel.Archive.Hash.Value))
+		result = append(result, hashKey)
 	}
 
 	return result

--- a/pkg/types/rekord/v0.0.1/entry.go
+++ b/pkg/types/rekord/v0.0.1/entry.go
@@ -88,7 +88,8 @@ func (v V001Entry) IndexKeys() []string {
 	result = append(result, v.keyObj.EmailAddresses()...)
 
 	if v.RekordObj.Data.Hash != nil {
-		result = append(result, strings.ToLower(swag.StringValue(v.RekordObj.Data.Hash.Value)))
+		hashKey := strings.ToLower(fmt.Sprintf("%s:%s", *v.RekordObj.Data.Hash.Algorithm, *v.RekordObj.Data.Hash.Value))
+		result = append(result, hashKey)
 	}
 
 	return result

--- a/pkg/types/rpm/v0.0.1/entry.go
+++ b/pkg/types/rpm/v0.0.1/entry.go
@@ -92,7 +92,8 @@ func (v V001Entry) IndexKeys() []string {
 	result = append(result, v.keyObj.EmailAddresses()...)
 
 	if v.RPMModel.Package.Hash != nil {
-		result = append(result, strings.ToLower(swag.StringValue(v.RPMModel.Package.Hash.Value)))
+		hashKey := strings.ToLower(fmt.Sprintf("%s:%s", *v.RPMModel.Package.Hash.Algorithm, *v.RPMModel.Package.Hash.Value))
+		result = append(result, hashKey)
 	}
 
 	return result

--- a/tests/e2e-test.sh
+++ b/tests/e2e-test.sh
@@ -45,3 +45,4 @@ TMPDIR="$(mktemp -d -t rekor_test.XXXXXX)"
 touch $TMPDIR.rekor.yaml
 trap "rm -rf $TMPDIR" EXIT
 TMPDIR=$TMPDIR go test -tags=e2e ./tests/
+docker-compose logs --no-color | grep -q "panic: runtime error:" && echo "Failing due to panics detected in logs" && docker-compose logs --no-color && exit 1

--- a/tests/e2e-test.sh
+++ b/tests/e2e-test.sh
@@ -45,4 +45,9 @@ TMPDIR="$(mktemp -d -t rekor_test.XXXXXX)"
 touch $TMPDIR.rekor.yaml
 trap "rm -rf $TMPDIR" EXIT
 TMPDIR=$TMPDIR go test -tags=e2e ./tests/
-docker-compose logs --no-color | grep -q "panic: runtime error:" && echo "Failing due to panics detected in logs" && docker-compose logs --no-color && exit 1
+if docker-compose logs --no-color | grep -q "panic: runtime error:" ; then
+   # if we're here, we found a panic
+   echo "Failing due to panics detected in logs"
+   docker-compose logs --no-color
+   exit 1
+fi

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -21,7 +21,9 @@ import (
 	"context"
 	"crypto"
 	"crypto/ecdsa"
+	"crypto/sha256"
 	"crypto/x509"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
@@ -186,6 +188,17 @@ func TestGet(t *testing.T) {
 	outputContains(t, out, uuid)
 
 	out = runCli(t, "search", "--public-key", pubPath)
+	outputContains(t, out, uuid)
+
+	hash := sha256.New()
+	artifactBytes, err := ioutil.ReadFile(artifactPath)
+	if err != nil {
+		t.Error(err)
+	}
+	hash.Write(artifactBytes)
+	sha := hash.Sum(nil)
+
+	out = runCli(t, "search", "--sha", fmt.Sprintf("sha256:%s", hex.EncodeToString(sha)))
 	outputContains(t, out, uuid)
 }
 


### PR DESCRIPTION
This change adds the `sha256:` prefix to index values that are created
to simplify searching the transparency log for artifacts. In case we
shift to using a different hashing algorithm in the future, this will
provide a way to specify it.

Fixes #289

Signed-off-by: Bob Callaway <bob.callaway@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
