### PR TITLE
api/index/retrieve: allow searching on indices with sha1 hashes

### DIFF
--- a/cmd/rekor-cli/app/pflags.go
+++ b/cmd/rekor-cli/app/pflags.go
@@ -61,7 +61,7 @@ func initializePFlagMap() {
 		},
 		shaFlag: func() pflag.Value {
 			// this validates a valid sha256 checksum which is optionally prefixed with 'sha256:'
-			return valueFactory(shaFlag, validateSHA256Value, "")
+			return valueFactory(shaFlag, validateSHAValue, "")
 		},
 		emailFlag: func() pflag.Value {
 			// this validates an email address
@@ -163,10 +163,16 @@ func isURL(v string) bool {
 	return valGen().Set(v) == nil
 }
 
-// validateSHA256Value ensures that the supplied string matches the following format:
+// validateSHAValue ensures that the supplied string matches the following formats:
 // [sha256:]<64 hexadecimal characters>
-// where [sha256:] is optional
-func validateSHA256Value(v string) error {
+// [sha1:]<40 hexadecimal characters>
+// where [sha256:] and [sha1:] are optional
+func validateSHAValue(v string) error {
+	err := util.ValidateSHA1Value(v)
+	if err == nil {
+		return nil
+	}
+
 	if err := util.ValidateSHA256Value(v); err != nil {
 		return fmt.Errorf("error parsing %v flag: %w", shaFlag, err)
 	}

--- a/cmd/rekor-cli/app/search.go
+++ b/cmd/rekor-cli/app/search.go
@@ -54,7 +54,7 @@ func addSearchPFlags(cmd *cobra.Command) error {
 
 	cmd.Flags().Var(NewFlagValue(fileOrURLFlag, ""), "artifact", "path or URL to artifact file")
 
-	cmd.Flags().Var(NewFlagValue(shaFlag, ""), "sha", "the SHA256 sum of the artifact")
+	cmd.Flags().Var(NewFlagValue(shaFlag, ""), "sha", "the SHA256 or SHA1 sum of the artifact")
 
 	cmd.Flags().Var(NewFlagValue(emailFlag, ""), "email", "email associated with the public key's subject")
 	return nil
@@ -109,8 +109,12 @@ var searchCmd = &cobra.Command{
 		sha := viper.GetString("sha")
 		if sha != "" {
 			var prefix string
-			if !strings.HasPrefix(sha, "sha256:") {
-				prefix = "sha256:"
+			if !strings.HasPrefix(sha, "sha256:") && !strings.HasPrefix(sha, "sha1:") {
+				if len(sha) == 40 {
+					prefix = "sha1:"
+				} else {
+					prefix = "sha256:"
+				}
 			}
 			params.Query.Hash = fmt.Sprintf("%v%v", prefix, sha)
 		} else if artifactStr != "" {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -497,7 +497,7 @@ definitions:
           - "format"
       hash:
         type: string
-        pattern: '^(sha256:)?[0-9a-fA-F]{64}$'
+        pattern: '^(sha256:)?[0-9a-fA-F]{64}$|^(sha1:)?[0-9a-fA-F]{40}$'
 
   SearchLogQuery:
     type: object

--- a/pkg/generated/models/search_index.go
+++ b/pkg/generated/models/search_index.go
@@ -41,7 +41,7 @@ type SearchIndex struct {
 	Email strfmt.Email `json:"email,omitempty"`
 
 	// hash
-	// Pattern: ^(sha256:)?[0-9a-fA-F]{64}$
+	// Pattern: ^(sha256:)?[0-9a-fA-F]{64}$|^(sha1:)?[0-9a-fA-F]{40}$
 	Hash string `json:"hash,omitempty"`
 
 	// public key
@@ -87,7 +87,7 @@ func (m *SearchIndex) validateHash(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.Pattern("hash", "body", m.Hash, `^(sha256:)?[0-9a-fA-F]{64}$`); err != nil {
+	if err := validate.Pattern("hash", "body", m.Hash, `^(sha256:)?[0-9a-fA-F]{64}$|^(sha1:)?[0-9a-fA-F]{40}$`); err != nil {
 		return err
 	}
 

--- a/pkg/generated/restapi/embedded_spec.go
+++ b/pkg/generated/restapi/embedded_spec.go
@@ -581,7 +581,7 @@ func init() {
         },
         "hash": {
           "type": "string",
-          "pattern": "^(sha256:)?[0-9a-fA-F]{64}$"
+          "pattern": "^(sha256:)?[0-9a-fA-F]{64}$|^(sha1:)?[0-9a-fA-F]{40}$"
         },
         "publicKey": {
           "type": "object",
@@ -2279,7 +2279,7 @@ func init() {
         },
         "hash": {
           "type": "string",
-          "pattern": "^(sha256:)?[0-9a-fA-F]{64}$"
+          "pattern": "^(sha256:)?[0-9a-fA-F]{64}$|^(sha1:)?[0-9a-fA-F]{40}$"
         },
         "publicKey": {
           "type": "object",

--- a/pkg/util/validate.go
+++ b/pkg/util/validate.go
@@ -44,3 +44,25 @@ func ValidateSHA256Value(v string) error {
 	validate := validator.New()
 	return validate.Struct(s)
 }
+
+func ValidateSHA1Value(v string) error {
+	var prefix, hash string
+
+	split := strings.SplitN(v, ":", 2)
+	switch len(split) {
+	case 1:
+		hash = split[0]
+	case 2:
+		prefix = split[0]
+		hash = split[1]
+	}
+
+	s := struct {
+		Prefix string `validate:"omitempty,oneof=sha1"`
+		Hash   string `validate:"required,len=40,hexadecimal"`
+	}{prefix, hash}
+
+	validate := validator.New()
+	return validate.Struct(s)
+
+}


### PR DESCRIPTION

Closes #498
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
Adds the ability to search for indices with sha1 hashes. Currently
rekor custom types can store indices with formats other than
sha256:<hash>.  Particularly the in-toto type can do this.

One particular use case of interest is indexing log entries by git
commit hash, which largely still use sha1.
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:


* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
* Added ability to search indices with sha1 hashes
```
