### PR TITLE
Update usage of ./cmd/rekor-cli/ from `rekor` to `rekor-cli`

### DIFF
--- a/cmd/rekor-cli/app/root.go
+++ b/cmd/rekor-cli/app/root.go
@@ -39,7 +39,7 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "rekor",
+	Use:   "rekor-cli",
 	Short: "Rekor CLI",
 	Long:  `Rekor command line interface tool`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
The distributed binary is currently called `rekor-cli` in both Arch Linux and NixOS, but the `rekor` string is used by `rekor-cli -h` and `rekor-cli completion`.

Signed-off-by: kpcyrd <git@rxv.cc>