### PR TITLE
makefile: add rule to download and set swagger and make rule to build rekor-cli for cross platform

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,10 +32,8 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GOVERSION }}
-      - name: download go-swagger
-        run : go install github.com/go-swagger/go-swagger/cmd/swagger@v0.27.0
       - name: Validate OpenAPI with Swagger
-        run: swagger validate openapi.yaml
+        run: make validate-openapi
       - name: Build
         run: make -C $GITHUB_WORKSPACE all
       - name: Test

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ logid
 /tests/rekor-server
 /server
 swagger
+dist/*
+hack/*

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,10 @@ $(GENSRC): $(SWAGGER) $(OPENAPIDEPS)
 	$(SWAGGER) generate client -f openapi.yaml -q -r COPYRIGHT.txt -t pkg/generated --default-consumes application/json\;q=1
 	$(SWAGGER) generate server -f openapi.yaml -q -r COPYRIGHT.txt -t pkg/generated --exclude-main -A rekor_server --exclude-spec --flag-strategy=pflag --default-produces application/json
 
+.PHONY: validate-openapi
+validate-openapi: $(SWAGGER)
+	$(SWAGGER) validate openapi.yaml
+
 # this exists to override pattern match rule above since this file is in the generated directory but should not be treated as generated code
 pkg/generated/restapi/configure_rekor_server.go: $(OPENAPIDEPS)
 	

--- a/scripts/go_install.sh
+++ b/scripts/go_install.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Copyright 2020 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [ -z "${1}" ]; then
+  echo "must provide module as first parameter"
+  exit 1
+fi
+
+if [ -z "${2}" ]; then
+  echo "must provide binary name as second parameter"
+  exit 1
+fi
+
+if [ -z "${3}" ]; then
+  echo "must provide version as third parameter"
+  exit 1
+fi
+
+if [ -z "${GOBIN}" ]; then
+  echo "GOBIN is not set. Must set GOBIN to install the bin in a specified directory."
+  exit 1
+fi
+
+tmp_dir=$(mktemp -d -t goinstall_XXXXXXXXXX)
+function clean {
+  rm -rf "${tmp_dir}"
+}
+trap clean EXIT
+
+rm "${GOBIN}/${2}"* || true
+
+cd "${tmp_dir}"
+
+# create a new module in the tmp directory
+go mod init fake/mod
+
+# install the golang module specified as the first argument
+go get -tags tools "${1}@${3}"
+mv "${GOBIN}/${2}" "${GOBIN}/${2}-${3}"
+ln -sf "${GOBIN}/${2}-${3}" "${GOBIN}/${2}"


### PR DESCRIPTION
- this adds a way to automatically download the swagger in the specific version we care and don't mess with go modules for the project.
- also add rule to cross build rekor-cli for other linux/darwin/windows