### PR TITLE
Cleanup some initialization/flag parsing in rekor-server.

### DIFF
--- a/pkg/api/timestamp.go
+++ b/pkg/api/timestamp.go
@@ -24,7 +24,6 @@ import (
 	"net/http"
 
 	"github.com/go-openapi/runtime/middleware"
-	"github.com/pkg/errors"
 	"github.com/sassoftware/relic/lib/pkcs9"
 	"github.com/sigstore/rekor/pkg/generated/restapi/operations/entries"
 	"github.com/sigstore/rekor/pkg/generated/restapi/operations/timestamp"
@@ -47,11 +46,6 @@ func RequestFromRekor(ctx context.Context, req pkcs9.TimeStampReq) ([]byte, erro
 }
 
 func TimestampResponseHandler(params timestamp.GetTimestampResponseParams) middleware.Responder {
-	// Fail early if we don't haven't configured rekor with a certificate for timestamping.
-	if len(api.certChain) == 0 {
-		return handleRekorAPIError(params, http.StatusNotImplemented, errors.New("rekor is not configured to serve timestamps"), "")
-	}
-
 	// TODO: Add support for in-house JSON based timestamp response.
 	requestBytes, err := ioutil.ReadAll(params.Request)
 	if err != nil {
@@ -96,8 +90,5 @@ func TimestampResponseHandler(params timestamp.GetTimestampResponseParams) middl
 }
 
 func GetTimestampCertChainHandler(params timestamp.GetTimestampCertChainParams) middleware.Responder {
-	if len(api.certChain) == 0 {
-		return handleRekorAPIError(params, http.StatusNotFound, errors.New("rekor is not configured with a timestamping certificate"), "")
-	}
 	return timestamp.NewGetTimestampCertChainOK().WithPayload(api.certChainPem)
 }


### PR DESCRIPTION
This is in preparation for supporting multiple logIDs (for sharding).

Signed-off-by: Dan Lorenc <dlorenc@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
