### PR TITLE
types/intoto: decode attestation before returning

### DIFF
--- a/pkg/types/intoto/v0.0.1/entry.go
+++ b/pkg/types/intoto/v0.0.1/entry.go
@@ -199,11 +199,19 @@ func (v *V001Entry) validate() error {
 }
 
 func (v *V001Entry) Attestation() (string, []byte) {
-	if len(v.env.Payload) > viper.GetInt("max_attestation_size") {
+	decodedLen := base64.StdEncoding.DecodedLen(len(v.env.Payload))
+	if decodedLen > viper.GetInt("max_attestation_size") {
 		log.Logger.Infof("Skipping attestation storage, size %d is greater than max %d", len(v.env.Payload), viper.GetInt("max_attestation_size"))
 		return "", nil
 	}
-	return v.env.PayloadType, []byte(v.env.Payload)
+
+	decodedPayload, err := base64.StdEncoding.DecodeString(v.env.Payload)
+	if err != nil {
+		log.Logger.Infof("skipping attestation storage, couldn't base64 decode payload: %v", err)
+		return "", nil
+	}
+
+	return v.env.PayloadType, decodedPayload
 }
 
 type verifier struct {


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
In-toto attestations returned from the API are currently base64 encoded
twice.  This is due to the attestation being stored on disk encoded as
base64 and the API encoding responses as base64.  This commit decodes
the attestation prior to being saved to disk.

Signed-off-by: Mikhail Swift <mswift@mswift.dev>

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes #511 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
in-toto attestations are base64 decoded before being stored to disk
in-toto attestations are only base64 encoded once in api responses
```
