### PR TITLE
Add Log ID into SET verification step

### DIFF
--- a/cmd/rekor-cli/app/upload.go
+++ b/cmd/rekor-cli/app/upload.go
@@ -137,10 +137,7 @@ func verifyLogEntry(ctx context.Context, rekorClient *client.Rekor, logEntry mod
 		IntegratedTime: logEntry.IntegratedTime,
 		LogIndex:       logEntry.LogIndex,
 		Body:           logEntry.Body,
-	}
-	// this was added after later, so we check for the scenario where it might be unset
-	if logEntry.LogID != nil {
-		le.LogID = logEntry.LogID
+		LogID:          logEntry.LogID,
 	}
 
 	payload, err := le.MarshalBinary()

--- a/cmd/rekor-cli/app/upload.go
+++ b/cmd/rekor-cli/app/upload.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/sha256"
-	"errors"
 	"fmt"
 	"os"
 
@@ -28,6 +27,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/pkg/errors"
 	"github.com/sigstore/rekor/cmd/rekor-cli/app/format"
 	"github.com/sigstore/rekor/pkg/generated/client"
 	"github.com/sigstore/rekor/pkg/generated/client/entries"
@@ -118,7 +118,7 @@ var uploadCmd = &cobra.Command{
 
 		// verify log entry
 		if verified, err := verifyLogEntry(ctx, rekorClient, logEntry); err != nil || !verified {
-			fmt.Fprintf(os.Stderr, "unable to verify entry was added to log: %v", err)
+			return nil, errors.Wrap(err, "unable to verify entry was added to log")
 		}
 
 		return &uploadCmdOutput{
@@ -138,6 +138,11 @@ func verifyLogEntry(ctx context.Context, rekorClient *client.Rekor, logEntry mod
 		LogIndex:       logEntry.LogIndex,
 		Body:           logEntry.Body,
 	}
+	// this was added after later, so we check for the scenario where it might be unset
+	if logEntry.LogID != nil {
+		le.LogID = logEntry.LogID
+	}
+
 	payload, err := le.MarshalBinary()
 	if err != nil {
 		return false, err


### PR DESCRIPTION
This also causes the upload command to return a non-zero error code
because of a verification failure.

Fixes #308

Signed-off-by: Bob Callaway <bob.callaway@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
