### PR TITLE
Use default trillian_log_server ports

### DIFF
--- a/cmd/rekor-server/app/root.go
+++ b/cmd/rekor-server/app/root.go
@@ -57,7 +57,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&logType, "log_type", "dev", "logger type to use (dev/prod)")
 
 	rootCmd.PersistentFlags().String("trillian_log_server.address", "127.0.0.1", "Trillian log server address")
-	rootCmd.PersistentFlags().Uint16("trillian_log_server.port", 8091, "Trillian log server port")
+	rootCmd.PersistentFlags().Uint16("trillian_log_server.port", 8090, "Trillian log server port")
 	rootCmd.PersistentFlags().Uint("trillian_log_server.tlog_id", 0, "Trillian tree id")
 	rootCmd.PersistentFlags().String("rekor_server.address", "127.0.0.1", "Address to bind to")
 	rootCmd.PersistentFlags().String("rekor_server.signer", "memory", "Rekor signer to use. Current valid options include: [gcpkms, memory]")

--- a/config/rekor.yaml
+++ b/config/rekor.yaml
@@ -42,7 +42,7 @@ spec:
         args: [
           "serve",
           "--trillian_log_server.address=trillian-server",
-          "--trillian_log_server.port=8091",
+          "--trillian_log_server.port=8090",
           "--rekor_server.address=0.0.0.0",
           "--redis_server.address=10.234.175.59",
           "--redis_server.port=6379",

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -30,7 +30,7 @@ services:
       "/usr/local/bin/rekor-server",
       "serve",
       "--trillian_log_server.address=trillian-log-server",
-      "--trillian_log_server.port=8091",
+      "--trillian_log_server.port=8090",
       "--redis_server.address=redis-server",
       "--redis_server.port=6379",
       "--rekor_server.address=0.0.0.0",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,8 +49,8 @@ services:
     command: [
       "--storage_system=mysql",
       "--mysql_uri=test:zaphod@tcp(mysql:3306)/test",
-      "--rpc_endpoint=0.0.0.0:8091",
-      "--http_endpoint=0.0.0.0:8090",
+      "--rpc_endpoint=0.0.0.0:8090",
+      "--http_endpoint=0.0.0.0:8091",
       "--alsologtostderr",
     ]
     restart: always # retry while mysql is starting up
@@ -82,7 +82,7 @@ services:
       "rekor-server",
       "serve",
       "--trillian_log_server.address=trillian-log-server",
-      "--trillian_log_server.port=8091",
+      "--trillian_log_server.port=8090",
       "--redis_server.address=redis-server",
       "--redis_server.port=6379",
       "--rekor_server.address=0.0.0.0",

--- a/rekor-server.yaml
+++ b/rekor-server.yaml
@@ -15,7 +15,7 @@
 
 trillian_log_server:
   address: "127.0.0.1"
-  port: 8091
+  port: 8090
 
 rekor_server:
   address: "127.0.0.1"


### PR DESCRIPTION
Switch away from using rpc_endpoint=8091 and back to 8090 which is trillian_log_server's default.

This simplifies the commands to start trillian log_server, reducing it down to:
`trillian_log_server --logtostderr ...`
and avoids diverging from upstream when there is no need.

This change also updates the corresponding docker-compose and k8s configs.

A corresponding documentation update is in the works.

Signed-off-by: axelsimon <github@axelsimon.net>


