### PR TITLE
Set Accept header in dynamic counter requests

### DIFF
--- a/pkg/generated/restapi/rekorHomePage.html
+++ b/pkg/generated/restapi/rekorHomePage.html
@@ -32,7 +32,7 @@
   <script type="text/javascript">
 const url = '/api/v1/log/';
 function update() {
-  fetch(url).then((resp) => {
+  fetch(url, {headers: {'Accept': 'application/json'}}).then((resp) => {
     resp.json().then((j) => {
       let count = j.treeSize;
       document.getElementById('count').innerText = count;


### PR DESCRIPTION
Ref: https://github.com/sigstore/rekor/issues/593

Without this header, sometimes the response will come back as YAML and `.json()` will fail to decode it, resulting in a bad experience.
