### PR TITLE
rekor-server: add html page when humans reach the server via the browser

### DIFF
--- a/pkg/generated/restapi/rekorHomePage.html
+++ b/pkg/generated/restapi/rekorHomePage.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en-us">
+
+<head>
+  <meta property="og:title" content="sigstore" />
+  <meta property="og:description" content="A non-profit, public good software signing &amp; transparency service" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="/" />
+  <meta name="description" content="A non-profit, public good software signing &amp; transparency service" />
+  <meta charset="utf-8">
+  <title>sigstore</title>
+
+  <link href="https://fonts.googleapis.com/css?family=Catamaran:400,600" rel="stylesheet">
+</head>
+
+<body>
+  <h1>
+    Rekor Server
+  </h1>
+  <h2>
+    A non-profit, public good software signing &amp; transparency service.
+    <p>To learn more visit <a href="https://sigstore.dev">Sigstore project page</a></p>
+  </h2>
+  <footer>
+    <p>Copyright © sigstore a Series of LF Projects, LLC For web site terms of use, trademark policy and general project
+      policies please see <a href="https://lfprojects.org">https://lfprojects.org</a>.
+      <p />
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
Applying similar work did in Fulcio in this PR https://github.com/sigstore/fulcio/pull/145

when users access via browser the rekor page they see, ie: https://rekor.sigstore.dev/

```
{
  "code": 404,
  "message": "path / was not found"
}
```

This PR adds a simple webpage to show to the user