### PR TITLE
fix pre-formed entry upload

### DIFF
--- a/cmd/rekor-cli/app/upload.go
+++ b/cmd/rekor-cli/app/upload.go
@@ -19,14 +19,15 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/sha256"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 
 	"github.com/cyberphone/json-canonicalization/go/src/webpki.org/jsoncanonicalizer"
+	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/swag"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -81,7 +82,7 @@ var uploadCmd = &cobra.Command{
 
 		entryStr := viper.GetString("entry")
 		if entryStr != "" {
-			var entryBytes []byte
+			var entryReader io.Reader
 			entryURL, err := url.Parse(entryStr)
 			if err == nil && entryURL.IsAbs() {
 				/* #nosec G107 */
@@ -90,17 +91,15 @@ var uploadCmd = &cobra.Command{
 					return nil, fmt.Errorf("error fetching entry: %w", err)
 				}
 				defer entryResp.Body.Close()
-				entryBytes, err = ioutil.ReadAll(entryResp.Body)
-				if err != nil {
-					return nil, fmt.Errorf("error fetching entry: %w", err)
-				}
+				entryReader = entryResp.Body
 			} else {
-				entryBytes, err = ioutil.ReadFile(filepath.Clean(entryStr))
+				entryReader, err = os.Open(filepath.Clean(entryStr))
 				if err != nil {
 					return nil, fmt.Errorf("error processing entry file: %w", err)
 				}
 			}
-			if err := json.Unmarshal(entryBytes, &entry); err != nil {
+			entry, err = models.UnmarshalProposedEntry(entryReader, runtime.JSONConsumer())
+			if err != nil {
 				return nil, fmt.Errorf("error parsing entry file: %w", err)
 			}
 		} else {

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -756,3 +756,47 @@ func rekorTimestampCertChain(t *testing.T, ctx context.Context, c *genclient.Rek
 	}
 	return certificates
 }
+
+func TestEntryUpload(t *testing.T) {
+	artifactPath := filepath.Join(t.TempDir(), "artifact")
+	sigPath := filepath.Join(t.TempDir(), "signature.asc")
+
+	createdPGPSignedArtifact(t, artifactPath, sigPath)
+	payload, _ := ioutil.ReadFile(artifactPath)
+	sig, _ := ioutil.ReadFile(sigPath)
+
+	// Create the entry file
+	entryPath := filepath.Join(t.TempDir(), "entry.json")
+
+	re := rekord.V001Entry{
+		RekordObj: models.RekordV001Schema{
+			Data: &models.RekordV001SchemaData{
+				Content: strfmt.Base64(payload),
+			},
+			Signature: &models.RekordV001SchemaSignature{
+				Content: strfmt.Base64(sig),
+				Format:  models.RekordV001SchemaSignatureFormatPgp,
+				PublicKey: &models.RekordV001SchemaSignaturePublicKey{
+					Content: strfmt.Base64([]byte(publicKey)),
+				},
+			},
+		},
+	}
+
+	returnVal := models.Rekord{
+		APIVersion: swag.String(re.APIVersion()),
+		Spec:       re.RekordObj,
+	}
+	entryBytes, err := json.Marshal(returnVal)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if err := ioutil.WriteFile(entryPath, entryBytes, 0644); err != nil {
+		t.Error(err)
+	}
+
+	// Now upload to rekor!
+	out := runCli(t, "upload", "--entry", entryPath)
+	outputContains(t, out, "Created entry at")
+}


### PR DESCRIPTION
When a CLI user has a JSON object representing a full proposed entry for Rekor, they should be able to pass it to the `rekor-cli upload` command using the `--entry` flag. However, the unmarshaling needs to be done in multiple stages to find the actual implementation for `models.ProposedEntry` interface. 

Signed-off-by: Bob Callaway <bob.callaway@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
