### PR TITLE
Add docs about API stability and deprecation policy

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -1,0 +1,10 @@
+# Deprecations
+
+This doc lists deprecated features in `rekor`.
+You can read more about Sigstore's deprecation policy [here](https://docs.sigstore.dev/api-stability)!
+
+| **Feature Being Deprecated** | **API Stability Level** | **Earliest Date of Removal** |
+|------------------------------|-------------------------|------------------------------|
+| My feature                   | Experimental/Beta/GA    | DD/MM/YY                     |
+|                              |                         |                              |
+|                              |                         |                              |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,0 +1,14 @@
+# Feature Stability
+
+This doc covers feature stability in `rekor` as described in the [API Stability Policy](https://docs.sigstore.dev/api-stability) for Sigstore.
+
+## Experimental
+
+
+## Beta
+* Rekor API, defined [here](https://github.com/sigstore/rekor/blob/main/openapi.yaml)
+* The Rekor RFC 3161 timestamping service
+* `rekor-cli` CLI tool
+* The `rekor/pkg/client` client library
+
+## General Availability


### PR DESCRIPTION
Adding deprecation policy and feature stability docs based on the policy described [here](https://docs.sigstore.dev/api-stability).

I put everything in `beta` right now because Rekor isn't 1.0, but happy to move features to other sections if that's more accurate.


Ref https://github.com/sigstore/sigstore-website/issues/119

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

