### PR TITLE
UUID parsing to include pre-pended shard ID

### DIFF
--- a/cmd/rekor-cli/app/sharding/sharding.go
+++ b/cmd/rekor-cli/app/sharding/sharding.go
@@ -1,0 +1,58 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sharding
+
+import (
+	"fmt"
+)
+
+// A FullID refers to a specific artifact's ID and is made of two components,
+// the ShardID and the UUID, separated by a character, the FullIDSeparator.
+// The ShardID is in human-readable decimal and refers to the specific log or
+// shard where the artifact can be found. The UUID refers to the hex-encoded
+// merkle leaf hash from trillian for the specific artifact.
+
+const ShardIDMax = 999999
+const FullIDSeparator = "-"
+
+const ShardIDLen = 6
+const UUIDLen = 64
+const SeparatorLen = len(FullIDSeparator)
+const FullIDLen = ShardIDLen + UUIDLen + SeparatorLen
+
+// A ShardID is a number with specific properties, including
+// its representation as a six-digit string.
+type ShardID struct {
+	ShardIDInt    uint32
+	ShardIDString string
+}
+
+// Create a 6-digit string from shardID
+func IntToString(i uint32) string {
+	return fmt.Sprintf("%06d", i)
+}
+
+// Create default values
+func NewCurrent() ShardID {
+	return ShardID{
+		ShardIDInt:    CurrentShardID,
+		ShardIDString: IntToString(CurrentShardID)}
+}
+
+// TODO: The shardID will be part of the state and will be updated. Store it in state.go?
+// TODO: Add a check that the CurrentShardID cannot be updated beyond 999,999
+
+var CurrentShardID uint32 = 0

--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -36,6 +36,7 @@ import (
 	"google.golang.org/genproto/googleapis/rpc/code"
 	"google.golang.org/grpc/codes"
 
+	"github.com/sigstore/rekor/cmd/rekor-cli/app/sharding"
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/rekor/pkg/generated/restapi/operations/entries"
 	"github.com/sigstore/rekor/pkg/log"
@@ -92,7 +93,8 @@ func logEntryFromLeaf(ctx context.Context, signer signature.Signer, tc TrillianC
 		Hashes:   hashes,
 	}
 
-	uuid := hex.EncodeToString(leaf.MerkleLeafHash)
+	shardID := sharding.NewCurrent()
+	uuid := shardID.ShardIDString + sharding.FullIDSeparator + hex.EncodeToString(leaf.MerkleLeafHash)
 	if viper.GetBool("enable_attestation_storage") {
 		att, typ, err := storageClient.FetchAttestation(ctx, uuid)
 		if err != nil {
@@ -183,7 +185,8 @@ func createLogEntry(params entries.CreateLogEntryParams) (models.LogEntry, middl
 	metricNewEntries.Inc()
 
 	queuedLeaf := resp.getAddResult.QueuedLeaf.Leaf
-	uuid := hex.EncodeToString(queuedLeaf.GetMerkleLeafHash())
+	shardID := sharding.NewCurrent()
+	uuid := shardID.ShardIDString + sharding.FullIDSeparator + hex.EncodeToString(queuedLeaf.GetMerkleLeafHash())
 
 	logEntryAnon := models.LogEntryAnon{
 		LogID:          swag.String(api.pubkeyHash),


### PR DESCRIPTION
#### Summary
This is a draft! Feedback welcome, including overall design considerations. I've got some to-dos that I am still sorting out as listed here and in code comments. It's not many lines of code, but I did a fair amount of experimentation to get to this point as it's my first "real" Rekor PR. : )

Here is how it's working currently:

![Screenshot from 2021-11-30 13-01-40](https://user-images.githubusercontent.com/22075926/144105582-89dc97b1-9892-41b9-9590-306da0614c8e.png)


#### Ticket Link

Fixes #487 

#### Release Note

```release-note

This would change the format of the UUID that people use on the CLI and pre-pend the 64-digit hex UUID with 
a 6-digit human-readable decimal shard ID, like so: 
`ssssss-uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu`
where `s` is a digit of the shard ID and `u` is a digit of the old UUID / hex-encoded trillian merkle leaf 
hash.
```

- [x] TODO: Allow for backwards-compatibility by letting people search for the old 64-digit UUIDs and internally prepending those with the current shard ID. Is there a way to allow two different valid lengths for a parameter in `pflags.go` and `openapi.yaml`? I'm looking into this.
