### PR TITLE
More verbose error message for redis connection failure (#479)

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -162,7 +162,7 @@ func ConfigureAPI() {
 	if viper.GetBool("enable_retrieve_api") {
 		redisClient, err = cfg.New(context.Background(), "tcp", fmt.Sprintf("%v:%v", viper.GetString("redis_server.address"), viper.GetUint64("redis_server.port")))
 		if err != nil {
-			log.Logger.Panic(err)
+			log.Logger.Panic("failure connecting to redis instance: ", err)
 		}
 	}
 


### PR DESCRIPTION
This PR adds a bit more context to the panic that results when Rekor can't connect to the redis server. It will look like this:

```
2021-11-03T16:07:17.091-0400	PANIC	api/api.go:165	failure connecting to redis instance: 
dial tcp 127.0.0.1:6379: connect: connection refused
```

rather than
```
2021-11-03T12:54:43.331-0400	PANIC	api/api.go:165	dial tcp 127.0.0.1:6379: connect: 
connection refused
```

Closes #479 
