### PR TITLE
Fix a bug in minisign canonicalization.

### DIFF
--- a/pkg/pki/minisign/minisign.go
+++ b/pkg/pki/minisign/minisign.go
@@ -120,6 +120,7 @@ func NewPublicKey(r io.Reader) (*PublicKey, error) {
 	}
 
 	inputString := inputBuffer.String()
+
 	key, err := minisign.DecodePublicKey(inputString)
 	if err != nil {
 		// try as a standalone base64 string
@@ -139,7 +140,11 @@ func (k PublicKey) CanonicalValue() ([]byte, error) {
 		return nil, fmt.Errorf("minisign public key has not been initialized")
 	}
 
-	b64Key := base64.StdEncoding.EncodeToString(k.key.PublicKey[:])
+	bin := []byte{}
+	bin = append(bin, k.key.SignatureAlgorithm[:]...)
+	bin = append(bin, k.key.KeyId[:]...)
+	bin = append(bin, k.key.PublicKey[:]...)
+	b64Key := base64.StdEncoding.EncodeToString(bin)
 	return []byte(b64Key), nil
 }
 

--- a/pkg/pki/minisign/minisign_test.go
+++ b/pkg/pki/minisign/minisign_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"go.uber.org/goleak"
 )
 
@@ -239,6 +240,15 @@ func TestCanonicalValuePublicKey(t *testing.T) {
 
 		if bytes.Equal(cvInput, cvOutput) != tc.match {
 			t.Errorf("%v: %v equality of canonical values of %v and %v was expected but not generated", tc.caseDesc, tc.match, tc.input, tc.output)
+		}
+
+		// The canonical values should be round-trippable
+		rt, err := NewPublicKey(bytes.NewReader(cvInput))
+		if err != nil {
+			t.Fatalf("error parsing canonicalized key: %v", err)
+		}
+		if diff := cmp.Diff(rt.key, inputKey.key); diff != "" {
+			t.Error(diff)
 		}
 	}
 }


### PR DESCRIPTION
We were previously stripping off the keyid/algorithm identifiers in minisign public keys.
These should be included in here to properly canonicalize/reconstruct the keys for verification.

I found this during debugging on #561 

Signed-off-by: Dan Lorenc <lorenc.d@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
