### PR TITLE
version: add way to display a version when using go get or go install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,10 @@ endif
 SWAGGER := $(TOOLS_BIN_DIR)/swagger
 
 CLI_PKG=github.com/sigstore/rekor/cmd/rekor-cli/app
-CLI_LDFLAGS="-X $(CLI_PKG).gitVersion=$(GIT_VERSION) -X $(CLI_PKG).gitCommit=$(GIT_HASH) -X $(CLI_PKG).gitTreeState=$(GIT_TREESTATE) -X $(CLI_PKG).buildDate=$(BUILD_DATE)"
+CLI_LDFLAGS="-X $(CLI_PKG).GitVersion=$(GIT_VERSION) -X $(CLI_PKG).gitCommit=$(GIT_HASH) -X $(CLI_PKG).gitTreeState=$(GIT_TREESTATE) -X $(CLI_PKG).buildDate=$(BUILD_DATE)"
 
 SERVER_PKG=github.com/sigstore/rekor/cmd/rekor-server/app
-SERVER_LDFLAGS="-X $(SERVER_PKG).gitVersion=$(GIT_VERSION) -X $(SERVER_PKG).gitCommit=$(GIT_HASH) -X $(SERVER_PKG).gitTreeState=$(GIT_TREESTATE) -X $(SERVER_PKG).buildDate=$(BUILD_DATE)"
+SERVER_LDFLAGS="-X $(SERVER_PKG).GitVersion=$(GIT_VERSION) -X $(SERVER_PKG).gitCommit=$(GIT_HASH) -X $(SERVER_PKG).gitTreeState=$(GIT_TREESTATE) -X $(SERVER_PKG).buildDate=$(BUILD_DATE)"
 
 $(GENSRC): $(SWAGGER) $(OPENAPIDEPS)
 	$(SWAGGER) generate client -f openapi.yaml -q -r COPYRIGHT.txt -t pkg/generated --default-consumes application/json\;q=1

--- a/cmd/rekor-cli/app/root.go
+++ b/cmd/rekor-cli/app/root.go
@@ -17,6 +17,7 @@ package app
 
 import (
 	"fmt"
+	"runtime/debug"
 	"strings"
 
 	homedir "github.com/mitchellh/go-homedir"
@@ -67,6 +68,19 @@ func init() {
 	if err := viper.BindPFlags(rootCmd.PersistentFlags()); err != nil {
 		log.CliLogger.Fatal(err)
 	}
+
+	// look for the default version and replace it, if found, from runtime build info
+	if GitVersion != "devel" {
+		return
+	}
+
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	// Version is set in artifacts built with -X github.com/sigstore/rekor/cmd/rekor-cli/app.GitVersion=1.2.3
+	// Ensure version is also set when installed via go install github.com/sigstore/rekor/cmd/rekor-cli
+	GitVersion = bi.Main.Version
 }
 
 func initConfig(cmd *cobra.Command) error {

--- a/cmd/rekor-cli/app/version.go
+++ b/cmd/rekor-cli/app/version.go
@@ -33,7 +33,7 @@ import (
 var (
 	// Output of "git describe". The prerequisite is that the branch should be
 	// tagged using the correct versioning strategy.
-	gitVersion = "unknown"
+	GitVersion string = "devel"
 	// SHA1 from git, output of $(git rev-parse HEAD)
 	gitCommit = "unknown"
 	// State of git tree, either "clean" or "dirty"
@@ -93,7 +93,7 @@ func VersionInfo() Info {
 	// These variables typically come from -ldflags settings and in
 	// their absence fallback to the global defaults set above.
 	return Info{
-		GitVersion:   gitVersion,
+		GitVersion:   GitVersion,
 		GitCommit:    gitCommit,
 		GitTreeState: gitTreeState,
 		BuildDate:    buildDate,

--- a/cmd/rekor-server/app/root.go
+++ b/cmd/rekor-server/app/root.go
@@ -18,6 +18,7 @@ package app
 import (
 	"fmt"
 	"os"
+	"runtime/debug"
 
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
@@ -79,6 +80,19 @@ func init() {
 	}
 
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+	// look for the default version and replace it, if found, from runtime build info
+	if GitVersion != "devel" {
+		return
+	}
+
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	// Version is set in artifacts built with -X github.com/sigstore/rekor/cmd/rekor-server/app.GitVersion=1.2.3
+	// Ensure version is also set when installed via go install github.com/sigstore/rekor/cmd/rekor-server
+	GitVersion = bi.Main.Version
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/rekor-server/app/version.go
+++ b/cmd/rekor-server/app/version.go
@@ -33,7 +33,7 @@ import (
 var (
 	// Output of "git describe". The prerequisite is that the branch should be
 	// tagged using the correct versioning strategy.
-	gitVersion = "unknown"
+	GitVersion string = "devel"
 	// SHA1 from git, output of $(git rev-parse HEAD)
 	gitCommit = "unknown"
 	// State of git tree, either "clean" or "dirty"
@@ -93,7 +93,7 @@ func VersionInfo() Info {
 	// These variables typically come from -ldflags settings and in
 	// their absence fallback to the global defaults set above.
 	return Info{
-		GitVersion:   gitVersion,
+		GitVersion:   GitVersion,
 		GitCommit:    gitCommit,
 		GitTreeState: gitTreeState,
 		BuildDate:    buildDate,


### PR DESCRIPTION
Add a way to display the version when using `go install`/ `go get`

Fixes: https://github.com/sigstore/rekor/issues/212


/cc @invidian @lukehinds @dlorenc  

