### PR TITLE
update release image to use go 1.17.6

### DIFF
--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -41,9 +41,9 @@ steps:
   - 'verify'
   - '--key'
   - 'https://raw.githubusercontent.com/gythialy/golang-cross/main/cosign.pub'
-  - 'ghcr.io/gythialy/golang-cross:v1.17.5-4@sha256:e1ae043ca969c0b46bb23aa3dd0443a9271c2f665513168091864aa3b751f12a'
+  - 'ghcr.io/gythialy/golang-cross:v1.17.6-0@sha256:d22430bb9b3b2ba21adae7f9774a68e9891a0458c8e487edf86311cefb32c766'
 
-- name: ghcr.io/gythialy/golang-cross:v1.17.5-4@sha256:e1ae043ca969c0b46bb23aa3dd0443a9271c2f665513168091864aa3b751f12a
+- name: ghcr.io/gythialy/golang-cross:v1.17.6-0@sha256:d22430bb9b3b2ba21adae7f9774a68e9891a0458c8e487edf86311cefb32c766
   entrypoint: /bin/sh
   dir: "go/src/sigstore/rekor"
   env:
@@ -64,7 +64,7 @@ steps:
     - |
       make release
 
-- name: ghcr.io/gythialy/golang-cross:v1.17.5-4@sha256:e1ae043ca969c0b46bb23aa3dd0443a9271c2f665513168091864aa3b751f12a
+- name: ghcr.io/gythialy/golang-cross:v1.17.6-0@sha256:d22430bb9b3b2ba21adae7f9774a68e9891a0458c8e487edf86311cefb32c766
   entrypoint: 'bash'
   dir: "go/src/sigstore/rekor"
   env:


### PR DESCRIPTION
#### Summary
- update release image to use go 1.17.6

release: https://github.com/gythialy/golang-cross/releases/tag/v1.17.6-0

#### Ticket Link
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
update release image to use go 1.17.6
```
