### PR TITLE
add readOnly/writeOnly annotations to openapi

### DIFF
--- a/pkg/generated/models/alpine_v001_schema.go
+++ b/pkg/generated/models/alpine_v001_schema.go
@@ -181,6 +181,7 @@ type AlpineV001SchemaPackage struct {
 	Hash *AlpineV001SchemaPackageHash `json:"hash,omitempty"`
 
 	// Values of the .PKGINFO key / value pairs
+	// Read Only: true
 	Pkginfo map[string]string `json:"pkginfo,omitempty"`
 
 	// Specifies the location of the package; if this is specified, a hash value must also be provided
@@ -243,6 +244,10 @@ func (m *AlpineV001SchemaPackage) ContextValidate(ctx context.Context, formats s
 		res = append(res, err)
 	}
 
+	if err := m.contextValidatePkginfo(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -259,6 +264,11 @@ func (m *AlpineV001SchemaPackage) contextValidateHash(ctx context.Context, forma
 			return err
 		}
 	}
+
+	return nil
+}
+
+func (m *AlpineV001SchemaPackage) contextValidatePkginfo(ctx context.Context, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/pkg/generated/models/helm_v001_schema.go
+++ b/pkg/generated/models/helm_v001_schema.go
@@ -380,8 +380,13 @@ func (m *HelmV001SchemaChartHash) validateValue(formats strfmt.Registry) error {
 	return nil
 }
 
-// ContextValidate validates this helm v001 schema chart hash based on context it is used
+// ContextValidate validate this helm v001 schema chart hash based on the context it is used
 func (m *HelmV001SchemaChartHash) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
 	return nil
 }
 
@@ -520,8 +525,9 @@ type HelmV001SchemaChartProvenanceSignature struct {
 
 	// Specifies the signature embedded within the provenance file
 	// Required: true
+	// Read Only: true
 	// Format: byte
-	Content *strfmt.Base64 `json:"content"`
+	Content strfmt.Base64 `json:"content"`
 }
 
 // Validate validates this helm v001 schema chart provenance signature
@@ -540,15 +546,33 @@ func (m *HelmV001SchemaChartProvenanceSignature) Validate(formats strfmt.Registr
 
 func (m *HelmV001SchemaChartProvenanceSignature) validateContent(formats strfmt.Registry) error {
 
-	if err := validate.Required("chart"+"."+"provenance"+"."+"signature"+"."+"content", "body", m.Content); err != nil {
+	if err := validate.Required("chart"+"."+"provenance"+"."+"signature"+"."+"content", "body", strfmt.Base64(m.Content)); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-// ContextValidate validates this helm v001 schema chart provenance signature based on context it is used
+// ContextValidate validate this helm v001 schema chart provenance signature based on the context it is used
 func (m *HelmV001SchemaChartProvenanceSignature) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.contextValidateContent(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *HelmV001SchemaChartProvenanceSignature) contextValidateContent(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "chart"+"."+"provenance"+"."+"signature"+"."+"content", "body", strfmt.Base64(m.Content)); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/generated/models/intoto_v001_schema.go
+++ b/pkg/generated/models/intoto_v001_schema.go
@@ -231,7 +231,7 @@ func (m *IntotoV001SchemaContent) UnmarshalBinary(b []byte) error {
 	return nil
 }
 
-// IntotoV001SchemaContentHash Specifies the hash algorithm and value encompassing the entire signed archive
+// IntotoV001SchemaContentHash Specifies the hash algorithm and value encompassing the entire signed envelope
 //
 // swagger:model IntotoV001SchemaContentHash
 type IntotoV001SchemaContentHash struct {
@@ -313,8 +313,13 @@ func (m *IntotoV001SchemaContentHash) validateValue(formats strfmt.Registry) err
 	return nil
 }
 
-// ContextValidate validates this intoto v001 schema content hash based on context it is used
+// ContextValidate validate this intoto v001 schema content hash based on the context it is used
 func (m *IntotoV001SchemaContentHash) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
 	return nil
 }
 

--- a/pkg/generated/models/jar_v001_schema.go
+++ b/pkg/generated/models/jar_v001_schema.go
@@ -388,8 +388,9 @@ type JarV001SchemaSignature struct {
 
 	// Specifies the PKCS7 signature embedded within the JAR file
 	// Required: true
+	// Read Only: true
 	// Format: byte
-	Content *strfmt.Base64 `json:"content"`
+	Content strfmt.Base64 `json:"content"`
 
 	// public key
 	// Required: true
@@ -416,7 +417,7 @@ func (m *JarV001SchemaSignature) Validate(formats strfmt.Registry) error {
 
 func (m *JarV001SchemaSignature) validateContent(formats strfmt.Registry) error {
 
-	if err := validate.Required("signature"+"."+"content", "body", m.Content); err != nil {
+	if err := validate.Required("signature"+"."+"content", "body", strfmt.Base64(m.Content)); err != nil {
 		return err
 	}
 
@@ -445,6 +446,10 @@ func (m *JarV001SchemaSignature) validatePublicKey(formats strfmt.Registry) erro
 func (m *JarV001SchemaSignature) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.contextValidateContent(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidatePublicKey(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -452,6 +457,15 @@ func (m *JarV001SchemaSignature) ContextValidate(ctx context.Context, formats st
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *JarV001SchemaSignature) contextValidateContent(ctx context.Context, formats strfmt.Registry) error {
+
+	if err := validate.ReadOnly(ctx, "signature"+"."+"content", "body", strfmt.Base64(m.Content)); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -521,8 +535,13 @@ func (m *JarV001SchemaSignaturePublicKey) validateContent(formats strfmt.Registr
 	return nil
 }
 
-// ContextValidate validates this jar v001 schema signature public key based on context it is used
+// ContextValidate validate this jar v001 schema signature public key based on the context it is used
 func (m *JarV001SchemaSignaturePublicKey) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
 	return nil
 }
 

--- a/pkg/generated/models/rekord_v001_schema.go
+++ b/pkg/generated/models/rekord_v001_schema.go
@@ -180,7 +180,7 @@ type RekordV001SchemaData struct {
 	// hash
 	Hash *RekordV001SchemaDataHash `json:"hash,omitempty"`
 
-	// Specifies the location of the content; if this is specified, a hash value must also be provided
+	// Specifies the location of the content
 	// Format: uri
 	URL strfmt.URI `json:"url,omitempty"`
 }

--- a/pkg/generated/models/rpm_v001_schema.go
+++ b/pkg/generated/models/rpm_v001_schema.go
@@ -181,6 +181,7 @@ type RpmV001SchemaPackage struct {
 	Hash *RpmV001SchemaPackageHash `json:"hash,omitempty"`
 
 	// Values of the RPM headers
+	// Read Only: true
 	Headers map[string]string `json:"headers,omitempty"`
 
 	// Specifies the location of the package; if this is specified, a hash value must also be provided
@@ -243,6 +244,10 @@ func (m *RpmV001SchemaPackage) ContextValidate(ctx context.Context, formats strf
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateHeaders(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
@@ -259,6 +264,11 @@ func (m *RpmV001SchemaPackage) contextValidateHash(ctx context.Context, formats 
 			return err
 		}
 	}
+
+	return nil
+}
+
+func (m *RpmV001SchemaPackage) contextValidateHeaders(ctx context.Context, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/pkg/generated/restapi/embedded_spec.go
+++ b/pkg/generated/restapi/embedded_spec.go
@@ -1307,7 +1307,8 @@ func init() {
         "content": {
           "description": "Specifies the package inline within the document",
           "type": "string",
-          "format": "byte"
+          "format": "byte",
+          "writeOnly": true
         },
         "hash": {
           "description": "Specifies the hash algorithm and value for the package",
@@ -1335,12 +1336,14 @@ func init() {
           "type": "object",
           "additionalProperties": {
             "type": "string"
-          }
+          },
+          "readOnly": true
         },
         "url": {
           "description": "Specifies the location of the package; if this is specified, a hash value must also be provided",
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "writeOnly": true
         }
       }
     },
@@ -1389,7 +1392,8 @@ func init() {
         "url": {
           "description": "Specifies the location of the public key",
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "writeOnly": true
         }
       }
     },
@@ -1452,7 +1456,8 @@ func init() {
               "description": "The hash value for the chart",
               "type": "string"
             }
-          }
+          },
+          "readOnly": true
         },
         "provenance": {
           "description": "The provenance entry associated with the signed Helm Chart",
@@ -1473,7 +1478,8 @@ func init() {
             "content": {
               "description": "Specifies the content of the provenance file inline within the document",
               "type": "string",
-              "format": "byte"
+              "format": "byte",
+              "writeOnly": true
             },
             "signature": {
               "description": "Information about the included signature in the provenance file",
@@ -1485,14 +1491,17 @@ func init() {
                 "content": {
                   "description": "Specifies the signature embedded within the provenance file ",
                   "type": "string",
-                  "format": "byte"
+                  "format": "byte",
+                  "readOnly": true
                 }
-              }
+              },
+              "readOnly": true
             },
             "url": {
               "description": "Specifies the location of the provenance file",
               "type": "string",
-              "format": "uri"
+              "format": "uri",
+              "writeOnly": true
             }
           }
         }
@@ -1517,7 +1526,8 @@ func init() {
           "description": "The hash value for the chart",
           "type": "string"
         }
-      }
+      },
+      "readOnly": true
     },
     "HelmV001SchemaChartProvenance": {
       "description": "The provenance entry associated with the signed Helm Chart",
@@ -1538,7 +1548,8 @@ func init() {
         "content": {
           "description": "Specifies the content of the provenance file inline within the document",
           "type": "string",
-          "format": "byte"
+          "format": "byte",
+          "writeOnly": true
         },
         "signature": {
           "description": "Information about the included signature in the provenance file",
@@ -1550,14 +1561,17 @@ func init() {
             "content": {
               "description": "Specifies the signature embedded within the provenance file ",
               "type": "string",
-              "format": "byte"
+              "format": "byte",
+              "readOnly": true
             }
-          }
+          },
+          "readOnly": true
         },
         "url": {
           "description": "Specifies the location of the provenance file",
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "writeOnly": true
         }
       }
     },
@@ -1571,9 +1585,11 @@ func init() {
         "content": {
           "description": "Specifies the signature embedded within the provenance file ",
           "type": "string",
-          "format": "byte"
+          "format": "byte",
+          "readOnly": true
         }
-      }
+      },
+      "readOnly": true
     },
     "HelmV001SchemaPublicKey": {
       "description": "The public key that can verify the package signature",
@@ -1599,7 +1615,8 @@ func init() {
         "url": {
           "description": "Specifies the location of the public key",
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "writeOnly": true
         }
       }
     },
@@ -1643,10 +1660,11 @@ func init() {
       "properties": {
         "envelope": {
           "description": "envelope",
-          "type": "string"
+          "type": "string",
+          "writeOnly": true
         },
         "hash": {
-          "description": "Specifies the hash algorithm and value encompassing the entire signed archive",
+          "description": "Specifies the hash algorithm and value encompassing the entire signed envelope",
           "type": "object",
           "required": [
             "algorithm",
@@ -1664,12 +1682,13 @@ func init() {
               "description": "The hash value for the archive",
               "type": "string"
             }
-          }
+          },
+          "readOnly": true
         }
       }
     },
     "IntotoV001SchemaContentHash": {
-      "description": "Specifies the hash algorithm and value encompassing the entire signed archive",
+      "description": "Specifies the hash algorithm and value encompassing the entire signed envelope",
       "type": "object",
       "required": [
         "algorithm",
@@ -1687,7 +1706,8 @@ func init() {
           "description": "The hash value for the archive",
           "type": "string"
         }
-      }
+      },
+      "readOnly": true
     },
     "JarV001SchemaArchive": {
       "description": "Information about the archive associated with the entry",
@@ -1708,7 +1728,8 @@ func init() {
         "content": {
           "description": "Specifies the archive inline within the document",
           "type": "string",
-          "format": "byte"
+          "format": "byte",
+          "writeOnly": true
         },
         "hash": {
           "description": "Specifies the hash algorithm and value encompassing the entire signed archive",
@@ -1734,7 +1755,8 @@ func init() {
         "url": {
           "description": "Specifies the location of the archive; if this is specified, a hash value must also be provided",
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "writeOnly": true
         }
       }
     },
@@ -1770,7 +1792,8 @@ func init() {
         "content": {
           "description": "Specifies the PKCS7 signature embedded within the JAR file ",
           "type": "string",
-          "format": "byte"
+          "format": "byte",
+          "readOnly": true
         },
         "publicKey": {
           "description": "The X509 certificate containing the public key JAR which verifies the signature of the JAR",
@@ -1784,7 +1807,8 @@ func init() {
               "type": "string",
               "format": "byte"
             }
-          }
+          },
+          "readOnly": true
         }
       }
     },
@@ -1800,7 +1824,8 @@ func init() {
           "type": "string",
           "format": "byte"
         }
-      }
+      },
+      "readOnly": true
     },
     "LogEntry": {
       "type": "object",
@@ -1941,7 +1966,8 @@ func init() {
         "content": {
           "description": "Specifies the content inline within the document",
           "type": "string",
-          "format": "byte"
+          "format": "byte",
+          "writeOnly": true
         },
         "hash": {
           "description": "Specifies the hash algorithm and value for the content",
@@ -1965,9 +1991,10 @@ func init() {
           }
         },
         "url": {
-          "description": "Specifies the location of the content; if this is specified, a hash value must also be provided",
+          "description": "Specifies the location of the content",
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "writeOnly": true
         }
       }
     },
@@ -2051,14 +2078,16 @@ func init() {
             "url": {
               "description": "Specifies the location of the public key",
               "type": "string",
-              "format": "uri"
+              "format": "uri",
+              "writeOnly": true
             }
           }
         },
         "url": {
           "description": "Specifies the location of the signature",
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "writeOnly": true
         }
       }
     },
@@ -2086,7 +2115,8 @@ func init() {
         "url": {
           "description": "Specifies the location of the public key",
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "writeOnly": true
         }
       }
     },
@@ -2123,7 +2153,8 @@ func init() {
         "content": {
           "description": "Specifies the package inline within the document",
           "type": "string",
-          "format": "byte"
+          "format": "byte",
+          "writeOnly": true
         },
         "hash": {
           "description": "Specifies the hash algorithm and value for the package",
@@ -2151,12 +2182,14 @@ func init() {
           "type": "object",
           "additionalProperties": {
             "type": "string"
-          }
+          },
+          "readOnly": true
         },
         "url": {
           "description": "Specifies the location of the package; if this is specified, a hash value must also be provided",
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "writeOnly": true
         }
       }
     },
@@ -2205,7 +2238,8 @@ func init() {
         "url": {
           "description": "Specifies the location of the public key",
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "writeOnly": true
         }
       }
     },
@@ -2368,7 +2402,8 @@ func init() {
             "content": {
               "description": "Specifies the package inline within the document",
               "type": "string",
-              "format": "byte"
+              "format": "byte",
+              "writeOnly": true
             },
             "hash": {
               "description": "Specifies the hash algorithm and value for the package",
@@ -2396,12 +2431,14 @@ func init() {
               "type": "object",
               "additionalProperties": {
                 "type": "string"
-              }
+              },
+              "readOnly": true
             },
             "url": {
               "description": "Specifies the location of the package; if this is specified, a hash value must also be provided",
               "type": "string",
-              "format": "uri"
+              "format": "uri",
+              "writeOnly": true
             }
           }
         },
@@ -2429,7 +2466,8 @@ func init() {
             "url": {
               "description": "Specifies the location of the public key",
               "type": "string",
-              "format": "uri"
+              "format": "uri",
+              "writeOnly": true
             }
           }
         }
@@ -2508,7 +2546,8 @@ func init() {
                   "description": "The hash value for the chart",
                   "type": "string"
                 }
-              }
+              },
+              "readOnly": true
             },
             "provenance": {
               "description": "The provenance entry associated with the signed Helm Chart",
@@ -2529,7 +2568,8 @@ func init() {
                 "content": {
                   "description": "Specifies the content of the provenance file inline within the document",
                   "type": "string",
-                  "format": "byte"
+                  "format": "byte",
+                  "writeOnly": true
                 },
                 "signature": {
                   "description": "Information about the included signature in the provenance file",
@@ -2541,14 +2581,17 @@ func init() {
                     "content": {
                       "description": "Specifies the signature embedded within the provenance file ",
                       "type": "string",
-                      "format": "byte"
+                      "format": "byte",
+                      "readOnly": true
                     }
-                  }
+                  },
+                  "readOnly": true
                 },
                 "url": {
                   "description": "Specifies the location of the provenance file",
                   "type": "string",
-                  "format": "uri"
+                  "format": "uri",
+                  "writeOnly": true
                 }
               }
             }
@@ -2583,7 +2626,8 @@ func init() {
             "url": {
               "description": "Specifies the location of the public key",
               "type": "string",
-              "format": "uri"
+              "format": "uri",
+              "writeOnly": true
             }
           }
         }
@@ -2642,10 +2686,11 @@ func init() {
           "properties": {
             "envelope": {
               "description": "envelope",
-              "type": "string"
+              "type": "string",
+              "writeOnly": true
             },
             "hash": {
-              "description": "Specifies the hash algorithm and value encompassing the entire signed archive",
+              "description": "Specifies the hash algorithm and value encompassing the entire signed envelope",
               "type": "object",
               "required": [
                 "algorithm",
@@ -2663,7 +2708,8 @@ func init() {
                   "description": "The hash value for the archive",
                   "type": "string"
                 }
-              }
+              },
+              "readOnly": true
             }
           }
         },
@@ -2745,7 +2791,8 @@ func init() {
             "content": {
               "description": "Specifies the archive inline within the document",
               "type": "string",
-              "format": "byte"
+              "format": "byte",
+              "writeOnly": true
             },
             "hash": {
               "description": "Specifies the hash algorithm and value encompassing the entire signed archive",
@@ -2771,7 +2818,8 @@ func init() {
             "url": {
               "description": "Specifies the location of the archive; if this is specified, a hash value must also be provided",
               "type": "string",
-              "format": "uri"
+              "format": "uri",
+              "writeOnly": true
             }
           }
         },
@@ -2791,7 +2839,8 @@ func init() {
             "content": {
               "description": "Specifies the PKCS7 signature embedded within the JAR file ",
               "type": "string",
-              "format": "byte"
+              "format": "byte",
+              "readOnly": true
             },
             "publicKey": {
               "description": "The X509 certificate containing the public key JAR which verifies the signature of the JAR",
@@ -2805,7 +2854,8 @@ func init() {
                   "type": "string",
                   "format": "byte"
                 }
-              }
+              },
+              "readOnly": true
             }
           }
         }
@@ -2878,7 +2928,8 @@ func init() {
             "content": {
               "description": "Specifies the content inline within the document",
               "type": "string",
-              "format": "byte"
+              "format": "byte",
+              "writeOnly": true
             },
             "hash": {
               "description": "Specifies the hash algorithm and value for the content",
@@ -2902,9 +2953,10 @@ func init() {
               }
             },
             "url": {
-              "description": "Specifies the location of the content; if this is specified, a hash value must also be provided",
+              "description": "Specifies the location of the content",
               "type": "string",
-              "format": "uri"
+              "format": "uri",
+              "writeOnly": true
             }
           }
         },
@@ -2972,14 +3024,16 @@ func init() {
                 "url": {
                   "description": "Specifies the location of the public key",
                   "type": "string",
-                  "format": "uri"
+                  "format": "uri",
+                  "writeOnly": true
                 }
               }
             },
             "url": {
               "description": "Specifies the location of the signature",
               "type": "string",
-              "format": "uri"
+              "format": "uri",
+              "writeOnly": true
             }
           }
         }
@@ -3125,7 +3179,8 @@ func init() {
             "content": {
               "description": "Specifies the package inline within the document",
               "type": "string",
-              "format": "byte"
+              "format": "byte",
+              "writeOnly": true
             },
             "hash": {
               "description": "Specifies the hash algorithm and value for the package",
@@ -3153,12 +3208,14 @@ func init() {
               "type": "object",
               "additionalProperties": {
                 "type": "string"
-              }
+              },
+              "readOnly": true
             },
             "url": {
               "description": "Specifies the location of the package; if this is specified, a hash value must also be provided",
               "type": "string",
-              "format": "uri"
+              "format": "uri",
+              "writeOnly": true
             }
           }
         },
@@ -3186,7 +3243,8 @@ func init() {
             "url": {
               "description": "Specifies the location of the public key",
               "type": "string",
-              "format": "uri"
+              "format": "uri",
+              "writeOnly": true
             }
           }
         }

--- a/pkg/types/alpine/v0.0.1/alpine_v0_0_1_schema.json
+++ b/pkg/types/alpine/v0.0.1/alpine_v0_0_1_schema.json
@@ -12,7 +12,8 @@
                 "url": {
                     "description": "Specifies the location of the public key",
                     "type": "string",
-                    "format": "uri"
+                    "format": "uri",
+                    "writeOnly": true
                 },
                 "content": {
                     "description": "Specifies the content of the public key inline within the document",
@@ -38,7 +39,8 @@
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
-                    }
+                    },
+                    "readOnly": true
                 },
                 "hash": {
                     "description": "Specifies the hash algorithm and value for the package",
@@ -59,12 +61,14 @@
                 "url": {
                     "description": "Specifies the location of the package; if this is specified, a hash value must also be provided",
                     "type": "string",
-                    "format": "uri"
+                    "format": "uri",
+                    "writeOnly": true
                 },
                 "content": {
                     "description": "Specifies the package inline within the document",
                     "type": "string",
-                    "format": "byte"
+                    "format": "byte",
+                    "writeOnly": true
                 }
             },
             "oneOf": [

--- a/pkg/types/helm/v0.0.1/entry.go
+++ b/pkg/types/helm/v0.0.1/entry.go
@@ -295,7 +295,7 @@ func (v *V001Entry) Canonicalize(ctx context.Context) ([]byte, error) {
 		return nil, err
 	}
 
-	canonicalEntry.Chart.Provenance.Signature.Content = (*strfmt.Base64)(&sigContent)
+	canonicalEntry.Chart.Provenance.Signature.Content = sigContent
 
 	// wrap in valid object with kind and apiVersion set
 	helmObj := models.Helm{}

--- a/pkg/types/helm/v0.0.1/helm_v0_0_1_schema.json
+++ b/pkg/types/helm/v0.0.1/helm_v0_0_1_schema.json
@@ -12,7 +12,8 @@
                 "url": {
                     "description": "Specifies the location of the public key",
                     "type": "string",
-                    "format": "uri"
+                    "format": "uri",
+                    "writeOnly": true
                 },
                 "content": {
                     "description": "Specifies the content of the public key inline within the document",
@@ -53,10 +54,8 @@
                             "type": "string"
                         }
                     },
-                    "required": [
-                        "algorithm",
-                        "value"
-                    ]
+                    "required": [ "algorithm", "value" ],
+                    "readOnly": true
                 },
                 "provenance": {
                     "description": "The provenance entry associated with the signed Helm Chart",
@@ -69,41 +68,37 @@
                                 "content": {
                                     "description": "Specifies the signature embedded within the provenance file ",
                                     "type": "string",
-                                    "format": "byte"
+                                    "format": "byte",
+                                    "readOnly": true
                                 }
                             },
-                            "required": [
-                                "content"
-                            ]
+                            "required": [ "content" ],
+                            "readOnly": true
                         },
                         "url": {
                             "description": "Specifies the location of the provenance file",
                             "type": "string",
-                            "format": "uri"
+                            "format": "uri",
+                            "writeOnly": true
                         },
                         "content": {
                             "description": "Specifies the content of the provenance file inline within the document",
                             "type": "string",
-                            "format": "byte"
+                            "format": "byte",
+                            "writeOnly": true
                         }
                     },
                     "oneOf": [
                         {
-                            "required": [
-                                "url"
-                            ]
+                            "required": [ "url" ]
                         },
                         {
-                            "required": [
-                                "content"
-                            ]
+                            "required": [ "content" ]
                         }
                     ]
                 }
             },
-            "required": [
-                "provenance"
-            ]
+            "required": [ "provenance" ]
         },
         "extraData": {
             "description": "Arbitrary content to be included in the verifiable entry in the transparency log",

--- a/pkg/types/intoto/v0.0.1/intoto_v0_0_1_schema.json
+++ b/pkg/types/intoto/v0.0.1/intoto_v0_0_1_schema.json
@@ -10,10 +10,11 @@
             "properties": {
                 "envelope": {
                     "description": "envelope",
-                    "type": "string"
+                    "type": "string",
+                    "writeOnly": true
                 },
                 "hash": {
-                    "description": "Specifies the hash algorithm and value encompassing the entire signed archive",
+                    "description": "Specifies the hash algorithm and value encompassing the entire signed envelope",
                     "type": "object",
                     "properties": {
                         "algorithm": {
@@ -31,7 +32,8 @@
                     "required": [
                         "algorithm",
                         "value"
-                    ]
+                    ],
+                    "readOnly": true
                 }
             }
         },

--- a/pkg/types/jar/v0.0.1/entry.go
+++ b/pkg/types/jar/v0.0.1/entry.go
@@ -240,7 +240,7 @@ func (v *V001Entry) Canonicalize(ctx context.Context) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	canonicalEntry.Signature.Content = (*strfmt.Base64)(&sigContent)
+	canonicalEntry.Signature.Content = sigContent
 
 	canonicalEntry.Archive = &models.JarV001SchemaArchive{}
 	canonicalEntry.Archive.Hash = &models.JarV001SchemaArchiveHash{}

--- a/pkg/types/jar/v0.0.1/jar_v0_0_1_schema.json
+++ b/pkg/types/jar/v0.0.1/jar_v0_0_1_schema.json
@@ -12,7 +12,8 @@
                 "content": {
                     "description": "Specifies the PKCS7 signature embedded within the JAR file ",
                     "type": "string",
-                    "format": "byte"
+                    "format": "byte",
+                    "readOnly": true
                 },
                 "publicKey" : {
                     "description": "The X509 certificate containing the public key JAR which verifies the signature of the JAR",
@@ -24,7 +25,8 @@
                             "format": "byte"
                         }
                     },
-                    "required": [ "content" ]
+                    "required": [ "content" ],
+                    "readOnly": true
                 }
             },
             "required": [ "publicKey", "content" ]
@@ -52,12 +54,14 @@
                 "url": {
                     "description": "Specifies the location of the archive; if this is specified, a hash value must also be provided",
                     "type": "string",
-                    "format": "uri"
+                    "format": "uri",
+                    "writeOnly": true
                 },
                 "content": {
                     "description": "Specifies the archive inline within the document",
                     "type": "string",
-                    "format": "byte"
+                    "format": "byte",
+                    "writeOnly": true
                 }
             },
             "oneOf": [

--- a/pkg/types/rekord/v0.0.1/rekord_v0_0_1_schema.json
+++ b/pkg/types/rekord/v0.0.1/rekord_v0_0_1_schema.json
@@ -17,7 +17,8 @@
                 "url": {
                     "description": "Specifies the location of the signature",
                     "type": "string",
-                    "format": "uri"
+                    "format": "uri",
+                    "writeOnly": true
                 },
                 "content": {
                     "description": "Specifies the content of the signature inline within the document",
@@ -31,7 +32,8 @@
                         "url": {
                             "description": "Specifies the location of the public key",
                             "type": "string",
-                            "format": "uri"
+                            "format": "uri",
+                            "writeOnly": true
                         },
                         "content": {
                             "description": "Specifies the content of the public key inline within the document",
@@ -79,14 +81,16 @@
                     "required": [ "algorithm", "value" ]
                 },
                 "url": {
-                    "description": "Specifies the location of the content; if this is specified, a hash value must also be provided",
+                    "description": "Specifies the location of the content",
                     "type": "string",
-                    "format": "uri"
+                    "format": "uri",
+                    "writeOnly": true
                 },
                 "content": {
                     "description": "Specifies the content inline within the document",
                     "type": "string",
-                    "format": "byte"
+                    "format": "byte",
+                    "writeOnly": true
                 }
             },
             "oneOf": [

--- a/pkg/types/rpm/v0.0.1/rpm_v0_0_1_schema.json
+++ b/pkg/types/rpm/v0.0.1/rpm_v0_0_1_schema.json
@@ -12,7 +12,8 @@
                 "url": {
                     "description": "Specifies the location of the public key",
                     "type": "string",
-                    "format": "uri"
+                    "format": "uri",
+                    "writeOnly": true
                 },
                 "content": {
                     "description": "Specifies the content of the public key inline within the document",
@@ -38,7 +39,8 @@
                     "type": "object",
                     "additionalProperties": {
                         "type": "string"
-                    }
+                    },
+                    "readOnly": true
                 },
                 "hash": {
                     "description": "Specifies the hash algorithm and value for the package",
@@ -59,12 +61,14 @@
                 "url": {
                     "description": "Specifies the location of the package; if this is specified, a hash value must also be provided",
                     "type": "string",
-                    "format": "uri"
+                    "format": "uri",
+                    "writeOnly": true
                 },
                 "content": {
                     "description": "Specifies the package inline within the document",
                     "type": "string",
-                    "format": "byte"
+                    "format": "byte",
+                    "writeOnly": true
                 }
             },
             "oneOf": [


### PR DESCRIPTION
The only functional part of this change is in the elements specified as `readOnly: true`, any incoming request to the Rekor API should return a 400 Bad Request error. 

This helps with being a bit clearer around the difference between what should be provided in a request VS what is stored in the log. 

Signed-off-by: Bob Callaway <bob.callaway@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
