### PR TITLE
update go tuf for rsa key impl

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.9.0
 	github.com/tent/canonical-json-go v0.0.0-20130607151641-96e4ba3a7613
-	github.com/theupdateframework/go-tuf v0.0.0-20210722233521-90e262754396
+	github.com/theupdateframework/go-tuf v0.0.0-20211006142131-1dc15a86c64d
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/tilinna/clock v1.1.0 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1172,6 +1172,8 @@ github.com/tent/canonical-json-go v0.0.0-20130607151641-96e4ba3a7613 h1:iGnD/q91
 github.com/tent/canonical-json-go v0.0.0-20130607151641-96e4ba3a7613/go.mod h1:g6AnIpDSYMcphz193otpSIzN+11Rs+AAIIC6rm1enug=
 github.com/theupdateframework/go-tuf v0.0.0-20210722233521-90e262754396 h1:j4odVZMwglHp54CYsNHd0wls+lkQzxloQU9AQjQu0W4=
 github.com/theupdateframework/go-tuf v0.0.0-20210722233521-90e262754396/go.mod h1:L+uU/NRFK/7h0NYAnsmvsX9EghDB5QVCcHCIrK2h5nw=
+github.com/theupdateframework/go-tuf v0.0.0-20211006142131-1dc15a86c64d h1:6u8WdfsjnV7hMFBekqY6j9WrOLEzhWFOAWmb8Yys0J8=
+github.com/theupdateframework/go-tuf v0.0.0-20211006142131-1dc15a86c64d/go.mod h1:oujGMqigj0NWDqeWBCzleayXXtux27r+kHAR2t5Yuk8=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=

--- a/pkg/pki/tuf/tuf.go
+++ b/pkg/pki/tuf/tuf.go
@@ -70,19 +70,8 @@ func (s Signature) CanonicalValue() ([]byte, error) {
 	if s.signed == nil {
 		return nil, fmt.Errorf("tuf manifest has not been initialized")
 	}
-
-	var decoded map[string]interface{}
-	if err := json.Unmarshal(s.signed.Signed, &decoded); err != nil {
-		return nil, err
-	}
-
-	canonicalSigned, err := cjson.Marshal(decoded)
-	if err != nil {
-		return nil, err
-	}
-	canonical, err := cjson.Marshal(&data.Signed{
-		Signed:     canonicalSigned,
-		Signatures: s.signed.Signatures})
+	// TODO(asraa): Should the Signed payload be canonicalized?
+	canonical, err := cjson.Marshal(s)
 	if err != nil {
 		return nil, err
 	}
@@ -154,22 +143,11 @@ func NewPublicKey(r io.Reader) (*PublicKey, error) {
 
 // CanonicalValue implements the pki.PublicKey interface
 func (k PublicKey) CanonicalValue() (encoded []byte, err error) {
+	// TODO(asraa): Should the Signed payload be canonicalized?
 	if k.root == nil {
 		return nil, fmt.Errorf("tuf root has not been initialized")
 	}
-
-	var decoded map[string]interface{}
-	if err := json.Unmarshal(k.root.Signed, &decoded); err != nil {
-		return nil, err
-	}
-
-	canonicalSigned, err := cjson.Marshal(decoded)
-	if err != nil {
-		return nil, err
-	}
-	canonical, err := cjson.Marshal(&data.Signed{
-		Signed:     canonicalSigned,
-		Signatures: k.root.Signatures})
+	canonical, err := cjson.Marshal(k.root)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/tuf.go
+++ b/tests/tuf.go
@@ -42,7 +42,7 @@ func generateTestRepo(t *testing.T, files map[string][]byte) tuf.LocalStore {
 	for file := range files {
 		repo.AddTarget(file, nil)
 	}
-	repo.Snapshot(tuf.CompressionTypeNone)
+	repo.Snapshot()
 	repo.Timestamp()
 	repo.Commit()
 


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
* Updates go-tuf to support RSA keys in TUF metadata (and also Canonicalizes TUF metadata as is, to avoid newlines in the PEM encoded RSA public key that Datadog uses. Added a TODO here)

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
