### PR TITLE
Create EntryID for new artifacts and return EntryID to user

### DIFF
--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -223,7 +223,10 @@ func TestGet(t *testing.T) {
 	out := runCli(t, "upload", "--artifact", artifactPath, "--signature", sigPath, "--public-key", pubPath)
 	outputContains(t, out, "Created entry at")
 
-	uuid := getUUIDFromUploadOutput(t, out)
+	uuid, err := sharding.GetUUIDFromIDString(getUUIDFromUploadOutput(t, out))
+	if err != nil {
+		t.Error(err)
+	}
 
 	// since we at least have 1 valid entry, check the log at index 0
 	runCli(t, "get", "--log-index", "0")


### PR DESCRIPTION
#### Summary
This will complete the UUID parsing component of the sharding work. It creates and returns a longer UUID (EntryID) to the user, so this change should go into a new release.

Edit:
As far as I understand, we should wait to merge this PR until we're ready for a new Rekor release - are there other changes that would go into that release? Do we have a timeline?

#### Ticket Link

Fixes #487 

#### Release Note

<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
    TODO
```
