### PR TITLE
rekor-cli: show the url in case of error

### DIFF
--- a/pkg/util/fetch.go
+++ b/pkg/util/fetch.go
@@ -39,7 +39,7 @@ func FileOrURLReadCloser(ctx context.Context, url string, content []byte) (io.Re
 			return nil, err
 		}
 		if resp.StatusCode < 200 || resp.StatusCode > 299 {
-			return nil, fmt.Errorf("error received while fetching artifact: %v", resp.Status)
+			return nil, fmt.Errorf("error received while fetching artifact '%v': %v", url, resp.Status)
 		}
 
 		dataReader = resp.Body


### PR DESCRIPTION
Otherwise, the error:
`
error retrieving external entities: error received while fetching artifact: 404 Not Found
`
Which isn't great for debugging

Signed-off-by: Sylvestre Ledru <sylvestre@debian.org>
