### PR TITLE
Fix help message outputs.

### DIFF
--- a/cmd/rekor-cli/app/timestamp.go
+++ b/cmd/rekor-cli/app/timestamp.go
@@ -197,7 +197,6 @@ var timestampCmd = &cobra.Command{
 		}
 		if err := validateTimestampFlags(); err != nil {
 			log.Logger.Error(err)
-			_ = cmd.Help()
 			return err
 		}
 		return nil

--- a/cmd/rekor-cli/app/upload.go
+++ b/cmd/rekor-cli/app/upload.go
@@ -20,7 +20,6 @@ import (
 	"crypto/ecdsa"
 	"crypto/sha256"
 	"fmt"
-	"os"
 
 	"github.com/cyberphone/json-canonicalization/go/src/webpki.org/jsoncanonicalizer"
 	"github.com/go-openapi/swag"
@@ -54,16 +53,15 @@ func (u *uploadCmdOutput) String() string {
 var uploadCmd = &cobra.Command{
 	Use:   "upload",
 	Short: "Upload an artifact to Rekor",
-	PreRun: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// these are bound here so that they are not overwritten by other commands
 		if err := viper.BindPFlags(cmd.Flags()); err != nil {
-			log.Logger.Fatal("Error initializing cmd line args: ", err)
+			return err
 		}
 		if err := validateArtifactPFlags(false, false); err != nil {
-			log.Logger.Error(err)
-			_ = cmd.Help()
-			os.Exit(1)
+			return err
 		}
+		return nil
 	},
 	Long: `This command takes the public key, signature and URL of the release artifact and uploads it to the rekor server.`,
 	Run: format.WrapCmd(func(args []string) (interface{}, error) {

--- a/cmd/rekor-cli/app/verify.go
+++ b/cmd/rekor-cli/app/verify.go
@@ -79,7 +79,6 @@ var verifyCmd = &cobra.Command{
 			return fmt.Errorf("error initializing cmd line args: %s", err)
 		}
 		if err := validateArtifactPFlags(true, true); err != nil {
-			_ = cmd.Help()
 			return err
 		}
 		return nil


### PR DESCRIPTION
Fixes https://github.com/sigstore/rekor/issues/365

```shell
$ ./rekor-cli verify
Error: either 'entry' or 'artifact' must be specified
Usage:
  rekor verify [flags]

Flags:
      --artifact fileOrURLFlag     path or URL to artifact file
      --artifact-hash uuid         hex encoded SHA256 hash of artifact (when using URL)
      --entry fileOrURLFlag        path or URL to pre-formatted entry file
  -h, --help                       help for verify
      --log-index logIndex         the index of the entry in the transparency log
      --pki-format pkiFormat       format of the signature and/or public key (default pgp)
      --public-key fileOrURLFlag   path or URL to public key file
      --signature fileOrURLFlag    path or URL to detached signature file
      --type typeFormat            type of entry (default rekord)
      --uuid uuid                  UUID of entry in transparency log (if known)

Global Flags:
      --api-key string     API key for rekor.sigstore.dev
      --config string      config file (default is $HOME/.rekor.yaml)
      --format format      Command output format (default default)
      --rekor_server url   Server address:port (default https://rekor.sigstore.dev)
      --store_tree_state   whether to store tree state in between invocations for additional verification (default true)

either 'entry' or 'artifact' must be specified
```

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
