### PR TITLE
Change from api.rekor.dev to rekor.sigstore.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If you're interesting in integration with Rekor, we have an [OpenAPI swagger edi
 
 ## Public Instance
 
-A public instance of rekor can be found at [api.sigstore.dev](https://api.sigstore.dev/api/v1/log/)
+A public instance of rekor can be found at [rekor.sigstore.dev](https://rekor.sigstore.dev/api/v1/log/)
 
 **IMPORTANT**: This instance is currently operated on a best-effort basis.
 We **will take the log down** and reset it with zero notice.

--- a/cmd/rekor-cli/app/root.go
+++ b/cmd/rekor-cli/app/root.go
@@ -55,10 +55,10 @@ func init() {
 	rootCmd.PersistentFlags().String("config", "", "config file (default is $HOME/.rekor.yaml)")
 	rootCmd.PersistentFlags().Bool("store_tree_state", true, "whether to store tree state in between invocations for additional verification")
 
-	rootCmd.PersistentFlags().Var(&urlFlag{url: "https://api.rekor.dev"}, "rekor_server", "Server address:port")
+	rootCmd.PersistentFlags().Var(&urlFlag{url: "https://rekor.sigstore.dev"}, "rekor_server", "Server address:port")
 	rootCmd.PersistentFlags().Var(&formatFlag{format: "default"}, "format", "Command output format")
 
-	rootCmd.PersistentFlags().String("api-key", "", "API key for api.rekor.dev")
+	rootCmd.PersistentFlags().String("api-key", "", "API key for rekor.sigstore.dev")
 
 	// these are bound here and not in PreRun so that all child commands can use them
 	if err := viper.BindPFlags(rootCmd.PersistentFlags()); err != nil {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -19,7 +19,7 @@ info:
   description: Rekor is a cryptographically secure, immutable transparency log for signed software releases.
   version: 0.0.1
 
-host: api.rekor.dev
+host: rekor.sigstore.dev
 schemes:
   - http
 

--- a/pkg/generated/client/rekor_client.go
+++ b/pkg/generated/client/rekor_client.go
@@ -38,7 +38,7 @@ var Default = NewHTTPClient(nil)
 const (
 	// DefaultHost is the default Host
 	// found in Meta (info) section of spec file
-	DefaultHost string = "api.rekor.dev"
+	DefaultHost string = "rekor.sigstore.dev"
 	// DefaultBasePath is the default BasePath
 	// found in Meta (info) section of spec file
 	DefaultBasePath string = "/"

--- a/pkg/generated/restapi/doc.go
+++ b/pkg/generated/restapi/doc.go
@@ -20,7 +20,7 @@
 //  Rekor is a cryptographically secure, immutable transparency log for signed software releases.
 //  Schemes:
 //    http
-//  Host: api.rekor.dev
+//  Host: rekor.sigstore.dev
 //  BasePath: /
 //  Version: 0.0.1
 //

--- a/pkg/generated/restapi/embedded_spec.go
+++ b/pkg/generated/restapi/embedded_spec.go
@@ -51,7 +51,7 @@ func init() {
     "title": "Rekor",
     "version": "0.0.1"
   },
-  "host": "api.rekor.dev",
+  "host": "rekor.sigstore.dev",
   "paths": {
     "/api/v1/index/retrieve": {
       "post": {
@@ -687,7 +687,7 @@ func init() {
     "title": "Rekor",
     "version": "0.0.1"
   },
-  "host": "api.rekor.dev",
+  "host": "rekor.sigstore.dev",
   "paths": {
     "/api/v1/index/retrieve": {
       "post": {


### PR DESCRIPTION
As we have moved away from the rekor.dev domain, switching over to
rekor.sigstore.dev for the public instance. api.sigstore.dev still works
as an alias.

Fixes #305

Signed-off-by: Bob Callaway <bob.callaway@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
