### PR TITLE
sign using keyless for ci containers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@
 name: CI-Container-Build
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -28,27 +29,39 @@ jobs:
     name: build
     runs-on: ubuntu-latest
 
+    permissions:
+      id-token: write
+      contents: read
+
     steps:
       - uses: actions/checkout@v2.4.0
       - uses: sigstore/cosign-installer@v1.4.1
 
       - name: Extract version of Go to use
         run: echo "GOVERSION=$(cat Dockerfile|grep golang | awk ' { print $2 } ' | sed -r 's/^.*://g'| uniq)" >> $GITHUB_ENV
+
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GOVERSION }}
+
       - name: deps
         run: sudo apt-get update && sudo apt-get install -yq libpcsclite-dev
+
       - uses: imjasonh/setup-ko@v0.4
         with:
-          version: v0.8.3
+          version: v0.9.3
+
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@master
         with:
           project_id: projectsigstore
           service_account_key: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           export_default_credentials: true
+
       - name: creds
         run: gcloud auth configure-docker --quiet
+
       - name: container
-        run: echo -n "${{secrets.COSIGN_PASSWORD}}" | KO_PREFIX=gcr.io/projectsigstore/rekor/ci/rekor make sign-container
+        run: KO_PREFIX=gcr.io/projectsigstore/rekor/ci/rekor make sign-container
+        env:
+          COSIGN_EXPERIMENTAL: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,6 @@ jobs:
         run: gcloud auth configure-docker --quiet
 
       - name: container
-        run: KO_PREFIX=gcr.io/projectsigstore/rekor/ci/rekor make sign-container
+        run: KO_PREFIX=gcr.io/projectsigstore/rekor/ci/rekor make sign-keyless-ci
         env:
           COSIGN_EXPERIMENTAL: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
           go-version: ${{ env.GOVERSION }}
       - uses: imjasonh/setup-ko@v0.4
         with:
-          version: v0.8.3
+          version: v0.9.3
       - name: container
         run: |
           KO_PREFIX=ko.local make ko 2>&1 | tee output.txt

--- a/Makefile
+++ b/Makefile
@@ -119,8 +119,8 @@ ko:
 		github.com/sigstore/rekor/cmd/rekor-cli
 
 sign-container: ko
-	cosign sign -key .github/workflows/cosign.key -a GIT_HASH=$(GIT_HASH) ${KO_DOCKER_REPO}/rekor-server:$(GIT_HASH)
-	cosign sign -key .github/workflows/cosign.key -a GIT_HASH=$(GIT_HASH) ${KO_DOCKER_REPO}/rekor-cli:$(GIT_HASH)
+	cosign sign --key .github/workflows/cosign.key -a GIT_HASH=$(GIT_HASH) ${KO_DOCKER_REPO}/rekor-server:$(GIT_HASH)
+	cosign sign --key .github/workflows/cosign.key -a GIT_HASH=$(GIT_HASH) ${KO_DOCKER_REPO}/rekor-cli:$(GIT_HASH)
 
 .PHONY: ko-local
 ko-local:

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,11 @@ sign-container: ko
 	cosign sign --key .github/workflows/cosign.key -a GIT_HASH=$(GIT_HASH) ${KO_DOCKER_REPO}/rekor-server:$(GIT_HASH)
 	cosign sign --key .github/workflows/cosign.key -a GIT_HASH=$(GIT_HASH) ${KO_DOCKER_REPO}/rekor-cli:$(GIT_HASH)
 
+.PHONY: sign-keyless-ci
+sign-keyless-ci: ko
+	cosign sign --force -a GIT_HASH=$(GIT_HASH) ${KO_DOCKER_REPO}/rekor-server:$(GIT_HASH)
+	cosign sign --force -a GIT_HASH=$(GIT_HASH) ${KO_DOCKER_REPO}/rekor-cli:$(GIT_HASH)
+
 .PHONY: ko-local
 ko-local:
 	LDFLAGS="$(SERVER_LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \


### PR DESCRIPTION
#### Summary
- update key flag and add workflow-dispacth to trigger the build manually
- sing using keyless approach 

#### Ticket Link
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
update key flag and add workflow-dispacth to trigger the build manually
```
