### PR TITLE
Add dynamic JS tree size counter

### DIFF
--- a/pkg/generated/restapi/rekorHomePage.html
+++ b/pkg/generated/restapi/rekorHomePage.html
@@ -21,10 +21,26 @@
     A non-profit, public good software signing &amp; transparency service.
     <p>To learn more visit <a href="https://sigstore.dev">Sigstore project page</a></p>
   </h2>
+
+  <p>Currently storing <span id="count">some</span> items.</p>
+
   <footer>
     <p>Copyright © sigstore a Series of LF Projects, LLC For web site terms of use, trademark policy and general project
-      policies please see <a href="https://lfprojects.org">https://lfprojects.org</a>.
-      <p />
+      policies please see <a href="https://lfprojects.org">https://lfprojects.org</a>.</p>
   </footer>
+
+  <script type="text/javascript">
+const url = '/api/v1/log/';
+function update() {
+  fetch(url).then((resp) => {
+    resp.json().then((j) => {
+      let count = j.treeSize;
+      document.getElementById('count').innerText = count;
+    }).catch(console.error);
+  }).catch(console.error);
+}
+update(); // Update immediately on page load.
+setInterval(update, 10000); // Update the counter every 10 seconds.
+  </script>
 </body>
 </html>


### PR DESCRIPTION
#### Summary
This adds a dynamic counter to rekor.sigstore.dev that updates every 10 seconds with the latest tree size.

Screenshot:
<kbd><img width="708" alt="Screen Shot 2021-10-27 at 12 00 27 PM" src="https://user-images.githubusercontent.com/210737/139103108-19b63d4a-219a-40a4-9b56-632277e78c93.png"></kbd>

There's obviously a lot of improvement we can make here to make this prettier, I wanted to start simple to get feedback. Feel free to reject this outright if this isn't something we want for whatever reason (e.g., load on the API).

I also wasn't able to get this running with `make up`, so I had to hack this together in Chrome devtools to ensure it works.

#### Ticket Link

Fixes #466 

#### Release Note

```release-note
Adds a JavaScript counter to the Rekor homepage (rekor.sigstore.dev) to dynamically show current tree size.
```
