### PR TITLE
Bump the trillian versions to v1.4.0 in our docker-compose setup.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@
 version: '3.4'
 services:
   mysql:
-    image: gcr.io/trillian-opensource-ci/db_server:df474653733c51ed91d60cf3efee69f7bf3199bd
+    image: gcr.io/trillian-opensource-ci/db_server:v1.4.0
     environment:
       - MYSQL_ROOT_PASSWORD=zaphod
       - MYSQL_DATABASE=test
@@ -45,7 +45,7 @@ services:
       retries: 3
       start_period: 5s
   trillian-log-server:
-    image: gcr.io/trillian-opensource-ci/log_server:df474653733c51ed91d60cf3efee69f7bf3199bd
+    image: gcr.io/trillian-opensource-ci/log_server:v1.4.0
     command: [
       "--storage_system=mysql",
       "--mysql_uri=test:zaphod@tcp(mysql:3306)/test",
@@ -60,7 +60,7 @@ services:
     depends_on:
       - mysql
   trillian-log-signer:
-    image: gcr.io/trillian-opensource-ci/log_signer:df474653733c51ed91d60cf3efee69f7bf3199bd
+    image: gcr.io/trillian-opensource-ci/log_signer:v1.4.0
     command: [
       "--storage_system=mysql",
       "--mysql_uri=test:zaphod@tcp(mysql:3306)/test",


### PR DESCRIPTION
This should validate that the current version of Rekor works against the
newest version of Trillian in CI.

Signed-off-by: Dan Lorenc <lorenc.d@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
