### PR TITLE
fix 0 log index

### DIFF
--- a/cmd/rekor-cli/app/pflags.go
+++ b/cmd/rekor-cli/app/pflags.go
@@ -195,7 +195,7 @@ func validateLogIndex(v string) error {
 		return err
 	}
 	l := struct {
-		Index int `validate:"required,gte=0"`
+		Index int `validate:"gte=0"`
 	}{i}
 
 	return useValidator(logIndexFlag, l)

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -192,6 +192,9 @@ func TestGet(t *testing.T) {
 
 	uuid := getUUIDFromUploadOutput(t, out)
 
+	// since we at least have 1 valid entry, check the log at index 0
+	runCli(t, "get", "--log-index", "0")
+
 	out = runCli(t, "get", "--format=json", "--uuid", uuid)
 
 	// The output here should be in JSON with this structure:


### PR DESCRIPTION
adding the `required` flag removed support for the default `int` value which is of course 0. Removing it and adding a check to ensure this works going forward.

Fixes #384 

Signed-off-by: Bob Callaway <bob.callaway@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
