### PR TITLE
GetLogByIndexHandler returns 404 for missing index

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,3 +58,9 @@ jobs:
           go-version: ${{ env.GOVERSION }}
       - name: CLI
         run: ./tests/e2e-test.sh
+      - name: Upload logs if they exist
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: Docker Compose logs
+          path: /tmp/docker-compose.log

--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -81,7 +81,7 @@ func GetLogEntryByIndexHandler(params entries.GetLogEntryByIndexParams) middlewa
 	resp := tc.getLeafAndProofByIndex(params.LogIndex)
 	switch resp.status {
 	case codes.OK:
-	case codes.NotFound, codes.OutOfRange:
+	case codes.NotFound, codes.OutOfRange, codes.InvalidArgument:
 		return handleRekorAPIError(params, http.StatusNotFound, fmt.Errorf("grpc error: %w", resp.err), "")
 	default:
 		return handleRekorAPIError(params, http.StatusInternalServerError, fmt.Errorf("grpc err: %w", resp.err), trillianCommunicationError)

--- a/tests/e2e-test.sh
+++ b/tests/e2e-test.sh
@@ -44,10 +44,13 @@ echo "running tests"
 TMPDIR="$(mktemp -d -t rekor_test.XXXXXX)"
 touch $TMPDIR.rekor.yaml
 trap "rm -rf $TMPDIR" EXIT
-TMPDIR=$TMPDIR go test -tags=e2e ./tests/
+if ! TMPDIR=$TMPDIR go test -tags=e2e ./tests/; then 
+   docker-compose logs --no-color > /tmp/docker-compose.log
+   exit 1
+fi
 if docker-compose logs --no-color | grep -q "panic: runtime error:" ; then
    # if we're here, we found a panic
    echo "Failing due to panics detected in logs"
-   docker-compose logs --no-color
+   docker-compose logs --no-color > /tmp/docker-compose.log
    exit 1
 fi

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -475,3 +475,15 @@ func TestSignedEntryTimestamp(t *testing.T) {
 		t.Fatal("unable to verify")
 	}
 }
+
+func TestGetNonExistantIndex(t *testing.T) {
+	// this index is extremely likely to not exist
+	out := runCliErr(t, "get", "--log-index", "100000000")
+	outputContains(t, out, "404")
+}
+
+func TestGetNonExistantUUID(t *testing.T) {
+	// this uuid is extremely likely to not exist
+	out := runCliErr(t, "get", "--uuid", "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+	outputContains(t, out, "404")
+}

--- a/tests/util.go
+++ b/tests/util.go
@@ -71,7 +71,7 @@ func runCli(t *testing.T, arg ...string) string {
 	return run(t, "", cli, arg...)
 }
 
-func runCliErr(t *testing.T, arg ...string) {
+func runCliErr(t *testing.T, arg ...string) string {
 	t.Helper()
 	cmd := exec.Command(cli, arg...)
 	b, err := cmd.CombinedOutput()
@@ -79,6 +79,7 @@ func runCliErr(t *testing.T, arg ...string) {
 		t.Log(string(b))
 		t.Fatalf("expected error, got %s", string(b))
 	}
+	return string(b)
 }
 
 func readFile(t *testing.T, p string) string {

--- a/tests/util.go
+++ b/tests/util.go
@@ -73,6 +73,11 @@ func runCli(t *testing.T, arg ...string) string {
 
 func runCliErr(t *testing.T, arg ...string) string {
 	t.Helper()
+	arg = append(arg, "--rekor_server=http://localhost:3000")
+	// use a blank config file to ensure no collision
+	if os.Getenv("TMPDIR") != "" {
+		arg = append(arg, "--config="+os.Getenv("TMPDIR")+".rekor.yaml")
+	}
 	cmd := exec.Command(cli, arg...)
 	b, err := cmd.CombinedOutput()
 	if err == nil {


### PR DESCRIPTION
GRPC return codes have changed after switching the Trillian GRPC calls due to recent changes; therefore we need to adapt for InvalidArgument which should be returned as a 404 Not Found error to callers.

Fixes #296

Signed-off-by: Bob Callaway <bob.callaway@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
