### PR TITLE
build containers for both arm64 and amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,8 +84,8 @@ debug:
 
 ko:
 	# We can't pass more than one LDFLAG via GOFLAGS, you can't have spaces in there.
-	CGO_ENABLED=0 GOFLAGS="-tags=pivkeydisabled -ldflags=-X=$(SERVER_PKG).gitCommit=$(GIT_HASH)" ko publish --bare \
-                --tags $(GIT_VERSION) --tags $(GIT_HASH) \
+	CGO_ENABLED=0 GOFLAGS="-ldflags=-X=$(SERVER_PKG).gitCommit=$(GIT_HASH)" ko publish --bare \
+                --tags $(GIT_VERSION) --tags $(GIT_HASH) --platform=linux/amd64,linux/arm64 \
                 github.com/sigstore/rekor/cmd/rekor-server
 
 sign-container: ko


### PR DESCRIPTION
Signed-off-by: Bob Callaway <bob.callaway@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
