### PR TITLE
timestamping: update key usage for ts cert

### DIFF
--- a/pkg/signer/memory.go
+++ b/pkg/signer/memory.go
@@ -98,7 +98,7 @@ func NewTimestampingCertWithChain(ctx context.Context, pub crypto.PublicKey, sig
 		NotAfter:     time.Now().AddDate(10, 0, 0),
 		SubjectKeyId: []byte{1, 2, 3, 4, 6},
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageTimeStamping},
-		KeyUsage:     x509.KeyUsageContentCommitment,
+		KeyUsage:     x509.KeyUsageDigitalSignature,
 		IsCA:         false,
 		ExtraExtensions: []pkix.Extension{
 			{


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
* Updates key usage per https://github.com/sigstore/rekor/pull/293#discussion_r750769509

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```

Confirmed openssl still like it
```
asraa@asraa-glaptop:~/git/rekor$ ./rekor timestamp --artifact README.md --rekor_server http://localhost:3000
Artifact timestamped at 2021-11-22 15:19:39 +0000 UTC
Wrote timestamp response to response.tsr
Created entry at index 0, available at: http://localhost:3000/api/v1/log/entries/fc4398aef624a8d32f876e32b03e31f132fdb29584492aed05b7dde539807f4b
asraa@asraa-glaptop:~/git/rekor$ curl http://localhost:3000/api/v1/timestamp/certchain --output -
-----BEGIN CERTIFICATE-----
MIIBwjCCAWigAwIBAgICBnowCgYIKoZIzj0EAwIwIjEgMB4GA1UEChMXcmVrb3Ig
aW4tbWVtb3J5IHJvb3QgQ0EwHhcNMjExMTIyMTUxNzQ1WhcNMzExMTIyMTUxNzQ1
WjAiMSAwHgYDVQQKExdSZWtvciBUaW1lc3RhbXBpbmcgQ2VydDBZMBMGByqGSM49
AgEGCCqGSM49AwEHA0IABFL/DUma8UzfLHot5bYhbNXSBT0HJEafpLXbHed/6xJ2
WOcV9DT97xcw26G89aelP2ox8U5xMEewW4oc9CURWnyjgY0wgYowDgYDVR0PAQH/
BAQDAgeAMAwGA1UdEwEB/wQCMAAwDgYDVR0OBAcEBQECAwQGMB8GA1UdIwQYMBaA
FAS8jprdty9L2JZn9JOMhr2REXyXMCEGA1UdEQQaMBiHBH8AAAGHEAAAAAAAAAAA
AAAAAAAAAAEwFgYDVR0lAQH/BAwwCgYIKwYBBQUHAwgwCgYIKoZIzj0EAwIDSAAw
RQIge/c3vH+EMs/KsJ0BK2dR8tJ+htmNuBDHDGNfHtK12OQCIQCPyz1qVWRWJjaW
wfztzFatjk0h82j3H8pX7GmpX/v3SQ==
-----END CERTIFICATE-----
-----BEGIN CERTIFICATE-----
MIIBdzCCARygAwIBAgICB+MwCgYIKoZIzj0EAwIwIjEgMB4GA1UEChMXcmVrb3Ig
aW4tbWVtb3J5IHJvb3QgQ0EwHhcNMjExMTIyMTUxNzQ1WhcNMzExMTIyMTUxNzQ1
WjAiMSAwHgYDVQQKExdyZWtvciBpbi1tZW1vcnkgcm9vdCBDQTBZMBMGByqGSM49
AgEGCCqGSM49AwEHA0IABDJUQex+ECYA3tQdamAlUotYZiKsZjSVTd6fuEAx6div
DUKAKVFOolLrbhKkhkB7dD86se816LRGADKe+lU7yqKjQjBAMA4GA1UdDwEB/wQE
AwICxDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBQEvI6a3bcvS9iWZ/STjIa9
kRF8lzAKBggqhkjOPQQDAgNJADBGAiEA/+X65oP1S97BRBz4SKGL452Vd1Yi593+
KJo4n6ok/4ACIQDfDa0j6IwbzBmwfNU1wLNRv26EqIWvjsbxpbRtqTwRsw==
-----END CERTIFICATE-----
asraa@asraa-glaptop:~/git/rekor$ emacs ts.cert
asraa@asraa-glaptop:~/git/rekor$ emacs root.ca
asraa@asraa-glaptop:~/git/rekor$ openssl ts -verify -in response.tsr -data README.md -CAfile root.ca -untrusted ts.cert
Using configuration from /usr/lib/ssl/openssl.cnf
Verification: OK
```
