### PR TITLE
Add another helper to return the active shard from the flag set.

### DIFF
--- a/cmd/rekor-server/app/flags.go
+++ b/cmd/rekor-server/app/flags.go
@@ -104,3 +104,8 @@ func (l *LogRanges) ResolveVirtualIndex(index int) (uint64, uint64) {
 	// Return the last one!
 	return l.Ranges[len(l.Ranges)-1].TreeID, uint64(indexLeft)
 }
+
+// ActiveIndex returns the active shard index, always the last shard in the range
+func (l *LogRanges) ActiveIndex() uint64 {
+	return l.Ranges[len(l.Ranges)-1].TreeID
+}

--- a/cmd/rekor-server/app/flags_test.go
+++ b/cmd/rekor-server/app/flags_test.go
@@ -23,9 +23,10 @@ import (
 
 func TestLogRanges_Set(t *testing.T) {
 	tests := []struct {
-		name string
-		arg  string
-		want []LogRange
+		name   string
+		arg    string
+		want   []LogRange
+		active uint64
 	}{
 		{
 			name: "one, no length",
@@ -36,6 +37,7 @@ func TestLogRanges_Set(t *testing.T) {
 					TreeLength: 0,
 				},
 			},
+			active: 1234,
 		},
 		{
 			name: "two",
@@ -50,6 +52,7 @@ func TestLogRanges_Set(t *testing.T) {
 					TreeLength: 0,
 				},
 			},
+			active: 7234,
 		},
 	}
 	for _, tt := range tests {
@@ -61,6 +64,11 @@ func TestLogRanges_Set(t *testing.T) {
 
 			if diff := cmp.Diff(tt.want, l.Ranges); diff != "" {
 				t.Errorf(diff)
+			}
+
+			active := l.ActiveIndex()
+			if active != tt.active {
+				t.Errorf("LogRanges.Active() expected %d no error, got %d", tt.active, active)
 			}
 		})
 	}


### PR DESCRIPTION
This should help out with #515.

Signed-off-by: Dan Lorenc <lorenc.d@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
