### PR TITLE
base64 encode timestamping cert chain

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/pem"
 	"fmt"
@@ -114,9 +115,12 @@ func NewAPI() (*API, error) {
 	}
 
 	var certChain []*x509.Certificate
-	certChainStr := viper.GetString("rekor_server.timestamp_chain")
-	if certChainStr != "" {
-		var err error
+	b64CertChainStr := viper.GetString("rekor_server.timestamp_chain")
+	if b64CertChainStr != "" {
+		certChainStr, err := base64.StdEncoding.DecodeString(b64CertChainStr)
+		if err != nil {
+			return nil, errors.Wrap(err, "decoding timestamping cert")
+		}
 		if certChain, err = pki.ParseTimestampCertChain([]byte(certChainStr)); err != nil {
 			return nil, errors.Wrap(err, "parsing timestamp cert chain")
 		}


### PR DESCRIPTION
Because of pesky newlines

Signed-off-by: Asra Ali <asraa@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
