### PR TITLE
remove extradata field from types

### DIFF
--- a/pkg/generated/models/alpine_v001_schema.go
+++ b/pkg/generated/models/alpine_v001_schema.go
@@ -38,9 +38,6 @@ import (
 // swagger:model alpineV001Schema
 type AlpineV001Schema struct {
 
-	// Arbitrary content to be included in the verifiable entry in the transparency log
-	ExtraData interface{} `json:"extraData,omitempty"`
-
 	// package
 	// Required: true
 	Package *AlpineV001SchemaPackage `json:"package"`

--- a/pkg/generated/models/helm_v001_schema.go
+++ b/pkg/generated/models/helm_v001_schema.go
@@ -42,9 +42,6 @@ type HelmV001Schema struct {
 	// Required: true
 	Chart *HelmV001SchemaChart `json:"chart"`
 
-	// Arbitrary content to be included in the verifiable entry in the transparency log
-	ExtraData interface{} `json:"extraData,omitempty"`
-
 	// public key
 	// Required: true
 	PublicKey *HelmV001SchemaPublicKey `json:"publicKey"`

--- a/pkg/generated/models/intoto_v001_schema.go
+++ b/pkg/generated/models/intoto_v001_schema.go
@@ -42,9 +42,6 @@ type IntotoV001Schema struct {
 	// Required: true
 	Content *IntotoV001SchemaContent `json:"content"`
 
-	// Arbitrary content to be included in the verifiable entry in the transparency log
-	ExtraData interface{} `json:"extraData,omitempty"`
-
 	// The public key that can verify the signature
 	// Required: true
 	// Format: byte

--- a/pkg/generated/models/jar_v001_schema.go
+++ b/pkg/generated/models/jar_v001_schema.go
@@ -42,9 +42,6 @@ type JarV001Schema struct {
 	// Required: true
 	Archive *JarV001SchemaArchive `json:"archive"`
 
-	// Arbitrary content to be included in the verifiable entry in the transparency log
-	ExtraData interface{} `json:"extraData,omitempty"`
-
 	// signature
 	Signature *JarV001SchemaSignature `json:"signature,omitempty"`
 }

--- a/pkg/generated/models/rekord_v001_schema.go
+++ b/pkg/generated/models/rekord_v001_schema.go
@@ -42,9 +42,6 @@ type RekordV001Schema struct {
 	// Required: true
 	Data *RekordV001SchemaData `json:"data"`
 
-	// Arbitrary content to be included in the verifiable entry in the transparency log
-	ExtraData interface{} `json:"extraData,omitempty"`
-
 	// signature
 	// Required: true
 	Signature *RekordV001SchemaSignature `json:"signature"`

--- a/pkg/generated/models/rfc3161_v001_schema.go
+++ b/pkg/generated/models/rfc3161_v001_schema.go
@@ -37,9 +37,6 @@ import (
 // swagger:model rfc3161V001Schema
 type Rfc3161V001Schema struct {
 
-	// Arbitrary content to be included in the verifiable entry in the transparency log
-	ExtraData interface{} `json:"extraData,omitempty"`
-
 	// tsr
 	// Required: true
 	Tsr *Rfc3161V001SchemaTsr `json:"tsr"`

--- a/pkg/generated/models/rpm_v001_schema.go
+++ b/pkg/generated/models/rpm_v001_schema.go
@@ -38,9 +38,6 @@ import (
 // swagger:model rpmV001Schema
 type RpmV001Schema struct {
 
-	// Arbitrary content to be included in the verifiable entry in the transparency log
-	ExtraData interface{} `json:"extraData,omitempty"`
-
 	// package
 	// Required: true
 	Package *RpmV001SchemaPackage `json:"package"`

--- a/pkg/generated/models/tuf_v001_schema.go
+++ b/pkg/generated/models/tuf_v001_schema.go
@@ -37,9 +37,6 @@ import (
 // swagger:model tufV001Schema
 type TUFV001Schema struct {
 
-	// Arbitrary content to be included in the verifiable entry in the transparency log
-	ExtraData interface{} `json:"extraData,omitempty"`
-
 	// metadata
 	// Required: true
 	Metadata *TUFV001SchemaMetadata `json:"metadata"`

--- a/pkg/generated/restapi/embedded_spec.go
+++ b/pkg/generated/restapi/embedded_spec.go
@@ -2443,11 +2443,6 @@ func init() {
         "package"
       ],
       "properties": {
-        "extraData": {
-          "description": "Arbitrary content to be included in the verifiable entry in the transparency log",
-          "type": "object",
-          "additionalProperties": true
-        },
         "package": {
           "description": "Information about the package associated with the entry",
           "type": "object",
@@ -2662,11 +2657,6 @@ func init() {
             }
           }
         },
-        "extraData": {
-          "description": "Arbitrary content to be included in the verifiable entry in the transparency log",
-          "type": "object",
-          "additionalProperties": true
-        },
         "publicKey": {
           "description": "The public key that can verify the package signature",
           "type": "object",
@@ -2778,11 +2768,6 @@ func init() {
             }
           }
         },
-        "extraData": {
-          "description": "Arbitrary content to be included in the verifiable entry in the transparency log",
-          "type": "object",
-          "additionalProperties": true
-        },
         "publicKey": {
           "description": "The public key that can verify the signature",
           "type": "string",
@@ -2887,11 +2872,6 @@ func init() {
               "writeOnly": true
             }
           }
-        },
-        "extraData": {
-          "description": "Arbitrary content to be included in the verifiable entry in the transparency log",
-          "type": "object",
-          "additionalProperties": true
         },
         "signature": {
           "description": "Information about the included signature in the JAR file",
@@ -3025,11 +3005,6 @@ func init() {
             }
           }
         },
-        "extraData": {
-          "description": "Arbitrary content to be included in the verifiable entry in the transparency log",
-          "type": "object",
-          "additionalProperties": true
-        },
         "signature": {
           "description": "Information about the detached signature associated with the entry",
           "type": "object",
@@ -3151,11 +3126,6 @@ func init() {
         "tsr"
       ],
       "properties": {
-        "extraData": {
-          "description": "Arbitrary content to be included in the verifiable entry in the transparency log",
-          "type": "object",
-          "additionalProperties": true
-        },
         "tsr": {
           "description": "Information about the tsr file associated with the entry",
           "type": "object",
@@ -3220,11 +3190,6 @@ func init() {
         "package"
       ],
       "properties": {
-        "extraData": {
-          "description": "Arbitrary content to be included in the verifiable entry in the transparency log",
-          "type": "object",
-          "additionalProperties": true
-        },
         "package": {
           "description": "Information about the package associated with the entry",
           "type": "object",
@@ -3363,11 +3328,6 @@ func init() {
         "root"
       ],
       "properties": {
-        "extraData": {
-          "description": "Arbitrary content to be included in the verifiable entry in the transparency log",
-          "type": "object",
-          "additionalProperties": true
-        },
         "metadata": {
           "description": "TUF metadata",
           "type": "object",

--- a/pkg/types/alpine/v0.0.1/alpine_v0_0_1_schema.json
+++ b/pkg/types/alpine/v0.0.1/alpine_v0_0_1_schema.json
@@ -79,11 +79,6 @@
                     "required": [ "content" ]
                 }
             ]
-        },
-        "extraData": {
-            "description": "Arbitrary content to be included in the verifiable entry in the transparency log", 
-            "type": "object",
-            "additionalProperties": true
         }
     },
     "required": [ "publicKey", "package" ]

--- a/pkg/types/alpine/v0.0.1/entry.go
+++ b/pkg/types/alpine/v0.0.1/entry.go
@@ -281,7 +281,6 @@ func (v *V001Entry) Canonicalize(ctx context.Context) ([]byte, error) {
 	}
 
 	canonicalEntry := models.AlpineV001Schema{}
-	canonicalEntry.ExtraData = v.AlpineModel.ExtraData
 
 	var err error
 
@@ -300,9 +299,6 @@ func (v *V001Entry) Canonicalize(ctx context.Context) ([]byte, error) {
 
 	// set .PKGINFO headers
 	canonicalEntry.Package.Pkginfo = v.apkObj.Pkginfo
-
-	// ExtraData is copied through unfiltered
-	canonicalEntry.ExtraData = v.AlpineModel.ExtraData
 
 	// wrap in valid object with kind and apiVersion set
 	apk := models.Alpine{}

--- a/pkg/types/alpine/v0.0.1/entry_test.go
+++ b/pkg/types/alpine/v0.0.1/entry_test.go
@@ -346,23 +346,6 @@ func TestCrossFieldValidation(t *testing.T) {
 			expectUnmarshalSuccess:    true,
 			expectCanonicalizeSuccess: true,
 		},
-		{
-			caseDesc: "valid obj with extradata",
-			entry: V001Entry{
-				AlpineModel: models.AlpineV001Schema{
-					PublicKey: &models.AlpineV001SchemaPublicKey{
-						Content: strfmt.Base64(keyBytes),
-					},
-					Package: &models.AlpineV001SchemaPackage{
-						Content: strfmt.Base64(dataBytes),
-					},
-					ExtraData: []byte("{\"something\": \"here\""),
-				},
-			},
-			hasExtEntities:            false,
-			expectUnmarshalSuccess:    true,
-			expectCanonicalizeSuccess: true,
-		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/types/helm/v0.0.1/entry.go
+++ b/pkg/types/helm/v0.0.1/entry.go
@@ -261,7 +261,6 @@ func (v *V001Entry) Canonicalize(ctx context.Context) ([]byte, error) {
 	}
 
 	canonicalEntry := models.HelmV001Schema{}
-	canonicalEntry.ExtraData = v.HelmObj.ExtraData
 
 	var err error
 

--- a/pkg/types/helm/v0.0.1/helm_v0_0_1_schema.json
+++ b/pkg/types/helm/v0.0.1/helm_v0_0_1_schema.json
@@ -99,11 +99,6 @@
                 }
             },
             "required": [ "provenance" ]
-        },
-        "extraData": {
-            "description": "Arbitrary content to be included in the verifiable entry in the transparency log",
-            "type": "object",
-            "additionalProperties": true
         }
     },
     "required": [

--- a/pkg/types/intoto/v0.0.1/intoto_v0_0_1_schema.json
+++ b/pkg/types/intoto/v0.0.1/intoto_v0_0_1_schema.json
@@ -41,11 +41,6 @@
             "description": "The public key that can verify the signature",
             "type": "string",
             "format": "byte"
-        },
-        "extraData": {
-            "description": "Arbitrary content to be included in the verifiable entry in the transparency log",
-            "type": "object",
-            "additionalProperties": true
         }
     },
     "required": [

--- a/pkg/types/jar/v0.0.1/entry.go
+++ b/pkg/types/jar/v0.0.1/entry.go
@@ -225,7 +225,6 @@ func (v *V001Entry) Canonicalize(ctx context.Context) ([]byte, error) {
 	}
 
 	canonicalEntry := models.JarV001Schema{}
-	canonicalEntry.ExtraData = v.JARModel.ExtraData
 
 	var err error
 	// need to canonicalize key content
@@ -247,9 +246,6 @@ func (v *V001Entry) Canonicalize(ctx context.Context) ([]byte, error) {
 	canonicalEntry.Archive.Hash.Algorithm = v.JARModel.Archive.Hash.Algorithm
 	canonicalEntry.Archive.Hash.Value = v.JARModel.Archive.Hash.Value
 	// archive content is not set deliberately
-
-	// ExtraData is copied through unfiltered
-	canonicalEntry.ExtraData = v.JARModel.ExtraData
 
 	// wrap in valid object with kind and apiVersion set
 	jar := models.Jar{}

--- a/pkg/types/jar/v0.0.1/entry_test.go
+++ b/pkg/types/jar/v0.0.1/entry_test.go
@@ -182,20 +182,6 @@ func TestCrossFieldValidation(t *testing.T) {
 			expectUnmarshalSuccess:    true,
 			expectCanonicalizeSuccess: false,
 		},
-		{
-			caseDesc: "valid obj with extradata",
-			entry: V001Entry{
-				JARModel: models.JarV001Schema{
-					Archive: &models.JarV001SchemaArchive{
-						Content: strfmt.Base64(jarBytes),
-					},
-					ExtraData: []byte("{\"something\": \"here\""),
-				},
-			},
-			hasExtEntities:            false,
-			expectUnmarshalSuccess:    true,
-			expectCanonicalizeSuccess: true,
-		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/types/jar/v0.0.1/jar_v0_0_1_schema.json
+++ b/pkg/types/jar/v0.0.1/jar_v0_0_1_schema.json
@@ -72,11 +72,6 @@
                     "required": [ "content" ]
                 }
             ]
-        },
-        "extraData": {
-            "description": "Arbitrary content to be included in the verifiable entry in the transparency log", 
-            "type": "object",
-            "additionalProperties": true
         }
     },
     "required": [ "archive" ]

--- a/pkg/types/rekord/v0.0.1/entry.go
+++ b/pkg/types/rekord/v0.0.1/entry.go
@@ -307,7 +307,6 @@ func (v *V001Entry) Canonicalize(ctx context.Context) ([]byte, error) {
 	}
 
 	canonicalEntry := models.RekordV001Schema{}
-	canonicalEntry.ExtraData = v.RekordObj.ExtraData
 
 	// need to canonicalize signature & key content
 	canonicalEntry.Signature = &models.RekordV001SchemaSignature{}
@@ -330,9 +329,6 @@ func (v *V001Entry) Canonicalize(ctx context.Context) ([]byte, error) {
 	canonicalEntry.Data = &models.RekordV001SchemaData{}
 	canonicalEntry.Data.Hash = v.RekordObj.Data.Hash
 	// data content is not set deliberately
-
-	// ExtraData is copied through unfiltered
-	canonicalEntry.ExtraData = v.RekordObj.ExtraData
 
 	// wrap in valid object with kind and apiVersion set
 	rekordObj := models.Rekord{}

--- a/pkg/types/rekord/v0.0.1/entry_test.go
+++ b/pkg/types/rekord/v0.0.1/entry_test.go
@@ -498,27 +498,6 @@ func TestCrossFieldValidation(t *testing.T) {
 			expectUnmarshalSuccess:    true,
 			expectCanonicalizeSuccess: true,
 		},
-		{
-			caseDesc: "valid obj with extradata",
-			entry: V001Entry{
-				RekordObj: models.RekordV001Schema{
-					Signature: &models.RekordV001SchemaSignature{
-						Format:  "pgp",
-						Content: strfmt.Base64(sigBytes),
-						PublicKey: &models.RekordV001SchemaSignaturePublicKey{
-							Content: strfmt.Base64(keyBytes),
-						},
-					},
-					Data: &models.RekordV001SchemaData{
-						Content: strfmt.Base64(dataBytes),
-					},
-					ExtraData: []byte("{\"something\": \"here\""),
-				},
-			},
-			hasExtEntities:            false,
-			expectUnmarshalSuccess:    true,
-			expectCanonicalizeSuccess: true,
-		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/types/rekord/v0.0.1/rekord_v0_0_1_schema.json
+++ b/pkg/types/rekord/v0.0.1/rekord_v0_0_1_schema.json
@@ -101,11 +101,6 @@
                     "required": [ "content" ]
                 }
             ]
-        },
-        "extraData": {
-            "description": "Arbitrary content to be included in the verifiable entry in the transparency log", 
-            "type": "object",
-            "additionalProperties": true
         }
     },
     "required": [ "signature", "data" ]

--- a/pkg/types/rfc3161/v0.0.1/entry.go
+++ b/pkg/types/rfc3161/v0.0.1/entry.go
@@ -128,9 +128,6 @@ func (v *V001Entry) Canonicalize(ctx context.Context) ([]byte, error) {
 		},
 	}
 
-	// ExtraData is copied through unfiltered
-	canonicalEntry.ExtraData = v.Rfc3161Obj.ExtraData
-
 	// wrap in valid object with kind and apiVersion set
 	ref3161Obj := models.Rfc3161{}
 	ref3161Obj.APIVersion = swag.String(APIVERSION)

--- a/pkg/types/rfc3161/v0.0.1/entry_test.go
+++ b/pkg/types/rfc3161/v0.0.1/entry_test.go
@@ -152,19 +152,6 @@ func TestCrossFieldValidation(t *testing.T) {
 			expectCanonicalizeSuccess:    false,
 			expectValidationErrorMessage: "tsr verification error",
 		},
-		{
-			caseDesc: "valid obj with extra data",
-			entry: V001Entry{
-				Rfc3161Obj: models.Rfc3161V001Schema{
-					Tsr: &models.Rfc3161V001SchemaTsr{
-						Content: p(tsrBytes),
-					},
-					ExtraData: []byte("{\"something\": \"here\""),
-				},
-			},
-			expectUnmarshalSuccess:    true,
-			expectCanonicalizeSuccess: true,
-		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/types/rfc3161/v0.0.1/rfc3161_v0_0_1_schema.json
+++ b/pkg/types/rfc3161/v0.0.1/rfc3161_v0_0_1_schema.json
@@ -16,11 +16,6 @@
                 }
             },
             "required": [ "content" ]
-        },
-        "extraData": {
-            "description": "Arbitrary content to be included in the verifiable entry in the transparency log",
-            "type": "object",
-            "additionalProperties": true
         }
     },
     "required": [ "tsr" ]

--- a/pkg/types/rpm/v0.0.1/entry.go
+++ b/pkg/types/rpm/v0.0.1/entry.go
@@ -286,7 +286,6 @@ func (v *V001Entry) Canonicalize(ctx context.Context) ([]byte, error) {
 	}
 
 	canonicalEntry := models.RpmV001Schema{}
-	canonicalEntry.ExtraData = v.RPMModel.ExtraData
 
 	var err error
 	// need to canonicalize key content
@@ -318,9 +317,6 @@ func (v *V001Entry) Canonicalize(ctx context.Context) ([]byte, error) {
 	if sha256sum := v.rpmObj.GetBytes(0, 1016); sha256sum != nil {
 		canonicalEntry.Package.Headers["RPMSIGTAG_SHA256"] = hex.EncodeToString(sha256sum)
 	}
-
-	// ExtraData is copied through unfiltered
-	canonicalEntry.ExtraData = v.RPMModel.ExtraData
 
 	// wrap in valid object with kind and apiVersion set
 	rpm := models.Rpm{}

--- a/pkg/types/rpm/v0.0.1/entry_test.go
+++ b/pkg/types/rpm/v0.0.1/entry_test.go
@@ -346,23 +346,6 @@ func TestCrossFieldValidation(t *testing.T) {
 			expectUnmarshalSuccess:    true,
 			expectCanonicalizeSuccess: true,
 		},
-		{
-			caseDesc: "valid obj with extradata",
-			entry: V001Entry{
-				RPMModel: models.RpmV001Schema{
-					PublicKey: &models.RpmV001SchemaPublicKey{
-						Content: strfmt.Base64(keyBytes),
-					},
-					Package: &models.RpmV001SchemaPackage{
-						Content: strfmt.Base64(dataBytes),
-					},
-					ExtraData: []byte("{\"something\": \"here\""),
-				},
-			},
-			hasExtEntities:            false,
-			expectUnmarshalSuccess:    true,
-			expectCanonicalizeSuccess: true,
-		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/types/rpm/v0.0.1/rpm_v0_0_1_schema.json
+++ b/pkg/types/rpm/v0.0.1/rpm_v0_0_1_schema.json
@@ -79,11 +79,6 @@
                     "required": [ "content" ]
                 }
             ]
-        },
-        "extraData": {
-            "description": "Arbitrary content to be included in the verifiable entry in the transparency log", 
-            "type": "object",
-            "additionalProperties": true
         }
     },
     "required": [ "publicKey", "package" ]

--- a/pkg/types/tuf/v0.0.1/entry.go
+++ b/pkg/types/tuf/v0.0.1/entry.go
@@ -294,7 +294,6 @@ func (v *V001Entry) Canonicalize(ctx context.Context) ([]byte, error) {
 	}
 
 	canonicalEntry := models.TUFV001Schema{}
-	canonicalEntry.ExtraData = v.TufObj.ExtraData
 
 	var err error
 	canonicalEntry.SpecVersion, err = v.keyObj.(*ptuf.PublicKey).SpecVersion()

--- a/pkg/types/tuf/v0.0.1/entry_test.go
+++ b/pkg/types/tuf/v0.0.1/entry_test.go
@@ -224,23 +224,6 @@ func TestCrossFieldValidation(t *testing.T) {
 			expectUnmarshalSuccess:    true,
 			expectCanonicalizeSuccess: true,
 		},
-		{
-			caseDesc: "valid obj with extradata",
-			entry: V001Entry{
-				TufObj: models.TUFV001Schema{
-					Root: &models.TUFV001SchemaRoot{
-						Content: keyContent,
-					},
-					Metadata: &models.TUFV001SchemaMetadata{
-						Content: dataContent,
-					},
-					ExtraData: []byte("{\"something\": \"here\""),
-				},
-			},
-			hasExtEntities:            false,
-			expectUnmarshalSuccess:    true,
-			expectCanonicalizeSuccess: true,
-		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/types/tuf/v0.0.1/tuf_v0_0_1_schema.json
+++ b/pkg/types/tuf/v0.0.1/tuf_v0_0_1_schema.json
@@ -45,11 +45,6 @@
                     "writeOnly": true
                 }
             }
-        },
-        "extraData": {
-            "description": "Arbitrary content to be included in the verifiable entry in the transparency log", 
-            "type": "object",
-            "additionalProperties": true
         }
     },
     "required": [ "metadata" , "root"]


### PR DESCRIPTION
Signed-off-by: Bob Callaway <bob.callaway@gmail.com>

We originally included `extraData` in the base `rekord` type in case there was additional information to be stored with an entry in the log. Given concerns about content distribution, we should remove this field to ensure arbitrary content will not be included in the log.

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
