### PR TITLE
Add Log ID to LogEntry field

### DIFF
--- a/cmd/rekor-cli/app/get.go
+++ b/cmd/rekor-cli/app/get.go
@@ -40,10 +40,12 @@ type getCmdOutput struct {
 	LogIndex       int
 	IntegratedTime int64
 	UUID           string
+	LogID          string
 }
 
 func (g *getCmdOutput) String() string {
-	s := fmt.Sprintf("Index: %d\n", g.LogIndex)
+	s := fmt.Sprintf("LogID: %v\n", g.LogID)
+	s += fmt.Sprintf("Index: %d\n", g.LogIndex)
 	dt := time.Unix(g.IntegratedTime, 0).UTC().Format(time.RFC3339)
 	s += fmt.Sprintf("IntegratedTime: %s\n", dt)
 	s += fmt.Sprintf("UUID: %s\n", g.UUID)
@@ -130,8 +132,9 @@ func parseEntry(uuid string, e models.LogEntryAnon) (interface{}, error) {
 	obj := getCmdOutput{
 		Body:           eimpl,
 		UUID:           uuid,
-		IntegratedTime: e.IntegratedTime,
+		IntegratedTime: *e.IntegratedTime,
 		LogIndex:       int(*e.LogIndex),
+		LogID:          *e.LogID,
 	}
 
 	return &obj, nil

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -291,6 +291,8 @@ definitions:
     additionalProperties:
       type: object
       properties:
+        logID:
+          type: string
         logIndex:
           type: integer
           minimum: 0
@@ -311,10 +313,12 @@ definitions:
                 # 1. Remove the Verification object from the JSON Document
                 # 2. Canonicalize the remaining JSON document by following RFC 8785 rules
                 # 3. Verify the canonicalized payload and signedEntryTimestamp against rekor's public key
-              description: Signature over the logIndex, body and integratedTime. 
+              description: Signature over the logID, logIndex, body and integratedTime.
       required:
+        - "logID"
         - "logIndex"
         - "body"
+        - "integratedTime"
 
   SearchIndex:
     type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -293,6 +293,8 @@ definitions:
       properties:
         logID:
           type: string
+          pattern: '^[0-9a-fA-F]{64}$'
+          description: This is the SHA256 hash of the DER-encoded public key for the log at the time the entry was included in the log
         logIndex:
           type: integer
           minimum: 0

--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -62,9 +62,10 @@ func logEntryFromLeaf(tc TrillianClient, leaf *trillian.LogLeaf, signedLogRoot *
 
 	logEntry := models.LogEntry{
 		hex.EncodeToString(leaf.MerkleLeafHash): models.LogEntryAnon{
+			LogID:          swag.String(fmt.Sprintf("%v", tc.logID)),
 			LogIndex:       &leaf.LeafIndex,
 			Body:           leaf.LeafValue,
-			IntegratedTime: leaf.IntegrateTimestamp.AsTime().Unix(),
+			IntegratedTime: swag.Int64(leaf.IntegrateTimestamp.AsTime().Unix()),
 			Verification: &models.LogEntryAnonVerification{
 				InclusionProof: &inclusionProof,
 			},
@@ -143,9 +144,10 @@ func CreateLogEntryHandler(params entries.CreateLogEntryParams) middleware.Respo
 	uuid := hex.EncodeToString(queuedLeaf.GetMerkleLeafHash())
 
 	logEntryAnon := models.LogEntryAnon{
+		LogID:          swag.String(fmt.Sprintf("%v", tc.logID)),
 		LogIndex:       swag.Int64(queuedLeaf.LeafIndex),
 		Body:           queuedLeaf.GetLeafValue(),
-		IntegratedTime: queuedLeaf.IntegrateTimestamp.AsTime().Unix(),
+		IntegratedTime: swag.Int64(queuedLeaf.IntegrateTimestamp.AsTime().Unix()),
 	}
 
 	if viper.GetBool("enable_retrieve_api") {

--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -62,7 +62,7 @@ func logEntryFromLeaf(tc TrillianClient, leaf *trillian.LogLeaf, signedLogRoot *
 
 	logEntry := models.LogEntry{
 		hex.EncodeToString(leaf.MerkleLeafHash): models.LogEntryAnon{
-			LogID:          swag.String(fmt.Sprintf("%v", tc.logID)),
+			LogID:          swag.String(api.pubkeyHash),
 			LogIndex:       &leaf.LeafIndex,
 			Body:           leaf.LeafValue,
 			IntegratedTime: swag.Int64(leaf.IntegrateTimestamp.AsTime().Unix()),
@@ -144,7 +144,7 @@ func CreateLogEntryHandler(params entries.CreateLogEntryParams) middleware.Respo
 	uuid := hex.EncodeToString(queuedLeaf.GetMerkleLeafHash())
 
 	logEntryAnon := models.LogEntryAnon{
-		LogID:          swag.String(fmt.Sprintf("%v", tc.logID)),
+		LogID:          swag.String(api.pubkeyHash),
 		LogIndex:       swag.Int64(queuedLeaf.LeafIndex),
 		Body:           queuedLeaf.GetLeafValue(),
 		IntegratedTime: swag.Int64(queuedLeaf.IntegrateTimestamp.AsTime().Unix()),

--- a/pkg/generated/models/log_entry.go
+++ b/pkg/generated/models/log_entry.go
@@ -91,8 +91,9 @@ type LogEntryAnon struct {
 	// Required: true
 	IntegratedTime *int64 `json:"integratedTime"`
 
-	// log ID
+	// This is the SHA256 hash of the DER-encoded public key for the log at the time the entry was included in the log
 	// Required: true
+	// Pattern: ^[0-9a-fA-F]{64}$
 	LogID *string `json:"logID"`
 
 	// log index
@@ -155,6 +156,10 @@ func (m *LogEntryAnon) validateIntegratedTime(formats strfmt.Registry) error {
 func (m *LogEntryAnon) validateLogID(formats strfmt.Registry) error {
 
 	if err := validate.Required("logID", "body", m.LogID); err != nil {
+		return err
+	}
+
+	if err := validate.Pattern("logID", "body", *m.LogID, `^[0-9a-fA-F]{64}$`); err != nil {
 		return err
 	}
 

--- a/pkg/generated/models/log_entry.go
+++ b/pkg/generated/models/log_entry.go
@@ -88,7 +88,12 @@ type LogEntryAnon struct {
 	Body interface{} `json:"body"`
 
 	// integrated time
-	IntegratedTime int64 `json:"integratedTime,omitempty"`
+	// Required: true
+	IntegratedTime *int64 `json:"integratedTime"`
+
+	// log ID
+	// Required: true
+	LogID *string `json:"logID"`
 
 	// log index
 	// Required: true
@@ -104,6 +109,14 @@ func (m *LogEntryAnon) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateBody(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateIntegratedTime(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateLogID(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -125,6 +138,24 @@ func (m *LogEntryAnon) validateBody(formats strfmt.Registry) error {
 
 	if m.Body == nil {
 		return errors.Required("body", "body", nil)
+	}
+
+	return nil
+}
+
+func (m *LogEntryAnon) validateIntegratedTime(formats strfmt.Registry) error {
+
+	if err := validate.Required("integratedTime", "body", m.IntegratedTime); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *LogEntryAnon) validateLogID(formats strfmt.Registry) error {
+
+	if err := validate.Required("logID", "body", m.LogID); err != nil {
+		return err
 	}
 
 	return nil
@@ -214,7 +245,7 @@ type LogEntryAnonVerification struct {
 	// inclusion proof
 	InclusionProof *InclusionProof `json:"inclusionProof,omitempty"`
 
-	// Signature over the logIndex, body and integratedTime.
+	// Signature over the logID, logIndex, body and integratedTime.
 	// Format: byte
 	SignedEntryTimestamp strfmt.Base64 `json:"signedEntryTimestamp,omitempty"`
 }

--- a/pkg/generated/restapi/embedded_spec.go
+++ b/pkg/generated/restapi/embedded_spec.go
@@ -414,7 +414,9 @@ func init() {
             "type": "integer"
           },
           "logID": {
-            "type": "string"
+            "description": "This is the SHA256 hash of the DER-encoded public key for the log at the time the entry was included in the log",
+            "type": "string",
+            "pattern": "^[0-9a-fA-F]{64}$"
           },
           "logIndex": {
             "type": "integer"
@@ -1212,7 +1214,9 @@ func init() {
           "type": "integer"
         },
         "logID": {
-          "type": "string"
+          "description": "This is the SHA256 hash of the DER-encoded public key for the log at the time the entry was included in the log",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{64}$"
         },
         "logIndex": {
           "type": "integer",

--- a/pkg/generated/restapi/embedded_spec.go
+++ b/pkg/generated/restapi/embedded_spec.go
@@ -400,8 +400,10 @@ func init() {
       "additionalProperties": {
         "type": "object",
         "required": [
+          "logID",
           "logIndex",
-          "body"
+          "body",
+          "integratedTime"
         ],
         "properties": {
           "body": {
@@ -410,6 +412,9 @@ func init() {
           },
           "integratedTime": {
             "type": "integer"
+          },
+          "logID": {
+            "type": "string"
           },
           "logIndex": {
             "type": "integer"
@@ -421,7 +426,7 @@ func init() {
                 "$ref": "#/definitions/InclusionProof"
               },
               "signedEntryTimestamp": {
-                "description": "Signature over the logIndex, body and integratedTime.",
+                "description": "Signature over the logID, logIndex, body and integratedTime.",
                 "type": "string",
                 "format": "byte"
               }
@@ -1193,8 +1198,10 @@ func init() {
     "LogEntryAnon": {
       "type": "object",
       "required": [
+        "logID",
         "logIndex",
-        "body"
+        "body",
+        "integratedTime"
       ],
       "properties": {
         "body": {
@@ -1203,6 +1210,9 @@ func init() {
         },
         "integratedTime": {
           "type": "integer"
+        },
+        "logID": {
+          "type": "string"
         },
         "logIndex": {
           "type": "integer",
@@ -1215,7 +1225,7 @@ func init() {
               "$ref": "#/definitions/InclusionProof"
             },
             "signedEntryTimestamp": {
-              "description": "Signature over the logIndex, body and integratedTime.",
+              "description": "Signature over the logID, logIndex, body and integratedTime.",
               "type": "string",
               "format": "byte"
             }
@@ -1230,7 +1240,7 @@ func init() {
           "$ref": "#/definitions/InclusionProof"
         },
         "signedEntryTimestamp": {
-          "description": "Signature over the logIndex, body and integratedTime.",
+          "description": "Signature over the logID, logIndex, body and integratedTime.",
           "type": "string",
           "format": "byte"
         }


### PR DESCRIPTION
Since the signed entry timestamp will be able to prove insertion into the log, we will need to include the log ID in order for the index to be meaningful.

Signed-off-by: Bob Callaway <bob.callaway@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
