### PR TITLE
Canonicalize JSON before inserting into trillian

### DIFF
--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -148,7 +148,7 @@ func createLogEntry(params entries.CreateLogEntryParams) (models.LogEntry, middl
 	if err != nil {
 		return nil, handleRekorAPIError(params, http.StatusBadRequest, err, fmt.Sprintf(validationError, err))
 	}
-	leaf, err := entry.Canonicalize(ctx)
+	leaf, err := types.CanonicalizeEntry(ctx, entry)
 	if err != nil {
 		if _, ok := (err).(types.ValidationError); ok {
 			return nil, handleRekorAPIError(params, http.StatusBadRequest, err, fmt.Sprintf(validationError, err))
@@ -315,7 +315,7 @@ func SearchLogQueryHandler(params entries.SearchLogQueryParams) middleware.Respo
 					return err
 				}
 
-				leaf, err := entry.Canonicalize(httpReqCtx)
+				leaf, err := types.CanonicalizeEntry(httpReqCtx, entry)
 				if err != nil {
 					code = http.StatusInternalServerError
 					return err

--- a/pkg/types/entries.go
+++ b/pkg/types/entries.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"reflect"
 
+	"github.com/cyberphone/json-canonicalization/go/src/webpki.org/jsoncanonicalizer"
 	"github.com/go-openapi/strfmt"
 	"github.com/mitchellh/mapstructure"
 	"github.com/sigstore/rekor/pkg/generated/models"
@@ -103,6 +104,17 @@ func DecodeEntry(input, output interface{}) error {
 	}
 
 	return dec.Decode(input)
+}
+
+// CanonicalizeEntry returns the entry marshalled in JSON according to the
+// canonicalization rules of RFC8785 to protect against any changes in golang's JSON
+// marshalling logic that may reorder elements
+func CanonicalizeEntry(ctx context.Context, entry EntryImpl) ([]byte, error) {
+	canonicalEntry, err := entry.Canonicalize(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return jsoncanonicalizer.Transform(canonicalEntry)
 }
 
 // ArtifactProperties provide a consistent struct for passing values from


### PR DESCRIPTION
Each of the supported types has a Canonicalize() method that generates a JSON representation of the entry. If the golang library were to make a change to the order of keys when marshaling an object, it would cause a duplicate entry in the log for a semantically equivalent object.

This change simply transforms the JSON into RFC8785-compliant canonicalized JSON protecting against any changes in golang's JSON libraries going forward.

Signed-off-by: Bob Callaway <bob.callaway@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
