### PR TITLE
feat: add goreleaser and cloudbuild for releases

### DIFF
--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -1,0 +1,67 @@
+#
+# Copyright 2021 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: CI-Validate-Release-Job
+
+on:
+  push:
+    branches:
+      - main
+      - release-*
+  pull_request:
+
+jobs:
+  validate-release-job:
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: none
+      checks: none
+      contents: none
+      deployments: none
+      issues: none
+      packages: none
+      pull-requests: none
+      repository-projects: none
+      security-events: none
+      statuses: none
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Extract version of Go to use
+        run: echo "GOVERSION=$(cat Dockerfile|grep golang | awk ' { print $2 } ' | sed -r 's/^.*://g'| uniq)" >> $GITHUB_ENV
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GOVERSION }}
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          install-only: true
+
+      - name: snaphot
+        run: make snapshot
+        env:
+          PROJECT_ID: honk-fake-project
+          RUNTIME_IMAGE: gcr.io/distroless/static:debug-nonroot
+
+      - name: check binaries
+        run: |
+          ./dist/rekor-server-linux-amd64 version
+          ./dist/rekor-cli-linux-amd64 version
+
+      - name: check images
+        run: |
+          docker run --entrypoint="" gcr.io/honk-fake-project/rekor-server-amd64:SNAPSHOT-${GITHUB_SHA:0:7} rekor-server version
+          docker run gcr.io/honk-fake-project/rekor-cli-amd64:SNAPSHOT-${GITHUB_SHA:0:7} version

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,114 @@
+project_name: rekor
+
+env:
+- GO111MODULE=on
+- CGO_ENABLED=0
+
+# Prevents parallel builds from stepping on eachothers toes downloading modules
+before:
+  hooks:
+  - go mod tidy
+
+builds:
+- id: rekor-server-linux
+  binary: rekor-server-linux-{{ .Arch }}
+  no_unique_dist_dir: true
+  main: ./cmd/rekor-server
+  goos:
+  - linux
+  goarch:
+  - amd64
+  - arm64
+  flags:
+  - -trimpath
+  ldflags:
+  - "{{ .Env.SERVER_LDFLAGS }}"
+
+- id: rekor-cli
+  binary: rekor-cli-{{ .Os }}-{{ .Arch }}
+  no_unique_dist_dir: true
+  main: ./cmd/rekor-cli
+  goos:
+  - linux
+  - darwin
+  - windows
+  goarch:
+  - amd64
+  - arm64
+  ignore:
+  - goos: windows
+    goarch: arm64
+  flags:
+  - -trimpath
+  ldflags:
+  - "{{ .Env.CLIENT_LDFLAGS }}"
+
+dockers:
+  # rekor-server Image
+  - image_templates:
+    - "gcr.io/{{ .Env.PROJECT_ID }}/rekor-server-amd64:{{ .Version }}"
+    use: buildx
+    dockerfile: ./release/Dockerfile.server.release
+    build_flag_templates:
+    - "--platform=linux/amd64"
+    - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}"
+    - "--build-arg=ARCH=amd64"
+  - image_templates:
+    - "gcr.io/{{ .Env.PROJECT_ID }}/rekor-server-arm64v8:{{ .Version }}"
+    use: buildx
+    goarch: arm64
+    dockerfile: ./release/Dockerfile.server.release
+    build_flag_templates:
+    - "--platform=linux/arm64/v8"
+    - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}"
+    - "--build-arg=ARCH=arm64"
+
+  # rekor-cli Image
+  - image_templates:
+    - "gcr.io/{{ .Env.PROJECT_ID }}/rekor-cli-amd64:{{ .Version }}"
+    use: buildx
+    dockerfile: ./release/Dockerfile.cli.release
+    build_flag_templates:
+    - "--platform=linux/amd64"
+    - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}"
+    - "--build-arg=ARCH=amd64"
+  - image_templates:
+    - "gcr.io/{{ .Env.PROJECT_ID }}/rekor-cli-arm64v8:{{ .Version }}"
+    use: buildx
+    goarch: arm64
+    dockerfile: ./release/Dockerfile.cli.release
+    build_flag_templates:
+    - "--platform=linux/arm64/v8"
+    - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}"
+    - "--build-arg=ARCH=arm64"
+
+docker_manifests:
+- name_template: gcr.io/{{ .Env.PROJECT_ID }}/rekor-server:{{ .Version }}
+  image_templates:
+  - gcr.io/{{ .Env.PROJECT_ID }}/rekor-server-amd64:{{ .Version }}
+  - gcr.io/{{ .Env.PROJECT_ID }}/rekor-server-arm64v8:{{ .Version }}
+
+- name_template: gcr.io/{{ .Env.PROJECT_ID }}/rekor-cli:{{ .Version }}
+  image_templates:
+    - gcr.io/{{ .Env.PROJECT_ID }}/rekor-cli-amd64:{{ .Version }}
+    - gcr.io/{{ .Env.PROJECT_ID }}/rekor-cli-arm64v8:{{ .Version }}
+
+archives:
+- format: binary
+  name_template: "{{ .Binary }}"
+  allow_different_binary_count: true
+
+checksum:
+  name_template: "{{ .ProjectName }}_checksums.txt"
+
+snapshot:
+  name_template: SNAPSHOT-{{ .ShortCommit }}
+
+release:
+  prerelease: allow # remove this when we start publishing non-prerelease or set to auto
+  draft: true # allow for manual edits
+  github:
+    owner: sigstore
+    name: rekor
+  footer: |
+    ### Thanks for all contributors!

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ TOOLS_DIR := hack/tools
 TOOLS_BIN_DIR := $(abspath $(TOOLS_DIR)/bin)
 BIN_DIR := $(abspath $(ROOT_DIR)/bin)
 
+PROJECT_ID ?= projectsigstore
+RUNTIME_IMAGE ?= gcr.io/distroless/static
 # Set version variables for LDFLAGS
 GIT_VERSION ?= $(shell git describe --tags --always --dirty)
 GIT_HASH ?= $(shell git rev-parse HEAD)
@@ -123,7 +125,16 @@ dist-server:
 
 .PHONY: dist
 dist: dist-server dist-cli
+# used when releasing together with GCP CloudBuild
 
+.PHONY: release
+release:
+	CLIENT_LDFLAGS=$(CLI_LDFLAGS) SERVER_LDFLAGS=$(SERVER_LDFLAGS) goreleaser release
+
+# used when need to validate the goreleaser
+.PHONY: snapshot
+snapshot:
+	CLIENT_LDFLAGS=$(CLI_LDFLAGS) SERVER_LDFLAGS=$(SERVER_LDFLAGS) goreleaser release --skip-sign --skip-publish --snapshot --rm-dist
 
 ## --------------------------------------
 ## Tooling Binaries

--- a/release/Dockerfile.cli.release
+++ b/release/Dockerfile.cli.release
@@ -1,0 +1,23 @@
+# Copyright 2021 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG RUNTIME_IMAGE=gcr.io/distroless/base:debug
+
+FROM $RUNTIME_IMAGE
+
+ARG ARCH
+COPY rekor-cli-linux-${ARCH} /bin/rekor-cli
+
+USER nobody
+ENTRYPOINT [ "/bin/rekor-cli" ]

--- a/release/Dockerfile.server.release
+++ b/release/Dockerfile.server.release
@@ -1,0 +1,24 @@
+# Copyright 2021 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG RUNTIME_IMAGE=gcr.io/distroless/base:debug
+
+FROM $RUNTIME_IMAGE as builder
+
+ARG ARCH
+COPY rekor-server-linux-${ARCH} /usr/local/bin/rekor-server
+
+USER nobody
+# Set the binary as the entrypoint of the container
+ENTRYPOINT ["/usr/local/bin/rekor-server", "serve"]

--- a/release/README.md
+++ b/release/README.md
@@ -1,0 +1,58 @@
+# Release
+
+This directory contain the files and scripts to run a cosign release.
+
+# Cutting a Rekor Release
+
+1. Release notes: Create a PR to update and review release notes in CHANGELOG.md.
+  - Check merged pull requests since the last release and make sure enhancements, bug fixes, and authors are reflected in the notes.
+
+You can get a list of pull requests since the last release by substituting in the date of the last release and running:
+
+```
+git log --pretty="* %s" --after="YYYY-MM-DD"
+```
+
+and a list of authors by running:
+
+```
+git log --pretty="* %an" --after="YYYY-MM-DD" | sort -u
+```
+
+
+2. Submit the cloudbuild Job using the following command:
+
+```shell
+$ gcloud builds submit --config <PATH_TO_CLOUDBUILD> \
+   --substitutions _GIT_TAG=<_GIT_TAG>,_TOOL_ORG=sigstore,_TOOL_REPO=rekor,_TOOL_REF=main,_STORAGE_LOCATION=rekor-releases \
+   --project <GCP_PROJECT>
+```
+
+Where:
+
+- `PATH_TO_CLOUDBUILD` is the path where the cloudbuild.yaml can be found.
+- `GCP_PROJECT` is the GCP project where we will run the job.
+- `_GIT_TAG` is the release version we are publishing, this will also create the GitHub Tag.
+- `_TOOL_ORG` is the GitHub Org we will use. Default `sigstore`.
+- `_TOOL_REPO` is the repository we will use to clone. Default `cosign`.
+- `_TOOL_REF` is the branch we will use to cut a release. Default `main`.
+- `_STORAGE_LOCATION` where to push the built artifacts. Default `cosign-releases`.
+- `_KEY_RING` key ring name of your cosign key.
+- `_KEY_NAME` key name of your  cosign key.
+- `_KEY_VERSION` version of the key storaged in KMS. Default `1`.
+- `_KEY_LOCATION` location in GCP where the key is storaged. Default `global`.
+
+
+3. When the job finish, whithout issues, you should be able to see in GitHub a draft release.
+You now can review the release, make any changes if needed and then publish to make it an official release.
+
+4. Send an annoucement email to `sigstore-dev@googlegroups.com` mailling list
+
+5. Tweet about the new release with a fun new trigonometry pun!
+
+6. Honk!
+
+#### After the release:
+
+* Add a pending new section in CHANGELOG.md to set up for the next release
+* Create a new GitHub Milestone

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -1,0 +1,111 @@
+#
+# Copyright 2021 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+timeout: 3600s
+
+steps:
+- name: gcr.io/cloud-builders/git
+  dir: "go/src/sigstore"
+  args:
+  - "clone"
+  - "https://github.com/${_TOOL_ORG}/${_TOOL_REPO}"
+
+- name: gcr.io/cloud-builders/git
+  entrypoint: "bash"
+  dir: "go/src/sigstore/rekor"
+  args:
+  - '-c'
+  - |
+    git fetch
+    echo "Checking out ${_TOOL_REF}"
+    git checkout ${_TOOL_REF}
+
+- name: 'gcr.io/projectsigstore/cosign:v1.2.1@sha256:68801416e6ae0a48820baa3f071146d18846d8cd26ca8ec3a1e87fca8a735498'
+  dir: "go/src/sigstore/rekor"
+  env:
+  - RUNTIME_IMAGE=${_RUNTIME_IMAGE}
+  args:
+  - 'dockerfile'
+  - 'verify'
+  - '-base-image-only'
+  - '-key'
+  - 'https://raw.githubusercontent.com/GoogleContainerTools/distroless/main/cosign.pub'
+  - './release/Dockerfile.cli.release'
+
+- name: 'gcr.io/projectsigstore/cosign:v1.2.1@sha256:68801416e6ae0a48820baa3f071146d18846d8cd26ca8ec3a1e87fca8a735498'
+  dir: "go/src/sigstore/rekor"
+  env:
+  - RUNTIME_IMAGE=${_RUNTIME_IMAGE}
+  args:
+  - 'dockerfile'
+  - 'verify'
+  - '-base-image-only'
+  - '-key'
+  - 'https://raw.githubusercontent.com/GoogleContainerTools/distroless/main/cosign.pub'
+  - './release/Dockerfile.server.release'
+
+- name: 'gcr.io/projectsigstore/cosign:v1.2.1@sha256:68801416e6ae0a48820baa3f071146d18846d8cd26ca8ec3a1e87fca8a735498'
+  dir: "go/src/sigstore/rekor"
+  args:
+  - 'verify'
+  - '-key'
+  - 'https://raw.githubusercontent.com/goreleaser/goreleaser/master/cosign.pub'
+  - 'docker.io/goreleaser/goreleaser:v0.183.0@sha256:fca7c247885a248771d1decf76559a66342097b894b87537567795e1a3dbd510'
+
+- name: docker.io/goreleaser/goreleaser:v0.183.0@sha256:fca7c247885a248771d1decf76559a66342097b894b87537567795e1a3dbd510
+  entrypoint: /bin/sh
+  dir: "go/src/sigstore/rekor"
+  env:
+  - "GOPATH=/workspace/go"
+  - "GOBIN=/workspace/bin"
+  - PROJECT_ID=${PROJECT_ID}
+  - RUNTIME_IMAGE=${_RUNTIME_IMAGE}
+  - GIT_TAG=${_GIT_TAG}
+  secretEnv:
+  - GITHUB_TOKEN
+  args:
+    - '-c'
+    - |
+      git tag ${_GIT_TAG}
+      make release
+
+availableSecrets:
+  secretManager:
+  - versionName: projects/${PROJECT_NUMBER}/secrets/GITHUB_TOKEN/versions/latest
+    env: GITHUB_TOKEN
+
+artifacts:
+  objects:
+    location: 'gs://${_STORAGE_LOCATION}/${_GIT_TAG}'
+    paths:
+    - "go/src/sigstore/rekor/dist/rekor*"
+
+options:
+  machineType: E2_HIGHCPU_8
+
+tags:
+- rekor-release
+- ${_GIT_TAG}
+- ${_TOOL_ORG}
+- ${_TOOL_REPO}
+- ${_TOOL_REF}
+
+substitutions:
+  _GIT_TAG: 'v0.0.0'
+  _TOOL_ORG: 'honk'
+  _TOOL_REPO: 'honk-repo'
+  _TOOL_REF: 'release-honk'
+  _STORAGE_LOCATION: 'honk'
+  _RUNTIME_IMAGE: 'gcr.io/distroless/static:debug-nonroot'


### PR DESCRIPTION
#### Summary
Add goreleaser and cloudbuild definition to cut a rekor release, similar we do in the cosign project

Some questions to be answered:

- We will use the same KMS key that is used in `cosign` to sing the blob/images here?
- How can we send the to the Rekor server the logs using the keyless approach?

#### Ticket Link

Related: https://github.com/sigstore/rekor/issues/419

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
feat: add goreleaser and cloudbuild for releases
```
