### PR TITLE
Fixed modtime for reproducible goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,6 +21,7 @@ builds:
   - arm64
   flags:
   - -trimpath
+  mod_timestamp: '{{ .CommitTimestamp }}'
   ldflags:
   - "{{ .Env.SERVER_LDFLAGS }}"
 
@@ -40,6 +41,7 @@ builds:
     goarch: arm64
   flags:
   - -trimpath
+  mod_timestamp: '{{ .CommitTimestamp }}'
   ldflags:
   - "{{ .Env.CLIENT_LDFLAGS }}"
 


### PR DESCRIPTION
The modtime setting was missing that was required for making goreleaser builds consistent.

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
