### PR TITLE
Fix unmarshalling an STH

### DIFF
--- a/pkg/util/checkpoint.go
+++ b/pkg/util/checkpoint.go
@@ -49,7 +49,7 @@ func (c Checkpoint) String() string {
 }
 
 // MarshalText returns the common format representation of this Checkpoint.
-func (c Checkpoint) MarshalText() ([]byte, error) {
+func (c Checkpoint) MarshalCheckpoint() ([]byte, error) {
 	return []byte(c.String()), nil
 }
 
@@ -65,7 +65,7 @@ func (c Checkpoint) MarshalText() ([]byte, error) {
 // <optional non-empty line of other content>...
 //
 // This will discard any content found after the checkpoint (including signatures)
-func (c *Checkpoint) UnmarshalText(data []byte) error {
+func (c *Checkpoint) UnmarshalCheckpoint(data []byte) error {
 	l := bytes.Split(data, []byte("\n"))
 	if len(l) < 4 {
 		return errors.New("invalid checkpoint - too few newlines")
@@ -104,7 +104,7 @@ type SignedCheckpoint struct {
 }
 
 func CreateSignedCheckpoint(c Checkpoint) (*SignedCheckpoint, error) {
-	text, err := c.MarshalText()
+	text, err := c.MarshalCheckpoint()
 	if err != nil {
 		return nil, err
 	}
@@ -120,12 +120,12 @@ func SignedCheckpointValidator(strToValidate string) bool {
 		return false
 	}
 	c := &Checkpoint{}
-	return c.UnmarshalText([]byte(s.Note)) == nil
+	return c.UnmarshalCheckpoint([]byte(s.Note)) == nil
 }
 
 func CheckpointValidator(strToValidate string) bool {
 	c := &Checkpoint{}
-	return c.UnmarshalText([]byte(strToValidate)) == nil
+	return c.UnmarshalCheckpoint([]byte(strToValidate)) == nil
 }
 
 func (r *SignedCheckpoint) UnmarshalText(data []byte) error {
@@ -134,7 +134,7 @@ func (r *SignedCheckpoint) UnmarshalText(data []byte) error {
 		return errors.Wrap(err, "unmarshalling signed note")
 	}
 	c := Checkpoint{}
-	if err := c.UnmarshalText([]byte(s.Note)); err != nil {
+	if err := c.UnmarshalCheckpoint([]byte(s.Note)); err != nil {
 		return errors.Wrap(err, "unmarshalling checkpoint")
 	}
 	*r = SignedCheckpoint{Checkpoint: c, SignedNote: s}

--- a/pkg/util/checkpoint_test.go
+++ b/pkg/util/checkpoint_test.go
@@ -62,7 +62,7 @@ func TestMarshalCheckpoint(t *testing.T) {
 		},
 	} {
 		t.Run(string(test.c.Hash), func(t *testing.T) {
-			got, err := test.c.MarshalText()
+			got, err := test.c.MarshalCheckpoint()
 			if err != nil {
 				t.Fatalf("unexpected error marshalling: %v", err)
 			}
@@ -155,7 +155,7 @@ func TestUnmarshalCheckpoint(t *testing.T) {
 		t.Run(string(test.desc), func(t *testing.T) {
 			var got Checkpoint
 			var gotErr error
-			if gotErr = got.UnmarshalText([]byte(test.m)); (gotErr != nil) != test.wantErr {
+			if gotErr = got.UnmarshalCheckpoint([]byte(test.m)); (gotErr != nil) != test.wantErr {
 				t.Fatalf("Unmarshal = %q, wantErr: %T", gotErr, test.wantErr)
 			}
 			if diff := cmp.Diff(test.want, got); len(diff) != 0 {
@@ -274,7 +274,7 @@ func TestSigningRoundtripCheckpoint(t *testing.T) {
 		},
 	} {
 		t.Run(string(test.c.Ecosystem), func(t *testing.T) {
-			text, _ := test.c.MarshalText()
+			text, _ := test.c.MarshalCheckpoint()
 			sc := &SignedNote{
 				Note: string(text),
 			}
@@ -307,7 +307,7 @@ func TestSigningRoundtripCheckpoint(t *testing.T) {
 				if err != nil {
 					t.Fatalf("error during marshalling: %v", err)
 				}
-				text, _ = test.c.MarshalText()
+				text, _ = test.c.MarshalCheckpoint()
 				sc2 := &SignedNote{
 					Note: string(text),
 				}
@@ -375,7 +375,7 @@ func TestInvalidSigVerification(t *testing.T) {
 		},
 	} {
 		t.Run(string(test.checkpoint.Ecosystem), func(t *testing.T) {
-			text, _ := test.checkpoint.MarshalText()
+			text, _ := test.checkpoint.MarshalCheckpoint()
 			sc := SignedNote{
 				Note:       string(text),
 				Signatures: test.s,


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

Fixed unmarshalling a util.SignedCheckpoint, which contianed embedded structs with their own UnmarshalText methods.

Renames  UnmarshalCheckpoint that we call internally anyway
