### PR TITLE
Refactor Trillian - Decoupling With Interface

### DIFF
--- a/pkg/api/tlog.go
+++ b/pkg/api/tlog.go
@@ -36,7 +36,7 @@ import (
 func GetLogInfoHandler(params tlog.GetLogInfoParams) middleware.Responder {
 	tc := NewTrillianClient(params.HTTPRequest.Context())
 
-	resp := tc.getLatest(0)
+	resp := tc.GetLatest(0)
 	if resp.status != codes.OK {
 		return handleRekorAPIError(params, http.StatusInternalServerError, fmt.Errorf("grpc error: %w", resp.err), trillianCommunicationError)
 	}
@@ -87,7 +87,7 @@ func GetLogProofHandler(params tlog.GetLogProofParams) middleware.Responder {
 	}
 	tc := NewTrillianClient(params.HTTPRequest.Context())
 
-	resp := tc.getConsistencyProof(*params.FirstSize, params.LastSize)
+	resp := tc.GetConsistencyProof(*params.FirstSize, params.LastSize)
 	if resp.status != codes.OK {
 		return handleRekorAPIError(params, http.StatusInternalServerError, fmt.Errorf("grpc error: %w", resp.err), trillianCommunicationError)
 	}


### PR DESCRIPTION
Refactoring trillian to be interface based which is easier to mock for testing. 
With the present implementation, it is impossible to test other than running a trillian server.
It is hard to get code coverage metrics with an external server.

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
