### PR TITLE
Add signedEntryTimestamp to LogEntry for offline verification

### DIFF
--- a/cmd/rekor-cli/app/verify.go
+++ b/cmd/rekor-cli/app/verify.go
@@ -140,11 +140,11 @@ var verifyCmd = &cobra.Command{
 		var o *verifyCmdOutput
 		for k, v := range logEntry {
 			o = &verifyCmdOutput{
-				RootHash:  *v.InclusionProof.RootHash,
+				RootHash:  *v.Verification.InclusionProof.RootHash,
 				EntryUUID: k,
 				Index:     *v.LogIndex,
-				Size:      *v.InclusionProof.TreeSize,
-				Hashes:    v.InclusionProof.Hashes,
+				Size:      *v.Verification.InclusionProof.TreeSize,
+				Hashes:    v.Verification.InclusionProof.Hashes,
 			}
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cavaliercoder/go-rpm v0.0.0-20200122174316-8cb9fd9c31a8
+	github.com/cyberphone/json-canonicalization v0.0.0-20210303052042-6bc126869bf4 // indirect
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/go-openapi/errors v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -234,6 +234,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/cyberphone/json-canonicalization v0.0.0-20210303052042-6bc126869bf4 h1:7AjYfmq7AmviXsuZjV5DcE7PuhJ4dWMi8gLllpLVDQY=
+github.com/cyberphone/json-canonicalization v0.0.0-20210303052042-6bc126869bf4/go.mod h1:uzvlm1mxhHkdfqitSA92i7Se+S9ksOn3a3qmv/kyOCw=
 github.com/danieljoos/wincred v1.1.0 h1:3RNcEpBg4IhIChZdFRSdlQt1QjCp1sMAPIrOnm7Yf8g=
 github.com/danieljoos/wincred v1.1.0/go.mod h1:XYlo+eRTsVA9aHGp7NGjFkPla4m+DCL7hqDjlFjiygg=
 github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -299,12 +299,15 @@ definitions:
           additionalProperties: true
         integratedTime:
           type: integer
-        inclusionProof:
-          $ref: '#/definitions/InclusionProof'
-        signature:
-          type: string
-          format: byte
-          description: signature over the log entry (acts as an inclusion promise if inclusion proof is not included)
+        verification:
+          type: object
+          properties:
+            inclusionProof:
+              $ref: '#/definitions/InclusionProof'
+            signedEntryTimestamp:
+              type: string
+              format: byte
+              description: signature over the logIndex, body and integratedTime
       required:
         - "logIndex"
         - "body"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -308,10 +308,9 @@ definitions:
               type: string
               format: byte
               # To verify the signedEntryTimestamp:
-                # 1. Set LogEntry.Verification = nil
-                # 2. Get the payload by running LogEntry.MarshalBinary()
-                # 3. Canonicalize the payload by running jsoncanonicalizer.Transform(payload)
-                # 4. Verify the canonicalized payload and signedEntryTimestamp against rekor's public key
+                # 1. Remove the Verification object from the JSON Document
+                # 2. Canonicalize the remaining JSON document by following RFC 8785 rules
+                # 3. Verify the canonicalized payload and signedEntryTimestamp against rekor's public key
               description: Signature over the logIndex, body and integratedTime. 
       required:
         - "logIndex"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -307,7 +307,12 @@ definitions:
             signedEntryTimestamp:
               type: string
               format: byte
-              description: signature over the logIndex, body and integratedTime
+              # To verify the signedEntryTimestamp:
+                # 1. Set LogEntry.Verification = nil
+                # 2. Get the payload by running LogEntry.MarshalBinary()
+                # 3. Canonicalize the payload by running jsoncanonicalizer.Transform(payload)
+                # 4. Verify the canonicalized payload and signedEntryTimestamp against rekor's public key
+              description: Signature over the logIndex, body and integratedTime. 
       required:
         - "logIndex"
         - "body"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -301,6 +301,10 @@ definitions:
           type: integer
         inclusionProof:
           $ref: '#/definitions/InclusionProof'
+        signature:
+          type: string
+          format: byte
+          description: signature over the log entry (acts as an inclusion promise if inclusion proof is not included)
       required:
         - "logIndex"
         - "body"

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -62,7 +62,7 @@ func NewAPI() (*API, error) {
 	ctx := context.Background()
 	tConn, err := dial(ctx, logRPCServer)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "dial")
 	}
 	logAdminClient := trillian.NewTrillianAdminClient(tConn)
 	logClient := trillian.NewTrillianLogClient(tConn)
@@ -71,7 +71,7 @@ func NewAPI() (*API, error) {
 	if tLogID == 0 {
 		t, err := createAndInitTree(ctx, logAdminClient, logClient)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "create and init tree")
 		}
 		tLogID = t.TreeId
 	}
@@ -80,7 +80,7 @@ func NewAPI() (*API, error) {
 		TreeId: tLogID,
 	})
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "get tree")
 	}
 
 	signer, err := signer.New(ctx, viper.GetString("rekor_server.signer"))
@@ -102,7 +102,7 @@ func NewAPI() (*API, error) {
 
 	verifier, err := client.NewLogVerifierFromTree(t)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "new verifier")
 	}
 
 	return &API{
@@ -124,6 +124,7 @@ func ConfigureAPI() {
 	var err error
 	api, err = NewAPI()
 	if err != nil {
+		fmt.Println(err)
 		log.Logger.Panic(err)
 	}
 	if viper.GetBool("enable_retrieve_api") {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -124,7 +124,6 @@ func ConfigureAPI() {
 	var err error
 	api, err = NewAPI()
 	if err != nil {
-		fmt.Println(err)
 		log.Logger.Panic(err)
 	}
 	if viper.GetBool("enable_retrieve_api") {

--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -42,6 +42,7 @@ const (
 	failedToGenerateCanonicalKey   = "Error generating canonicalized public key"
 	redisUnexpectedResult          = "Unexpected result from searching index"
 	lastSizeGreaterThanKnown       = "The tree size requested(%d) was greater than what is currently observable(%d)"
+	signingError                   = "Error signing"
 )
 
 func errorMsg(message string, code int) *models.Error {

--- a/pkg/api/trillian_client.go
+++ b/pkg/api/trillian_client.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/google/trillian/merkle/logverifier"
 	"github.com/google/trillian/merkle/rfc6962/hasher"
+	"github.com/pkg/errors"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -311,7 +312,7 @@ func createAndInitTree(ctx context.Context, adminClient trillian.TrillianAdminCl
 	// First look for and use an existing tree
 	trees, err := adminClient.ListTrees(ctx, &trillian.ListTreesRequest{})
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "list trees")
 	}
 
 	for _, t := range trees.Tree {
@@ -336,11 +337,11 @@ func createAndInitTree(ctx context.Context, adminClient trillian.TrillianAdminCl
 		},
 	})
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "create tree")
 	}
 
 	if err := client.InitLog(ctx, t, logClient); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "init log")
 	}
 	return t, nil
 }

--- a/pkg/generated/models/log_entry.go
+++ b/pkg/generated/models/log_entry.go
@@ -97,6 +97,10 @@ type LogEntryAnon struct {
 	// Required: true
 	// Minimum: 0
 	LogIndex *int64 `json:"logIndex"`
+
+	// signature over the log entry (acts as an inclusion promise if inclusion proof is not included)
+	// Format: byte
+	Signature strfmt.Base64 `json:"signature,omitempty"`
 }
 
 // Validate validates this log entry anon

--- a/pkg/generated/models/log_entry.go
+++ b/pkg/generated/models/log_entry.go
@@ -214,7 +214,7 @@ type LogEntryAnonVerification struct {
 	// inclusion proof
 	InclusionProof *InclusionProof `json:"inclusionProof,omitempty"`
 
-	// signature over the logIndex, body and integratedTime
+	// Signature over the logIndex, body and integratedTime.
 	// Format: byte
 	SignedEntryTimestamp strfmt.Base64 `json:"signedEntryTimestamp,omitempty"`
 }

--- a/pkg/generated/models/log_entry.go
+++ b/pkg/generated/models/log_entry.go
@@ -87,9 +87,6 @@ type LogEntryAnon struct {
 	// Required: true
 	Body interface{} `json:"body"`
 
-	// inclusion proof
-	InclusionProof *InclusionProof `json:"inclusionProof,omitempty"`
-
 	// integrated time
 	IntegratedTime int64 `json:"integratedTime,omitempty"`
 
@@ -98,9 +95,8 @@ type LogEntryAnon struct {
 	// Minimum: 0
 	LogIndex *int64 `json:"logIndex"`
 
-	// signature over the log entry (acts as an inclusion promise if inclusion proof is not included)
-	// Format: byte
-	Signature strfmt.Base64 `json:"signature,omitempty"`
+	// verification
+	Verification *LogEntryAnonVerification `json:"verification,omitempty"`
 }
 
 // Validate validates this log entry anon
@@ -111,11 +107,11 @@ func (m *LogEntryAnon) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateInclusionProof(formats); err != nil {
+	if err := m.validateLogIndex(formats); err != nil {
 		res = append(res, err)
 	}
 
-	if err := m.validateLogIndex(formats); err != nil {
+	if err := m.validateVerification(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -134,23 +130,6 @@ func (m *LogEntryAnon) validateBody(formats strfmt.Registry) error {
 	return nil
 }
 
-func (m *LogEntryAnon) validateInclusionProof(formats strfmt.Registry) error {
-	if swag.IsZero(m.InclusionProof) { // not required
-		return nil
-	}
-
-	if m.InclusionProof != nil {
-		if err := m.InclusionProof.Validate(formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("inclusionProof")
-			}
-			return err
-		}
-	}
-
-	return nil
-}
-
 func (m *LogEntryAnon) validateLogIndex(formats strfmt.Registry) error {
 
 	if err := validate.Required("logIndex", "body", m.LogIndex); err != nil {
@@ -164,11 +143,28 @@ func (m *LogEntryAnon) validateLogIndex(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *LogEntryAnon) validateVerification(formats strfmt.Registry) error {
+	if swag.IsZero(m.Verification) { // not required
+		return nil
+	}
+
+	if m.Verification != nil {
+		if err := m.Verification.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("verification")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 // ContextValidate validate this log entry anon based on the context it is used
 func (m *LogEntryAnon) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.contextValidateInclusionProof(ctx, formats); err != nil {
+	if err := m.contextValidateVerification(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -178,12 +174,12 @@ func (m *LogEntryAnon) ContextValidate(ctx context.Context, formats strfmt.Regis
 	return nil
 }
 
-func (m *LogEntryAnon) contextValidateInclusionProof(ctx context.Context, formats strfmt.Registry) error {
+func (m *LogEntryAnon) contextValidateVerification(ctx context.Context, formats strfmt.Registry) error {
 
-	if m.InclusionProof != nil {
-		if err := m.InclusionProof.ContextValidate(ctx, formats); err != nil {
+	if m.Verification != nil {
+		if err := m.Verification.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("inclusionProof")
+				return ve.ValidateName("verification")
 			}
 			return err
 		}
@@ -203,6 +199,96 @@ func (m *LogEntryAnon) MarshalBinary() ([]byte, error) {
 // UnmarshalBinary interface implementation
 func (m *LogEntryAnon) UnmarshalBinary(b []byte) error {
 	var res LogEntryAnon
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*m = res
+	return nil
+}
+
+// LogEntryAnonVerification log entry anon verification
+//
+// swagger:model LogEntryAnonVerification
+type LogEntryAnonVerification struct {
+
+	// inclusion proof
+	InclusionProof *InclusionProof `json:"inclusionProof,omitempty"`
+
+	// signature over the logIndex, body and integratedTime
+	// Format: byte
+	SignedEntryTimestamp strfmt.Base64 `json:"signedEntryTimestamp,omitempty"`
+}
+
+// Validate validates this log entry anon verification
+func (m *LogEntryAnonVerification) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.validateInclusionProof(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *LogEntryAnonVerification) validateInclusionProof(formats strfmt.Registry) error {
+	if swag.IsZero(m.InclusionProof) { // not required
+		return nil
+	}
+
+	if m.InclusionProof != nil {
+		if err := m.InclusionProof.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("verification" + "." + "inclusionProof")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ContextValidate validate this log entry anon verification based on the context it is used
+func (m *LogEntryAnonVerification) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateInclusionProof(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *LogEntryAnonVerification) contextValidateInclusionProof(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.InclusionProof != nil {
+		if err := m.InclusionProof.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("verification" + "." + "inclusionProof")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (m *LogEntryAnonVerification) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation
+func (m *LogEntryAnonVerification) UnmarshalBinary(b []byte) error {
+	var res LogEntryAnonVerification
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}

--- a/pkg/generated/restapi/embedded_spec.go
+++ b/pkg/generated/restapi/embedded_spec.go
@@ -416,6 +416,11 @@ func init() {
           },
           "logIndex": {
             "type": "integer"
+          },
+          "signature": {
+            "description": "signature over the log entry (acts as an inclusion promise if inclusion proof is not included)",
+            "type": "string",
+            "format": "byte"
           }
         }
       }
@@ -1200,6 +1205,11 @@ func init() {
         "logIndex": {
           "type": "integer",
           "minimum": 0
+        },
+        "signature": {
+          "description": "signature over the log entry (acts as an inclusion promise if inclusion proof is not included)",
+          "type": "string",
+          "format": "byte"
         }
       }
     },

--- a/pkg/generated/restapi/embedded_spec.go
+++ b/pkg/generated/restapi/embedded_spec.go
@@ -421,7 +421,7 @@ func init() {
                 "$ref": "#/definitions/InclusionProof"
               },
               "signedEntryTimestamp": {
-                "description": "signature over the logIndex, body and integratedTime",
+                "description": "Signature over the logIndex, body and integratedTime.",
                 "type": "string",
                 "format": "byte"
               }
@@ -1215,7 +1215,7 @@ func init() {
               "$ref": "#/definitions/InclusionProof"
             },
             "signedEntryTimestamp": {
-              "description": "signature over the logIndex, body and integratedTime",
+              "description": "Signature over the logIndex, body and integratedTime.",
               "type": "string",
               "format": "byte"
             }
@@ -1230,7 +1230,7 @@ func init() {
           "$ref": "#/definitions/InclusionProof"
         },
         "signedEntryTimestamp": {
-          "description": "signature over the logIndex, body and integratedTime",
+          "description": "Signature over the logIndex, body and integratedTime.",
           "type": "string",
           "format": "byte"
         }

--- a/pkg/generated/restapi/embedded_spec.go
+++ b/pkg/generated/restapi/embedded_spec.go
@@ -408,19 +408,24 @@ func init() {
             "type": "object",
             "additionalProperties": true
           },
-          "inclusionProof": {
-            "$ref": "#/definitions/InclusionProof"
-          },
           "integratedTime": {
             "type": "integer"
           },
           "logIndex": {
             "type": "integer"
           },
-          "signature": {
-            "description": "signature over the log entry (acts as an inclusion promise if inclusion proof is not included)",
-            "type": "string",
-            "format": "byte"
+          "verification": {
+            "type": "object",
+            "properties": {
+              "inclusionProof": {
+                "$ref": "#/definitions/InclusionProof"
+              },
+              "signedEntryTimestamp": {
+                "description": "signature over the logIndex, body and integratedTime",
+                "type": "string",
+                "format": "byte"
+              }
+            }
           }
         }
       }
@@ -1196,9 +1201,6 @@ func init() {
           "type": "object",
           "additionalProperties": true
         },
-        "inclusionProof": {
-          "$ref": "#/definitions/InclusionProof"
-        },
         "integratedTime": {
           "type": "integer"
         },
@@ -1206,8 +1208,29 @@ func init() {
           "type": "integer",
           "minimum": 0
         },
-        "signature": {
-          "description": "signature over the log entry (acts as an inclusion promise if inclusion proof is not included)",
+        "verification": {
+          "type": "object",
+          "properties": {
+            "inclusionProof": {
+              "$ref": "#/definitions/InclusionProof"
+            },
+            "signedEntryTimestamp": {
+              "description": "signature over the logIndex, body and integratedTime",
+              "type": "string",
+              "format": "byte"
+            }
+          }
+        }
+      }
+    },
+    "LogEntryAnonVerification": {
+      "type": "object",
+      "properties": {
+        "inclusionProof": {
+          "$ref": "#/definitions/InclusionProof"
+        },
+        "signedEntryTimestamp": {
+          "description": "signature over the logIndex, body and integratedTime",
           "type": "string",
           "format": "byte"
         }

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -376,7 +376,7 @@ func TestWatch(t *testing.T) {
 	fmt.Println(fi[0].Name())
 }
 
-func TestCreateLogEntrySignature(t *testing.T) {
+func TestSignedEntryTimestamp(t *testing.T) {
 	// Create a random payload and sign it
 	ctx := context.Background()
 	payload := []byte("payload")
@@ -433,15 +433,7 @@ func TestCreateLogEntrySignature(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// unmarshal the response
-	le := resp.GetPayload()
-	if len(le) != 1 {
-		t.Fatal("expected length to be 1, is actually", len(le))
-	}
-	var logEntry models.LogEntryAnon
-	for _, v := range le {
-		logEntry = v
-	}
+	logEntry := extractLogEntry(t, resp.GetPayload())
 
 	// verify the signature against the log entry (without the signature)
 	sig := logEntry.Verification.SignedEntryTimestamp

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -18,7 +18,12 @@
 package e2e
 
 import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -28,6 +33,16 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/sigstore/rekor/cmd/rekor-cli/app"
+	"github.com/sigstore/rekor/pkg/generated/client"
+	"github.com/sigstore/rekor/pkg/generated/client/entries"
+	"github.com/sigstore/rekor/pkg/generated/client/pubkey"
+	"github.com/sigstore/rekor/pkg/generated/models"
+	"github.com/sigstore/rekor/pkg/signer"
+	rekord "github.com/sigstore/rekor/pkg/types/rekord/v0.0.1"
 )
 
 func getUUIDFromUploadOutput(t *testing.T, out string) string {
@@ -358,4 +373,118 @@ func TestWatch(t *testing.T) {
 		t.Error("expected files")
 	}
 	fmt.Println(fi[0].Name())
+}
+
+func TestCreateLogEntrySignature(t *testing.T) {
+	// Create a random payload and sign it
+	ctx := context.Background()
+	payload := []byte("payload")
+	s, err := signer.NewMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	signature, _, err := s.Sign(ctx, payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubkey, err := s.PublicKey(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := x509.MarshalPKIXPublicKey(pubkey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: b,
+	})
+
+	// submit our newly signed payload to rekor
+	rekorClient, err := app.GetRekorClient("http://localhost:3000")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	re := rekord.V001Entry{
+		RekordObj: models.RekordV001Schema{
+			Data: &models.RekordV001SchemaData{
+				Content: strfmt.Base64(payload),
+			},
+			Signature: &models.RekordV001SchemaSignature{
+				Content: strfmt.Base64(signature),
+				Format:  models.RekordV001SchemaSignatureFormatX509,
+				PublicKey: &models.RekordV001SchemaSignaturePublicKey{
+					Content: strfmt.Base64(pemBytes),
+				},
+			},
+		},
+	}
+
+	returnVal := models.Rekord{
+		APIVersion: swag.String(re.APIVersion()),
+		Spec:       re.RekordObj,
+	}
+	params := entries.NewCreateLogEntryParams()
+	params.SetProposedEntry(&returnVal)
+	resp, err := rekorClient.Entries.CreateLogEntry(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// unmarshal the response
+	le := resp.GetPayload()
+	if len(le) != 1 {
+		t.Fatal("expected length to be 1, is actually", len(le))
+	}
+	var logEntry models.LogEntryAnon
+	for _, v := range le {
+		logEntry = v
+	}
+
+	// verify the signature against the log entry (without the signature)
+	sig := logEntry.Signature
+	logEntry.Signature = nil
+	payload, err = logEntry.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// get rekor's public key
+	rekorPubKey := rekorPublicKey(t, ctx, rekorClient)
+
+	// verify the signature against the public key
+	h := crypto.SHA256.New()
+	if _, err := h.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+	sum := h.Sum(nil)
+
+	if !ecdsa.VerifyASN1(rekorPubKey, sum, []byte(sig)) {
+		t.Fatal("unable to verify")
+	}
+}
+
+func rekorPublicKey(t *testing.T, ctx context.Context, c *client.Rekor) *ecdsa.PublicKey {
+	resp, err := c.Pubkey.GetPublicKey(&pubkey.GetPublicKeyParams{Context: ctx})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubKey := resp.GetPayload()
+
+	// marshal the pubkey
+	p, _ := pem.Decode([]byte(pubKey))
+	if p == nil {
+		t.Fatal("shouldn't be nil")
+	}
+
+	decoded, err := x509.ParsePKIXPublicKey(p.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ed, ok := decoded.(*ecdsa.PublicKey)
+	if !ok {
+		t.Fatal("not ecdsa public key")
+	}
+	return ed
 }

--- a/tests/util.go
+++ b/tests/util.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/sigstore/rekor/pkg/generated/models"
 )
 
 const (
@@ -110,4 +112,17 @@ func createArtifact(t *testing.T, artifactPath string) string {
 		t.Fatal(err)
 	}
 	return artifact
+}
+
+func extractLogEntry(t *testing.T, le models.LogEntry) models.LogEntryAnon {
+	t.Helper()
+
+	if len(le) != 1 {
+		t.Fatal("expected length to be 1, is actually", len(le))
+	}
+	for _, v := range le {
+		return v
+	}
+	// this should never happen
+	return models.LogEntryAnon{}
 }


### PR DESCRIPTION
This PR adds a signature field to LogEntry (I'm open to different names for signature here since it might be overused). It can be used to verify the LogEntry was signed for offline verification, which cosign will be using for bundling!

Basically, rekor will:
1. Sign the LogEntry
2. Add the signature to the "Verification.SignedEntryTimestamp" field of the LogEntry
3. Send that to the client whenever they create a new entry

and clients will:
1. Get the LogEntry when they create a new entry, and set signature=nil to get the payload (making people set signature=nil is kinda weird, but follows the precert model where the poison extension has to be removed to validate the cert). I went this route so that the signature could be bundled with the LogEntry which is already being returned when users add an entry to the log.
2. Validate the payload and signature against the rekor public key

Also adds an integration test for this.

cc @dlorenc @asraa 

