### PR TITLE
Cleanup the output of search (the text goes to stderr not stdout).

### DIFF
--- a/cmd/rekor-cli/app/search.go
+++ b/cmd/rekor-cli/app/search.go
@@ -44,14 +44,7 @@ type searchCmdOutput struct {
 }
 
 func (s *searchCmdOutput) String() string {
-	str := "No matching entries were found\n"
-	for i, uuid := range s.uuids {
-		if i == 0 {
-			str = "Found matching entries (listed by UUID):\n"
-		}
-		str += fmt.Sprintf("%v\n", uuid)
-	}
-	return str
+	return strings.Join(s.uuids, "\n") + "\n" // one extra /n to terminate the list
 }
 
 func addSearchPFlags(cmd *cobra.Command) error {
@@ -202,6 +195,8 @@ var searchCmd = &cobra.Command{
 		if len(resp.Payload) == 0 {
 			return nil, fmt.Errorf("no matching entries found")
 		}
+
+		fmt.Fprintln(os.Stderr, "Found matching entries (listed by UUID):")
 
 		return &searchCmdOutput{
 			uuids: resp.GetPayload(),


### PR DESCRIPTION
The output looks the same:
```shell
$ ./rekor-cli search --sha sha256:1189a2207be3e93e91aaeff323dc2804576f188527afe3cc2e9a9a0c688344df
Found matching entries (listed by UUID):
60a1e4f9c78ae76b2b2a06745340b8ed74c8b2ea2c124b8520ba319d03957906
3873a54462deab6320d1cac993b31b36bb28ff5c2f0d16993909b61907235ec6
```

but the output goes to stderr:

```shell
a=$(./rekor-cli search --sha sha256:1189a2207be3e93e91aaeff323dc2804576f188527afe3cc2e9a9a0c688344df)
Found matching entries (listed by UUID):
```

Fixes #420.

Signed-off-by: Dan Lorenc <dlorenc@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
