### PR TITLE
Stop depending on external jenkins mirror

### DIFF
--- a/tests/jar.go
+++ b/tests/jar.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"crypto"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/sassoftware/relic/lib/certloader"
@@ -33,6 +34,7 @@ import (
 //note: reuses PKI artifacts from x509 tests
 
 const manifest = `Manifest-Version: 1.0
+Created-By: REPLACE
 
 Name: src/some/java/HelloWorld.class
 SHA-256-Digest: cp40SgHlLIIr397GHijW7aAmWNLn0rgKm5Ap9B4hLd4=
@@ -58,7 +60,8 @@ func createSignedJar(t *testing.T, artifactPath string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	mf.Write([]byte(manifest))
+	randManifest := strings.Replace(manifest, "REPLACE", randomRpmSuffix(), 1)
+	mf.Write([]byte(randManifest))
 	if err := zw.Close(); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This causes a JAR to be fetched over a local HTTP server in the
e2e test harness instead of the external Jenkins mirror. Also causes the
JAR input to be randomized so we can re-use the createSignedJar method
in multiple tests.

Fixes: #375

Signed-off-by: Bob Callaway <bob.callaway@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
