### PR TITLE
makefile: small fix on the makefile for the rekor-server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,8 @@ dist-cli:
 
 .PHONY: dist-server
 dist-server:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags $(SERVER_LDFLAGS) -o rekor-server ./cmd/rekor-server
+	mkdir -p dist/
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags $(SERVER_LDFLAGS) -o dist/rekor-server-linux-amd64 ./cmd/rekor-server
 
 .PHONY: dist
 dist: dist-server dist-cli


### PR DESCRIPTION
when running the release 0.3.0 notice the rule to build the binaries for the server was wrong and not following the similar pattern that has for rekor-cli.

this fix that and make the `dist-server` similar to the `dist-cli`
