### PR TITLE
Remove the attestation media type field.

### DIFF
--- a/cmd/rekor-cli/app/get.go
+++ b/cmd/rekor-cli/app/get.go
@@ -159,7 +159,6 @@ func parseEntry(uuid string, e models.LogEntryAnon) (interface{}, error) {
 
 	if e.Attestation != nil {
 		obj.Attestation = string(e.Attestation.Data)
-		obj.AttestationType = e.Attestation.MediaType
 	}
 
 	return &obj, nil

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -468,9 +468,7 @@ definitions:
           type: object
           properties:
             data:
-              format: byte
-            mediaType:
-              format: string
+              format: byte       
 
           format: byte
         verification:

--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -94,13 +94,12 @@ func logEntryFromLeaf(ctx context.Context, signer signature.Signer, tc TrillianC
 
 	uuid := hex.EncodeToString(leaf.MerkleLeafHash)
 	if viper.GetBool("enable_attestation_storage") {
-		att, typ, err := storageClient.FetchAttestation(ctx, uuid)
+		att, err := storageClient.FetchAttestation(ctx, uuid)
 		if err != nil {
 			log.Logger.Errorf("error fetching attestation: %s %s", uuid, err)
 		} else {
 			logEntryAnon.Attestation = &models.LogEntryAnonAttestation{
-				Data:      att,
-				MediaType: typ,
+				Data: att,
 			}
 		}
 	}
@@ -210,12 +209,12 @@ func createLogEntry(params entries.CreateLogEntryParams) (models.LogEntry, middl
 	if viper.GetBool("enable_attestation_storage") {
 
 		go func() {
-			typ, attestation := entry.Attestation()
-			if typ == "" {
+			attestation := entry.Attestation()
+			if attestation == nil {
 				log.RequestIDLogger(params.HTTPRequest).Infof("no attestation for %s", uuid)
 				return
 			}
-			if err := storeAttestation(context.Background(), uuid, typ, attestation); err != nil {
+			if err := storeAttestation(context.Background(), uuid, attestation); err != nil {
 				log.RequestIDLogger(params.HTTPRequest).Errorf("error storing attestation: %s", err)
 			}
 		}()

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -96,6 +96,6 @@ func addToIndex(ctx context.Context, key, value string) error {
 	return redisClient.Do(ctx, radix.Cmd(nil, "LPUSH", key, value))
 }
 
-func storeAttestation(ctx context.Context, uuid, attestationType string, attestation []byte) error {
-	return storageClient.StoreAttestation(ctx, uuid, attestationType, attestation)
+func storeAttestation(ctx context.Context, uuid string, attestation []byte) error {
+	return storageClient.StoreAttestation(ctx, uuid, attestation)
 }

--- a/pkg/generated/models/log_entry.go
+++ b/pkg/generated/models/log_entry.go
@@ -300,9 +300,6 @@ type LogEntryAnonAttestation struct {
 	// data
 	// Format: byte
 	Data strfmt.Base64 `json:"data,omitempty"`
-
-	// media type
-	MediaType string `json:"mediaType,omitempty"`
 }
 
 // Validate validates this log entry anon attestation

--- a/pkg/generated/restapi/embedded_spec.go
+++ b/pkg/generated/restapi/embedded_spec.go
@@ -498,9 +498,6 @@ func init() {
             "properties": {
               "data": {
                 "format": "byte"
-              },
-              "mediaType": {
-                "format": "string"
               }
             }
           },
@@ -1982,9 +1979,6 @@ func init() {
           "properties": {
             "data": {
               "format": "byte"
-            },
-            "mediaType": {
-              "format": "string"
             }
           }
         },
@@ -2025,9 +2019,6 @@ func init() {
       "properties": {
         "data": {
           "format": "byte"
-        },
-        "mediaType": {
-          "format": "string"
         }
       }
     },

--- a/pkg/types/alpine/v0.0.1/entry.go
+++ b/pkg/types/alpine/v0.0.1/entry.go
@@ -300,8 +300,8 @@ func (v V001Entry) validate() error {
 	return nil
 }
 
-func (v V001Entry) Attestation() (string, []byte) {
-	return "", nil
+func (v V001Entry) Attestation() []byte {
+	return nil
 }
 
 func (v V001Entry) CreateFromArtifactProperties(ctx context.Context, props types.ArtifactProperties) (models.ProposedEntry, error) {

--- a/pkg/types/entries.go
+++ b/pkg/types/entries.go
@@ -35,7 +35,7 @@ type EntryImpl interface {
 	IndexKeys() ([]string, error)                     // the keys that should be added to the external index for this entry
 	Canonicalize(ctx context.Context) ([]byte, error) // marshal the canonical entry to be put into the tlog
 	Unmarshal(e models.ProposedEntry) error           // unmarshal the abstract entry into the specific struct for this versioned type
-	Attestation() (string, []byte)
+	Attestation() []byte
 	CreateFromArtifactProperties(context.Context, ArtifactProperties) (models.ProposedEntry, error)
 }
 

--- a/pkg/types/hashedrekord/v0.0.1/entry.go
+++ b/pkg/types/hashedrekord/v0.0.1/entry.go
@@ -182,8 +182,8 @@ func (v *V001Entry) validate() (pki.Signature, pki.PublicKey, error) {
 	return sigObj, keyObj, nil
 }
 
-func (v V001Entry) Attestation() (string, []byte) {
-	return "", nil
+func (v V001Entry) Attestation() []byte {
+	return nil
 }
 
 func (v V001Entry) CreateFromArtifactProperties(ctx context.Context, props types.ArtifactProperties) (models.ProposedEntry, error) {

--- a/pkg/types/helm/v0.0.1/entry.go
+++ b/pkg/types/helm/v0.0.1/entry.go
@@ -299,8 +299,8 @@ func (v V001Entry) validate() error {
 	return nil
 }
 
-func (v V001Entry) Attestation() (string, []byte) {
-	return "", nil
+func (v V001Entry) Attestation() []byte {
+	return nil
 }
 
 func (v V001Entry) CreateFromArtifactProperties(ctx context.Context, props types.ArtifactProperties) (models.ProposedEntry, error) {

--- a/pkg/types/intoto/v0.0.1/entry.go
+++ b/pkg/types/intoto/v0.0.1/entry.go
@@ -193,12 +193,12 @@ func (v *V001Entry) validate() error {
 	return nil
 }
 
-func (v *V001Entry) Attestation() (string, []byte) {
+func (v *V001Entry) Attestation() []byte {
 	if len(v.env.Payload) > viper.GetInt("max_attestation_size") {
 		log.Logger.Infof("Skipping attestation storage, size %d is greater than max %d", len(v.env.Payload), viper.GetInt("max_attestation_size"))
-		return "", nil
+		return nil
 	}
-	return v.env.PayloadType, []byte(v.env.Payload)
+	return []byte(v.env.Payload)
 }
 
 type verifier struct {

--- a/pkg/types/jar/v0.0.1/entry.go
+++ b/pkg/types/jar/v0.0.1/entry.go
@@ -290,8 +290,8 @@ func extractPKCS7SignatureFromJAR(inz *zip.Reader) ([]byte, error) {
 	return nil, errors.New("unable to locate signature in JAR file")
 }
 
-func (v V001Entry) Attestation() (string, []byte) {
-	return "", nil
+func (v V001Entry) Attestation() []byte {
+	return nil
 }
 
 func (v V001Entry) CreateFromArtifactProperties(ctx context.Context, props types.ArtifactProperties) (models.ProposedEntry, error) {

--- a/pkg/types/rekord/v0.0.1/entry.go
+++ b/pkg/types/rekord/v0.0.1/entry.go
@@ -353,8 +353,8 @@ func (v V001Entry) validate() error {
 	return nil
 }
 
-func (v V001Entry) Attestation() (string, []byte) {
-	return "", nil
+func (v V001Entry) Attestation() []byte {
+	return nil
 }
 
 func (v V001Entry) CreateFromArtifactProperties(ctx context.Context, props types.ArtifactProperties) (models.ProposedEntry, error) {

--- a/pkg/types/rfc3161/v0.0.1/entry.go
+++ b/pkg/types/rfc3161/v0.0.1/entry.go
@@ -173,8 +173,8 @@ func (v V001Entry) validate() error {
 	return nil
 }
 
-func (v V001Entry) Attestation() (string, []byte) {
-	return "", nil
+func (v V001Entry) Attestation() []byte {
+	return nil
 }
 
 func (v V001Entry) CreateFromArtifactProperties(_ context.Context, props types.ArtifactProperties) (models.ProposedEntry, error) {

--- a/pkg/types/rpm/v0.0.1/entry.go
+++ b/pkg/types/rpm/v0.0.1/entry.go
@@ -321,8 +321,8 @@ func (v V001Entry) validate() error {
 	return nil
 }
 
-func (v V001Entry) Attestation() (string, []byte) {
-	return "", nil
+func (v V001Entry) Attestation() []byte {
+	return nil
 }
 
 func (v V001Entry) CreateFromArtifactProperties(ctx context.Context, props types.ArtifactProperties) (models.ProposedEntry, error) {

--- a/pkg/types/test_util.go
+++ b/pkg/types/test_util.go
@@ -48,8 +48,8 @@ func (u BaseUnmarshalTester) Validate() error {
 	return nil
 }
 
-func (u BaseUnmarshalTester) Attestation() (string, []byte) {
-	return "", nil
+func (u BaseUnmarshalTester) Attestation() []byte {
+	return nil
 }
 
 func (u BaseUnmarshalTester) CreateFromArtifactProperties(_ context.Context, _ ArtifactProperties) (models.ProposedEntry, error) {

--- a/pkg/types/tuf/v0.0.1/entry.go
+++ b/pkg/types/tuf/v0.0.1/entry.go
@@ -313,8 +313,8 @@ func (v V001Entry) Validate() error {
 	return nil
 }
 
-func (v *V001Entry) Attestation() (string, []byte) {
-	return "", nil
+func (v *V001Entry) Attestation() []byte {
+	return nil
 }
 
 func (v V001Entry) CreateFromArtifactProperties(ctx context.Context, props types.ArtifactProperties) (models.ProposedEntry, error) {


### PR DESCRIPTION
This was never actually correct - these are technically "payloadTypes", which are
not actually mediaTypes. Some implementations mistakenly sent incorrect media types, so
it appeared to work. The GCS storage layer rejected correct implementations that sent the
payloadType, because these are not valid mediaTypes.

We never used this field anyway, so let's drop it. I verified that the API correctly ignores
unknown fields, so removing this will not break clients that send it.

Signed-off-by: Dan Lorenc <lorenc.d@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
