### PR TITLE
Switch the trillian containers to multi-plat builds.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,17 @@ ko-local:
 		--tags $(GIT_VERSION) --tags $(GIT_HASH) --local \
 		github.com/sigstore/rekor/cmd/rekor-cli
 
+# This builds the trillian containers we rely on using ko for cross platform support
+.PHONY: ko-trillian
+ko-trillian:
+	LDFLAGS="$(SERVER_LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
+	ko publish --base-import-paths --bare \
+		--platform=all --tags $(GIT_VERSION) --tags $(GIT_HASH) \
+		github.com/google/trillian/cmd/trillian_log_signer
+	ko publish --base-import-paths --bare \
+		--platform=all --tags $(GIT_VERSION) --tags $(GIT_HASH) \
+		github.com/google/trillian/cmd/trillian_log_server
+
 
 ## --------------------------------------
 ## Tooling Binaries

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@
 version: '3.4'
 services:
   mysql:
+    platform: linux/amd64
     image: gcr.io/trillian-opensource-ci/db_server:v1.4.0
     environment:
       - MYSQL_ROOT_PASSWORD=zaphod
@@ -45,7 +46,7 @@ services:
       retries: 3
       start_period: 5s
   trillian-log-server:
-    image: gcr.io/trillian-opensource-ci/log_server:v1.4.0
+    image: gcr.io/projectsigstore/trillian_log_server@sha256:f850a0defd089ea844822030c67ae05bc93c91168a7dd4aceb0b6648c39f696b
     command: [
       "--storage_system=mysql",
       "--mysql_uri=test:zaphod@tcp(mysql:3306)/test",
@@ -60,7 +61,7 @@ services:
     depends_on:
       - mysql
   trillian-log-signer:
-    image: gcr.io/trillian-opensource-ci/log_signer:v1.4.0
+    image: gcr.io/projectsigstore/trillian_log_signer@sha256:fe90d523f6617974f70878918e4b31d49b2b46a86024bb2d6b01d2bbfed8edbf
     command: [
       "--storage_system=mysql",
       "--mysql_uri=test:zaphod@tcp(mysql:3306)/test",

--- a/hack/tools/tools.go
+++ b/hack/tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 // Copyright 2021 The Sigstore Authors.
@@ -24,4 +25,8 @@ import (
 	_ "github.com/dvyukov/go-fuzz/go-fuzz-build"
 	_ "github.com/dvyukov/go-fuzz/go-fuzz-dep"
 	_ "github.com/go-swagger/go-swagger/cmd/swagger"
+
+	// These are so we can build these two binaries into containers with ko
+	_ "github.com/google/trillian/cmd/trillian_log_server"
+	_ "github.com/google/trillian/cmd/trillian_log_signer"
 )


### PR DESCRIPTION
These were done using ko. We should probably figure out the best
way to automate this.


Ref #545

Signed-off-by: Dan Lorenc <lorenc.d@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
