### PR TITLE
Fix port flag override

### DIFF
--- a/cmd/rekor-server/app/root.go
+++ b/cmd/rekor-server/app/root.go
@@ -64,7 +64,7 @@ func init() {
 	rootCmd.PersistentFlags().String("rekor_server.signer", "memory", "Rekor signer to use. Current valid options include: [gcpkms, memory]")
 	rootCmd.PersistentFlags().String("rekor_server.timestamp_chain", "", "PEM encoded cert chain to use for timestamping")
 
-	rootCmd.PersistentFlags().Uint16("rekor_server.port", 3000, "Port to bind to")
+	rootCmd.PersistentFlags().Uint16("port", 3000, "Port to bind to")
 
 	rootCmd.PersistentFlags().Bool("enable_retrieve_api", true, "enables Redis-based index API endpoint")
 	rootCmd.PersistentFlags().String("redis_server.address", "127.0.0.1", "Redis server address")

--- a/cmd/rekor-server/app/serve.go
+++ b/cmd/rekor-server/app/serve.go
@@ -93,7 +93,7 @@ var serveCmd = &cobra.Command{
 		}
 
 		server.Host = viper.GetString("rekor_server.address")
-		server.Port = int(viper.GetUint("rekor_server.port"))
+		server.Port = int(viper.GetUint("port"))
 		server.EnabledListeners = []string{"http"}
 
 		api.ConfigureAPI()

--- a/cmd/rekor-server/app/watch.go
+++ b/cmd/rekor-server/app/watch.go
@@ -64,7 +64,7 @@ var watchCmd = &cobra.Command{
 		_ = flag.CommandLine.Parse([]string{})
 
 		host := viper.GetString("rekor_server.address")
-		port := viper.GetUint("rekor_server.port")
+		port := viper.GetUint("port")
 		interval := viper.GetDuration("interval")
 		url := fmt.Sprintf("http://%s:%d", host, port)
 		c, err := client.GetRekorClient(url)

--- a/config/watcher.yaml
+++ b/config/watcher.yaml
@@ -43,7 +43,7 @@ spec:
         args: [
           "watch",
           "--rekor_server.address=rekor-server",
-          "--rekor_server.port=80",
+          "--port=80",
           "--log_type=prod",
         ]
         env:


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
Closes https://github.com/sigstore/rekor/issues/234

We got two flags `port` (as a result of go-openapi to generate code for the server) and `rekor_server.port`. It was confusing to users, so I decided to go with the override of the `--port` flag but using the original default `3000`. With this change we don't need anymore a second flag `rekor_server.port`.

