### PR TITLE
Enable JSON format for search command

### DIFF
--- a/cmd/rekor-cli/app/search.go
+++ b/cmd/rekor-cli/app/search.go
@@ -40,11 +40,11 @@ import (
 )
 
 type searchCmdOutput struct {
-	uuids []string
+	UUIDs []string
 }
 
 func (s *searchCmdOutput) String() string {
-	return strings.Join(s.uuids, "\n") + "\n" // one extra /n to terminate the list
+	return strings.Join(s.UUIDs, "\n") + "\n" // one extra /n to terminate the list
 }
 
 func addSearchPFlags(cmd *cobra.Command) error {
@@ -199,7 +199,7 @@ var searchCmd = &cobra.Command{
 		fmt.Fprintln(os.Stderr, "Found matching entries (listed by UUID):")
 
 		return &searchCmdOutput{
-			uuids: resp.GetPayload(),
+			UUIDs: resp.GetPayload(),
 		}, nil
 	}),
 }


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

I noticed that there was an inconsistency in the output for the `rekor-cli search` command between the default format and the JSON format:

```
$ rekor-cli search --email dan.luhring@anchore.com              
Found matching entries (listed by UUID):
30c398a619c5eb00856bc41df6ab4c660e321ed06e745b562947c48e0dc5ef64
```

```
$ rekor-cli search --email dan.luhring@anchore.com --format json
Found matching entries (listed by UUID):
{}
```

**Diagnosis:** The `searchCmdOutput` struct wasn't able to be marshaled because its field `uuids` wasn't exported. This PR exports that field.

#### Testing

Run the search command and specify the JSON format:

```
$ go run ./cmd/rekor-cli/main.go search --email dan.luhring@anchore.com --format json                   
```

See that the JSON output has the UUIDs field populated correctly:

```
Found matching entries (listed by UUID):
{"UUIDs":["30c398a619c5eb00856bc41df6ab4c660e321ed06e745b562947c48e0dc5ef64"]}
```


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
(n/a)

#### Release Note

```release-note
Enable JSON format for search command
```

Signed-off-by: Dan Luhring <dan.luhring@anchore.com>
