### PR TITLE
Fix #373: skip openssh tests if ssh-keygen is not in PATH

### DIFF
--- a/pkg/pki/ssh/sign_test.go
+++ b/pkg/pki/ssh/sign_test.go
@@ -140,6 +140,9 @@ func TestFromOpenSSH(t *testing.T) {
 			priv: ed25519PrivateKey,
 		},
 	} {
+		if _, err := exec.LookPath("ssh-keygen"); err != nil {
+			t.Skip("skip TestFromOpenSSH: missing ssh-keygen in PATH")
+		}
 		t.Run(tt.name, func(t *testing.T) {
 			tt := tt
 
@@ -193,6 +196,9 @@ func TestToOpenSSH(t *testing.T) {
 			priv: ed25519PrivateKey,
 		},
 	} {
+		if _, err := exec.LookPath("ssh-keygen"); err != nil {
+			t.Skip("skip TestToOpenSSH: missing ssh-keygen in PATH")
+		}
 		t.Run(tt.name, func(t *testing.T) {
 			tt := tt
 			// Test that a signature from here can validate in the CLI.


### PR DESCRIPTION
This PR tries to solve #373  via checking for the ssh-keygen executable in the path.
Note: The skipped tests will only be shown when adding the `-v` flag to `go test`.
The PR has been tested on my local system: 

**without ssh-keygen in the PATH:**:
```
❯ go test -v ./...
=== RUN   TestFromOpenSSH
    sign_test.go:144: skip TestFromOpenSSH: missing ssh-keygen in PATH
--- SKIP: TestFromOpenSSH (0.00s)
=== RUN   TestToOpenSSH
    sign_test.go:200: skip TestToOpenSSH: missing ssh-keygen in PATH
--- SKIP: TestToOpenSSH (0.00s)
=== RUN   TestRoundTrip
=== RUN   TestRoundTrip/rsa
=== RUN   TestRoundTrip/ed25519
--- PASS: TestRoundTrip (0.02s)
    --- PASS: TestRoundTrip/rsa (0.01s)
    --- PASS: TestRoundTrip/ed25519 (0.00s)
PASS
```

**with ssh-keygen in the PATH:**
```
❯ go test -v ./...                                    
=== RUN   TestFromOpenSSH
=== RUN   TestFromOpenSSH/rsa
    sign_test.go:159: cmd /usr/bin/ssh-keygen -Y sign -n file -f /tmp/TestFromOpenSSH_rsa719251063/001/id /tmp/TestFromOpenSSH_rsa719251063/001/data: Signing file /tmp/TestFromOpenSSH_rsa719251063/001/data
        Write signature to /tmp/TestFromOpenSSH_rsa719251063/001/data.sig
=== RUN   TestFromOpenSSH/ed25519
    sign_test.go:159: cmd /usr/bin/ssh-keygen -Y sign -n file -f /tmp/TestFromOpenSSH_ed255193943236978/001/id /tmp/TestFromOpenSSH_ed255193943236978/001/data: Signing file /tmp/TestFromOpenSSH_ed255193943236978/001/data
        Write signature to /tmp/TestFromOpenSSH_ed255193943236978/001/data.sig
--- PASS: TestFromOpenSSH (0.02s)
    --- PASS: TestFromOpenSSH/rsa (0.01s)
    --- PASS: TestFromOpenSSH/ed25519 (0.01s)
=== RUN   TestToOpenSSH
=== RUN   TestToOpenSSH/rsa
    sign_test.go:223: cmd /usr/bin/ssh-keygen -Y verify -f /tmp/TestToOpenSSH_rsa2114079591/001/allowed_signer -I test@rekor.dev -n file -s /tmp/TestToOpenSSH_rsa2114079591/001/oursig: Good "file" signature for test@rekor.dev with RSA key SHA256:IkDRT/GXJRFrSruMf8F+ilGMaW+kFf2D4quUApK8p6E
    sign_test.go:227: cmd /usr/bin/ssh-keygen -Y verify -f /tmp/TestToOpenSSH_rsa2114079591/001/allowed_signer -I othertest@rekor.dev -n file -s /tmp/TestToOpenSSH_rsa2114079591/001/oursig: Could not verify signature.
    sign_test.go:232: cmd /usr/bin/ssh-keygen -Y check-novalidate -n file -s /tmp/TestToOpenSSH_rsa2114079591/001/oursig: Signature verification failed: incorrect signature
        Could not verify signature.
=== RUN   TestToOpenSSH/ed25519
    sign_test.go:223: cmd /usr/bin/ssh-keygen -Y verify -f /tmp/TestToOpenSSH_ed25519648723907/001/allowed_signer -I test@rekor.dev -n file -s /tmp/TestToOpenSSH_ed25519648723907/001/oursig: Good "file" signature for test@rekor.dev with ED25519 key SHA256:nTfAQgoE0o29gjmx7bF3pSliPLQ/UVdzeK2QFM4qEw4
    sign_test.go:227: cmd /usr/bin/ssh-keygen -Y verify -f /tmp/TestToOpenSSH_ed25519648723907/001/allowed_signer -I othertest@rekor.dev -n file -s /tmp/TestToOpenSSH_ed25519648723907/001/oursig: Could not verify signature.
    sign_test.go:232: cmd /usr/bin/ssh-keygen -Y check-novalidate -n file -s /tmp/TestToOpenSSH_ed25519648723907/001/oursig: Signature verification failed: incorrect signature
        Could not verify signature.
--- PASS: TestToOpenSSH (0.06s)
    --- PASS: TestToOpenSSH/rsa (0.03s)
    --- PASS: TestToOpenSSH/ed25519 (0.03s)
=== RUN   TestRoundTrip
=== RUN   TestRoundTrip/rsa
=== RUN   TestRoundTrip/ed25519
--- PASS: TestRoundTrip (0.01s)
    --- PASS: TestRoundTrip/rsa (0.00s)
    --- PASS: TestRoundTrip/ed25519 (0.00s)
PASS
```

