### PR TITLE
Updates to INSTALLATION.md notes

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -80,6 +80,10 @@ go install github.com/google/trillian/cmd/trillian_log_server@v1.3.14-0.20210713
 go install github.com/google/trillian/cmd/trillian_log_signer@v1.3.14-0.20210713114448-df474653733c
 ```
 
+```
+go install github.com/google/trillian/cmd/createtree@v1.3.14-0.20210713114448-df474653733c
+```
+
 ## Run trillian
 
 First run the trillian log server
@@ -92,6 +96,12 @@ Now run the signer:
 
 ```
 trillian_log_signer --logtostderr --force_master --http_endpoint=localhost:8191 -rpc_endpoint=localhost:8190  --batch_size=1000 --sequencer_guard_window=0 --sequencer_interval=200ms
+```
+
+Create tree:
+
+```
+createtree --admin_server=localhost:8090
 ```
 
 ## Run Rekor

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -85,25 +85,24 @@ go install github.com/google/trillian/cmd/trillian_log_signer@v1.3.14-0.20210713
 First run the trillian log server
 
 ```
-trillian_log_server -http_endpoint=localhost:8090 -rpc_endpoint=localhost:8091 --logtostderr ... 
+trillian_log_server -http_endpoint=localhost:8091 -rpc_endpoint=localhost:8090 --logtostderr ...
 ```
 
 Now run the signer:
 
 ```
-trillian_log_signer --logtostderr --force_master --http_endpoint=localhost:8190 -rpc_endpoint=localhost:8191  --batch_size=1000 --sequencer_guard_window=0 --sequencer_interval=200ms
+trillian_log_signer --logtostderr --force_master --http_endpoint=localhost:8191 -rpc_endpoint=localhost:8190  --batch_size=1000 --sequencer_guard_window=0 --sequencer_interval=200ms
 ```
 
 ## Run Rekor
 
 We are now ready to run rekor.
 
+```
+rekor-server serve --rekor_server.address=0.0.0.0 --rekor_server.port=3000 --enable_retrieve_api=false
+```
 > :notebook: If you want a quick handy search index, then you will need to install redis-server
-   if you choose not to, then you must pass the argument `--enable_retrieve_api` false.
-
-```
-rekor-server serve --rekor_server.address=0.0.0.0 --rekor_server.port=3000
-```
+   and remove the argument `--enable_retrieve_api=false`.
 
 Example:
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

## Description

I was walking through the installation of rekor locally and had some discrepancies about getting it started from the existing INSTALLATION.md docs. Im not sure if this is something thats an oversight on my part or not but raising up this PR from what I found to work.

## Previous Behavior
1. cli example default assumes redis when starting the `rekor-server` but doesnt mention it in `set up`
2. Docs do not reflect changes that were made to the rest of the codebase for default trillian ports:  https://github.com/sigstore/rekor/pull/312
3. Without creating the tree via `createtree` I got the following when trying to start the `rekor-server`:

```
$ rekor-server serve --rekor_server.address=localhost

2021-08-18T02:50:34.828Z INFO app/serve.go:66 starting rekor-server @ {
 "GitVersion": "v0.3.0", 
 "GitCommit": "unknown", 
 "GitTreeState": "unknown",
 "BuildDate": "unknown",
 "GoVersion": "go1.16.7", 
 "Compiler": "gc", 
 "Platform": "linux/amd64" 
} 

2021-08-18T02:50:34.849Z INFO app/serve.go:91 Loading support for pluggable type 'rekord'
2021-08-18T02:50:34.849Z INFO app/serve.go:92 Loading version '0.0.1' for pluggable type 'rekord'
2021-08-18T02:50:34.849Z INFO app/serve.go:91 Loading support for pluggable type 'rpm'
2021-08-18T02:50:34.849Z INFO app/serve.go:92 Loading version '0.0.1' for pluggable type 'rpm'
2021-08-18T02:50:34.849Z INFO app/serve.go:91 Loading support for pluggable type 'jar'
2021-08-18T02:50:34.849Z INFO app/serve.go:92 Loading version '0.0.1' for pluggable type 'jar'
2021-08-18T02:50:34.849Z INFO app/serve.go:91 Loading support for pluggable type 'intoto' 
2021-08-18T02:50:34.849Z INFO app/serve.go:92 Loading version '0.0.1' for pluggable type 'intoto'
2021-08-18T02:50:34.849Z INFO app/serve.go:91 Loading support for pluggable type 'rfc3161'
2021-08-18T02:50:34.849Z INFO app/serve.go:92 Loading version '0.0.1' for pluggable type 'rfc3161'
2021-08-18T02:50:34.849Z INFO app/serve.go:91 Loading support for pluggable type 'alpine'
2021-08-18T02:50:34.849Z INFO app/serve.go:92 Loading version '0.0.1' for pluggable type 'alpine'
2021-08-18T02:50:34.849Z INFO app/serve.go:91 Loading support for pluggable type 'helm'
2021-08-18T02:50:34.849Z INFO app/serve.go:92 Loading version '0.0.1' for pluggable type 'helm'
2021-08-18T02:50:34.853Z PANIC api/api.go:162 create and init tree: create tree: rpc error: code = InvalidArgument desc = failed to create hasher for tree: LogHasher(UNKNOWN_HASH_STRATEGY) is an unknown hasher

      

github.com/sigstore/rekor/pkg/api.ConfigureAPI
 github.com/sigstore/rekor/pkg/api/api.go:162 github.com/sigstore/rekor/cmd/rekor-server/app.glob..func1
 github.com/sigstore/rekor/cmd/rekor-server/app/serve.go:99
github.com/spf13/cobra.(*Command).execute
 github.com/spf13/cobra@v1.2.1/command.go:860
github.com/spf13/cobra.(*Command).ExecuteC
 github.com/spf13/cobra@v1.2.1/command.go:974
github.com/spf13/cobra.(*Command).Execute
 github.com/spf13/cobra@v1.2.1/command.go:902
github.com/sigstore/rekor/cmd/rekor-server/app.Execute
 github.com/sigstore/rekor/cmd/rekor-server/app/root.go:47
main.main
 github.com/sigstore/rekor/cmd/rekor-server/main.go:21
runtime.main
 runtime/proc.go:225
panic: create and init tree: create tree: rpc error: code = InvalidArgument desc = failed to create hasher for tree: LogHasher(UNKNOWN_HASH_STRATEGY) is an unknown hasher
  

goroutine 1 [running]:
go.uber.org/zap/zapcore.(*CheckedEntry).Write(0xc0001c00c0, 0x0, 0x0, 0x0)
 go.uber.org/zap@v1.18.1/zapcore/entry.go:234 +0x532
go.uber.org/zap.(*SugaredLogger).log(0xc0001428e8, 0x136e004, 0x0, 0x0, 0xc00061f960, 0x1, 0x1, 0x0, 0x0, 0x0)
 go.uber.org/zap@v1.18.1/sugar.go:227 +0x111
go.uber.org/zap.(*SugaredLogger).Panic(...)
 go.uber.org/zap@v1.18.1/sugar.go:123
github.com/sigstore/rekor/pkg/api.ConfigureAPI()
 github.com/sigstore/rekor/pkg/api/api.go:162 +0x112
github.com/sigstore/rekor/cmd/rekor-server/app.glob..func1(0x1a3fbc0, 0xc00022beb0, 0x0, 0x1)
 github.com/sigstore/rekor/cmd/rekor-server/app/serve.go:99 +0x80e
github.com/spf13/cobra.(*Command).execute(0x1a3fbc0, 0xc00022bea0, 0x1, 0x1, 0x1a3fbc0, 0xc00022bea0)
 github.com/spf13/cobra@v1.2.1/command.go:860 +0x2c2
github.com/spf13/cobra.(*Command).ExecuteC(0x1a3f940, 0xc00005c740, 0x46f285, 0xc000000180)
 github.com/spf13/cobra@v1.2.1/command.go:974 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
 github.com/spf13/cobra@v1.2.1/command.go:902
github.com/sigstore/rekor/cmd/rekor-server/app.Execute()
 github.com/sigstore/rekor/cmd/rekor-server/app/root.go:47 +0x31
main.main()
 github.com/sigstore/rekor/cmd/rekor-server/main.go:21 +0x25
 ```

## New Behavior
1. Don't assume that `redis` is going to be available while following INSTALLATION.md. Alternatively, if the projects wants to call out `redis` as a requirement for set up then I think it should do so in more than single existing note.
2. Ports for trillian now match: https://github.com/sigstore/rekor/pull/312 and https://github.com/sigstore/sigstore.github.io/blob/gh-pages/content/get_started/server.md
3. Levering `createtree` to fix the initial `rpc error: code = InvalidArgument desc = failed to create hasher for tree: LogHasher(UNKNOWN_HASH_STRATEGY) is an unknown hasher` while starting `rekor`

## Test

Server now runs as expected:
```
$ rekor-server serve --rekor_server.address=localhost --rekor_server.port=3000 --enable_retrieve_api=false
2021-08-18T10:30:36.331Z        INFO    app/serve.go:66 starting rekor-server @ {
  "GitVersion": "v0.3.0",
  "GitCommit": "unknown",
  "GitTreeState": "unknown",
  "BuildDate": "unknown",
  "GoVersion": "go1.16.7",
  "Compiler": "gc",
  "Platform": "linux/amd64"
}
2021-08-18T10:30:36.366Z        INFO    app/serve.go:91 Loading support for pluggable type 'rpm'
2021-08-18T10:30:36.366Z        INFO    app/serve.go:92 Loading version '0.0.1' for pluggable type 'rpm'
2021-08-18T10:30:36.366Z        INFO    app/serve.go:91 Loading support for pluggable type 'jar'
2021-08-18T10:30:36.366Z        INFO    app/serve.go:92 Loading version '0.0.1' for pluggable type 'jar'
2021-08-18T10:30:36.366Z        INFO    app/serve.go:91 Loading support for pluggable type 'intoto'
2021-08-18T10:30:36.366Z        INFO    app/serve.go:92 Loading version '0.0.1' for pluggable type 'intoto'
2021-08-18T10:30:36.366Z        INFO    app/serve.go:91 Loading support for pluggable type 'rfc3161'
2021-08-18T10:30:36.366Z        INFO    app/serve.go:92 Loading version '0.0.1' for pluggable type 'rfc3161'
2021-08-18T10:30:36.366Z        INFO    app/serve.go:91 Loading support for pluggable type 'alpine'
2021-08-18T10:30:36.366Z        INFO    app/serve.go:92 Loading version '0.0.1' for pluggable type 'alpine'
2021-08-18T10:30:36.366Z        INFO    app/serve.go:91 Loading support for pluggable type 'helm'
2021-08-18T10:30:36.366Z        INFO    app/serve.go:92 Loading version '0.0.1' for pluggable type 'helm'
2021-08-18T10:30:36.366Z        INFO    app/serve.go:91 Loading support for pluggable type 'rekord'
2021-08-18T10:30:36.366Z        INFO    app/serve.go:92 Loading version '0.0.1' for pluggable type 'rekord'
2021-08-18T10:30:36.475Z        INFO    restapi/server.go:230   Serving rekor server at http://127.0.0.1:3000
```

## Version info:

I have not installed go and the go deps via the native go tooling but instead via nixpkgs which is leveraging the `v0.3.0` tag

```
$ rekor-server version
GitVersion:    v0.3.0
GitCommit:     unknown
GitTreeState:  unknown
BuildDate:     unknown
GoVersion:     go1.16.7
Compiler:      gc
Platform:      linux/amd64
```

```
$ rekor-cli version
GitVersion:    v0.3.0
GitCommit:     unknown
GitTreeState:  unknown
BuildDate:     unknown
GoVersion:     go1.16.7
Compiler:      gc
Platform:      linux/amd64
```
