### PR TITLE
Fix typo in kubernetes yaml for attestation storage.

### DIFF
--- a/config/rekor.yaml
+++ b/config/rekor.yaml
@@ -50,7 +50,7 @@ spec:
           "--log_type=prod",
           "--rekor_server.signer=$(KMS)",
           "--enable_attestation_storage=$(ENABLE_ATTESTATION_STORAGE)",
-          "attestation_storage_bucket=$(ATTESTATION_BUCKET)"
+          "--attestation_storage_bucket=$(ATTESTATION_BUCKET)"
         ]
         env:
         - name: KMS


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
