### PR TITLE
Only include Attestation data if attestation storage enabled

### DIFF
--- a/cmd/rekor-cli/app/get.go
+++ b/cmd/rekor-cli/app/get.go
@@ -150,13 +150,16 @@ func parseEntry(uuid string, e models.LogEntryAnon) (interface{}, error) {
 	}
 
 	obj := getCmdOutput{
-		Attestation:     string(e.Attestation.Data),
-		AttestationType: e.Attestation.MediaType,
-		Body:            eimpl,
-		UUID:            uuid,
-		IntegratedTime:  *e.IntegratedTime,
-		LogIndex:        int(*e.LogIndex),
-		LogID:           *e.LogID,
+		Body:           eimpl,
+		UUID:           uuid,
+		IntegratedTime: *e.IntegratedTime,
+		LogIndex:       int(*e.LogIndex),
+		LogID:          *e.LogID,
+	}
+
+	if e.Attestation != nil {
+		obj.Attestation = string(e.Attestation.Data)
+		obj.AttestationType = e.Attestation.MediaType
 	}
 
 	return &obj, nil


### PR DESCRIPTION
Signed-off-by: Lily Sturmann <lsturman@redhat.com>

#### Summary
This adds a check for whether attestation storage is enabled before including attestation info for a GET request.

#### Ticket Link

Fixes #493 

#### Release Note

```release-note
    NONE
```
