### PR TITLE
update release job

### DIFF
--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -38,6 +38,10 @@ jobs:
       security-events: none
       statuses: none
 
+    env:
+      CROSS_BUILDER_IMAGE: ghcr.io/gythialy/golang-cross:v1.17.6-3@sha256:312ac8449408302e5fdde452578607cff075bc80052f4526254cd25fa96ce9e0
+      COSIGN_IMAGE: gcr.io/projectsigstore/cosign:v1.5.1@sha256:6247b2e693b0e6a62dcfa75eb46b698c1f4cd1aca36aaefafd4bbb2f2b2af717
+
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 #v2.4.0
       - name: Extract version of Go to use
@@ -50,6 +54,15 @@ jobs:
         uses: goreleaser/goreleaser-action@79d4afbba1b4eff8b9a98e3d2e58c4dbaf094e2b #v2.8.1
         with:
           install-only: true
+
+      - name: Check Signature
+        run: |
+          docker run --rm \
+          -e COSIGN_EXPERIMENTAL=true \
+          -e TUF_ROOT=/tmp \
+          $COSIGN_IMAGE \
+          verify \
+          $CROSS_BUILDER_IMAGE
 
       - name: snaphot
         run: make snapshot

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,6 +10,7 @@ env:
 before:
   hooks:
     - go mod tidy
+    - /bin/bash -c 'if [ -n "$(git --no-pager diff --exit-code go.mod go.sum)" ]; then exit 1; fi'
 
 gomod:
   proxy: true
@@ -70,7 +71,8 @@ builds:
      - "{{ .Env.CLIENT_LDFLAGS }}"
 
 signs:
-  - signature: "${artifact}.sig"
+  - id: rekor
+    signature: "${artifact}.sig"
     cmd: cosign
     args: ["sign-blob", "--output-signature", "${artifact}.sig", "--key", "gcpkms://projects/{{ .Env.PROJECT_ID }}/locations/{{ .Env.KEY_LOCATION }}/keyRings/{{ .Env.KEY_RING }}/cryptoKeys/{{ .Env.KEY_NAME }}/versions/{{ .Env.KEY_VERSION }}", "${artifact}"]
     artifacts: binary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Highlights
 
+* Add Rekor logo to README (https://github.com/sigstore/rekor/pull/650)
 * update API calls to v5 (https://github.com/sigstore/rekor/pull/591)
 * Refactor helm type to remove intermediate state. (https://github.com/sigstore/rekor/pull/575)
 * Refactor the shard map parsing so we can pass it down into the API object. (https://github.com/sigstore/rekor/pull/564)
@@ -70,6 +71,7 @@
 * Jason Hall (@imjasonh)
 * Lily Sturmann (@lkatalin)
 * Morten Linderud (@Foxboron)
+* Nathan Smith (@nsmith5)
 * Sylvestre Ledru (@sylvestre)
 * Trishank Karthik Kuppusamy (@trishankatdatadog)
 

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -32,18 +32,16 @@ steps:
     echo "Checking out ${_GIT_TAG}"
     git checkout ${_GIT_TAG}
 
-- name: 'gcr.io/projectsigstore/cosign:v1.4.1@sha256:502d5130431e45f28c51d2c24a05ef5ccd3fd916bcc91db0c8bee3a81e09a0bb'
+- name: 'gcr.io/projectsigstore/cosign:v1.5.1@sha256:6247b2e693b0e6a62dcfa75eb46b698c1f4cd1aca36aaefafd4bbb2f2b2af717'
   dir: "go/src/sigstore/rekor"
   env:
   - COSIGN_EXPERIMENTAL=true
   - TUF_ROOT=/tmp
   args:
   - 'verify'
-  - '--key'
-  - 'https://raw.githubusercontent.com/gythialy/golang-cross/main/cosign.pub'
-  - 'ghcr.io/gythialy/golang-cross:v1.17.6-0@sha256:d22430bb9b3b2ba21adae7f9774a68e9891a0458c8e487edf86311cefb32c766'
+  - 'ghcr.io/gythialy/golang-cross:v1.17.6-3@sha256:312ac8449408302e5fdde452578607cff075bc80052f4526254cd25fa96ce9e0'
 
-- name: ghcr.io/gythialy/golang-cross:v1.17.6-0@sha256:d22430bb9b3b2ba21adae7f9774a68e9891a0458c8e487edf86311cefb32c766
+- name: ghcr.io/gythialy/golang-cross:v1.17.6-3@sha256:312ac8449408302e5fdde452578607cff075bc80052f4526254cd25fa96ce9e0
   entrypoint: /bin/sh
   dir: "go/src/sigstore/rekor"
   env:
@@ -64,7 +62,7 @@ steps:
     - |
       make release
 
-- name: ghcr.io/gythialy/golang-cross:v1.17.6-0@sha256:d22430bb9b3b2ba21adae7f9774a68e9891a0458c8e487edf86311cefb32c766
+- name: ghcr.io/gythialy/golang-cross:v1.17.6-3@sha256:312ac8449408302e5fdde452578607cff075bc80052f4526254cd25fa96ce9e0
   entrypoint: 'bash'
   dir: "go/src/sigstore/rekor"
   env:


### PR DESCRIPTION
#### Summary
before the 0.5.0 release I did a rehearsal and found some updates to be made



rehearsal: https://github.com/cpanato/rekor/releases/tag/v9.99.9

```
$ docker run gcr.io/cpanato-general/rekor-server:v9.99.9 version
Unable to find image 'gcr.io/cpanato-general/rekor-server:v9.99.9' locally
v9.99.9: Pulling from cpanato-general/rekor-server
2df365faf0e3: Already exists
c6f4d1a13b69: Already exists
7e061386ba97: Already exists
250c06f7c38e: Already exists
b41daeca4c61: Pull complete
Digest: sha256:4d869ec63cbb4528b77848007dcd47e8e19b286a133e3143bb334550c41c7888
Status: Downloaded newer image for gcr.io/cpanato-general/rekor-server:v9.99.9
GitVersion:    v9.99.9
GitCommit:     af4e6c7b852140e88b14b252a5694f8d116cfbea
GitTreeState:  clean
BuildDate:     '2022-02-04T09:31:09Z'
GoVersion:     go1.17.6
Compiler:      gc
Platform:      linux/amd64

```

#### Ticket Link
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
NONE
```
