### PR TITLE
Use logRangesFlag in API, route reads based on TreeID

### DIFF
--- a/cmd/rekor-cli/app/log_info.go
+++ b/cmd/rekor-cli/app/log_info.go
@@ -43,6 +43,7 @@ type logInfoCmdOutput struct {
 	TreeSize       int64
 	RootHash       string
 	TimestampNanos uint64
+	TreeID         int64
 }
 
 func (l *logInfoCmdOutput) String() string {
@@ -52,7 +53,8 @@ func (l *logInfoCmdOutput) String() string {
 Tree Size: %v
 Root Hash: %s
 Timestamp: %s
-`, l.TreeSize, l.RootHash, ts)
+TreeID:    %v
+`, l.TreeSize, l.RootHash, ts, l.TreeID)
 }
 
 // logInfoCmd represents the current information about the transparency log
@@ -114,6 +116,7 @@ var logInfoCmd = &cobra.Command{
 			TreeSize:       *logInfo.TreeSize,
 			RootHash:       *logInfo.RootHash,
 			TimestampNanos: sth.GetTimestamp(),
+			TreeID:         *logInfo.TreeID,
 		}
 
 		oldState := state.Load(serverURL)

--- a/cmd/rekor-server/app/flags.go
+++ b/cmd/rekor-server/app/flags.go
@@ -41,11 +41,11 @@ func (l *LogRangesFlag) Set(s string) error {
 			return fmt.Errorf("invalid range flag, expected two parts separated by an =, got %s", r)
 		}
 		lr := sharding.LogRange{}
-		lr.TreeID, err = strconv.ParseUint(split[0], 10, 64)
+		lr.TreeID, err = strconv.ParseInt(split[0], 10, 64)
 		if err != nil {
 			return err
 		}
-		lr.TreeLength, err = strconv.ParseUint(split[1], 10, 64)
+		lr.TreeLength, err = strconv.ParseInt(split[1], 10, 64)
 		if err != nil {
 			return err
 		}
@@ -55,7 +55,7 @@ func (l *LogRangesFlag) Set(s string) error {
 
 	// The last entry is special and should not have a terminating range, because this is active.
 	lastRangeStr := ranges[len(ranges)-1]
-	lastTreeID, err := strconv.ParseUint(lastRangeStr, 10, 64)
+	lastTreeID, err := strconv.ParseInt(lastRangeStr, 10, 64)
 	if err != nil {
 		return err
 	}
@@ -65,7 +65,7 @@ func (l *LogRangesFlag) Set(s string) error {
 	})
 
 	// Look for duplicate tree ids
-	TreeIDs := map[uint64]struct{}{}
+	TreeIDs := map[int64]struct{}{}
 	for _, lr := range inputRanges {
 		if _, ok := TreeIDs[lr.TreeID]; ok {
 			return fmt.Errorf("duplicate tree id: %d", lr.TreeID)

--- a/cmd/rekor-server/app/flags_test.go
+++ b/cmd/rekor-server/app/flags_test.go
@@ -27,7 +27,7 @@ func TestLogRanges_Set(t *testing.T) {
 		name   string
 		arg    string
 		want   []sharding.LogRange
-		active uint64
+		active int64
 	}{
 		{
 			name: "one, no length",

--- a/cmd/rekor-server/app/root.go
+++ b/cmd/rekor-server/app/root.go
@@ -65,7 +65,7 @@ func init() {
 	rootCmd.PersistentFlags().String("trillian_log_server.address", "127.0.0.1", "Trillian log server address")
 	rootCmd.PersistentFlags().Uint16("trillian_log_server.port", 8090, "Trillian log server port")
 	rootCmd.PersistentFlags().Uint("trillian_log_server.tlog_id", 0, "Trillian tree id")
-	rootCmd.PersistentFlags().Var(&logRangeMap, "trillian_log_server.log_id_ranges", "ordered list of tree ids and ranges")
+	rootCmd.PersistentFlags().String("trillian_log_server.log_id_ranges", "", "ordered list of tree ids and ranges")
 
 	rootCmd.PersistentFlags().String("rekor_server.hostname", "rekor.sigstore.dev", "public hostname of instance")
 	rootCmd.PersistentFlags().String("rekor_server.address", "127.0.0.1", "Address to bind to")

--- a/cmd/rekor-server/app/serve.go
+++ b/cmd/rekor-server/app/serve.go
@@ -103,6 +103,14 @@ var serveCmd = &cobra.Command{
 		server.Port = int(viper.GetUint("port"))
 		server.EnabledListeners = []string{"http"}
 
+		// Update logRangeMap if flag was passed in
+		rangeMap := viper.GetString("trillian_log_server.log_id_ranges")
+		if rangeMap != "" {
+			if err := logRangeMap.Set(rangeMap); err != nil {
+				log.Logger.Fatal("unable to set logRangeMap from flag: %v", err)
+			}
+		}
+
 		api.ConfigureAPI(logRangeMap.Ranges)
 		server.ConfigureAPI()
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -581,10 +581,14 @@ definitions:
         type: string
         format: signedCheckpoint
         description: The current signed tree head
+      treeID:
+        type: integer
+        description: The current treeID
     required:
       - rootHash
       - treeSize
       - signedTreeHead
+      - treeID
 
   ConsistencyProof:
     type: object

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -85,7 +85,10 @@ func NewAPI(ranges sharding.LogRanges) (*API, error) {
 			return nil, errors.Wrap(err, "create and init tree")
 		}
 		tLogID = t.TreeId
+		log.Logger.Infof("Creating new tree with ID: %v", t.TreeId)
 	}
+	// append the active treeID to the API's logRangeMap for lookups
+	ranges.Ranges = append(ranges.Ranges, sharding.LogRange{TreeID: tLogID})
 
 	rekorSigner, err := signer.New(ctx, viper.GetString("rekor_server.signer"))
 	if err != nil {

--- a/pkg/api/tlog.go
+++ b/pkg/api/tlog.go
@@ -76,7 +76,9 @@ func GetLogInfoHandler(params tlog.GetLogInfoParams) middleware.Responder {
 		RootHash:       &hashString,
 		TreeSize:       &treeSize,
 		SignedTreeHead: &scString,
+		TreeID:         &tc.logID,
 	}
+
 	return tlog.NewGetLogInfoOK().WithPayload(&logInfo)
 }
 

--- a/pkg/api/trillian_client.go
+++ b/pkg/api/trillian_client.go
@@ -48,6 +48,14 @@ func NewTrillianClient(ctx context.Context) TrillianClient {
 	}
 }
 
+func NewTrillianClientFromTreeID(ctx context.Context, tid int64) TrillianClient {
+	return TrillianClient{
+		client:  api.logClient,
+		logID:   tid,
+		context: ctx,
+	}
+}
+
 type Response struct {
 	status                    codes.Code
 	err                       error

--- a/pkg/generated/models/log_info.go
+++ b/pkg/generated/models/log_info.go
@@ -44,6 +44,10 @@ type LogInfo struct {
 	// Required: true
 	SignedTreeHead *string `json:"signedTreeHead"`
 
+	// The current treeID
+	// Required: true
+	TreeID *int64 `json:"treeID"`
+
 	// The current number of nodes in the merkle tree
 	// Required: true
 	// Minimum: 1
@@ -59,6 +63,10 @@ func (m *LogInfo) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateSignedTreeHead(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateTreeID(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -88,6 +96,15 @@ func (m *LogInfo) validateRootHash(formats strfmt.Registry) error {
 func (m *LogInfo) validateSignedTreeHead(formats strfmt.Registry) error {
 
 	if err := validate.Required("signedTreeHead", "body", m.SignedTreeHead); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *LogInfo) validateTreeID(formats strfmt.Registry) error {
+
+	if err := validate.Required("treeID", "body", m.TreeID); err != nil {
 		return err
 	}
 

--- a/pkg/sharding/ranges.go
+++ b/pkg/sharding/ranges.go
@@ -20,24 +20,24 @@ type LogRanges struct {
 }
 
 type LogRange struct {
-	TreeID     uint64
-	TreeLength uint64
+	TreeID     int64
+	TreeLength int64
 }
 
-func (l *LogRanges) ResolveVirtualIndex(index int) (uint64, uint64) {
+func (l *LogRanges) ResolveVirtualIndex(index int) (int64, int64) {
 	indexLeft := index
 	for _, l := range l.Ranges {
 		if indexLeft < int(l.TreeLength) {
-			return l.TreeID, uint64(indexLeft)
+			return l.TreeID, int64(indexLeft)
 		}
 		indexLeft -= int(l.TreeLength)
 	}
 
 	// Return the last one!
-	return l.Ranges[len(l.Ranges)-1].TreeID, uint64(indexLeft)
+	return l.Ranges[len(l.Ranges)-1].TreeID, int64(indexLeft)
 }
 
 // ActiveIndex returns the active shard index, always the last shard in the range
-func (l *LogRanges) ActiveIndex() uint64 {
+func (l *LogRanges) ActiveIndex() int64 {
 	return l.Ranges[len(l.Ranges)-1].TreeID
 }

--- a/pkg/sharding/ranges_test.go
+++ b/pkg/sharding/ranges_test.go
@@ -29,8 +29,8 @@ func TestLogRanges_ResolveVirtualIndex(t *testing.T) {
 
 	for _, tt := range []struct {
 		Index      int
-		WantTreeID uint64
-		WantIndex  uint64
+		WantTreeID int64
+		WantIndex  int64
 	}{
 		{
 			Index:      3,

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -258,7 +258,13 @@ func TestGet(t *testing.T) {
 	outputContains(t, out, uuid)
 
 	// Exercise GET with the new EntryID (TreeID + UUID)
-	entryID, err := sharding.CreateEntryIDFromParts("0", uuid)
+	out = runCli(t, "loginfo")
+	tidStr := strings.TrimSpace(strings.Split(out, "TreeID: ")[1])
+	tid, err := strconv.ParseInt(tidStr, 10, 64)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	entryID, err := sharding.CreateEntryIDFromParts(fmt.Sprintf("%x", tid), uuid)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
#### Summary
This PR hooks up the `logRangeMap` flag to be used in API construction. The map can then be accessed to do routing for uuid-based and log-index-based reads.

I made the `logRangeMap` flag into a string because the `Set()` method can be used for construction and it was easier than trying to cram the data into a struct from the flag. But if there's a clean way to do this that doesn't involve this change, I'm happy to do it.

WIP because I still need to add some tests, ~~fix the e2e test~~, and do some cleanup, ex. maybe around the int types. And I need to think through 1) making sure this will not break old clients, 2) do we need to use this logic in the writes too before merging (I think this will actually be a change made to the pending PR that emits longer UUIDs upon artifact upload).

Questions:
- [x] How can the current TreeID be accessed during e2e testing?
  - Instead of this, I added a condition that if the `treeID` is zero, we use the `api.logID` instead 
- [x] In the case that both a `tlog_id` and `logRangeMap` are passed in, which takes precedence? The `logRangeMap`'s `ActiveIndex()` **should be** the `tlog_id` (currently using `ActiveIndex()`). 
  - Should we add a check to make sure these are the same? Edit: not doing this
  - Should we base the `tlog_id` in the API on the `ActiveIndex`? Edit: no, I'm appending the `tlog_id` to the `rangeMap`
  - Or should the `tlog_id` function as a flag for signaling the need for a new shard? This seems to be how it is used currently via `createAndInitTree`. Edit: yes, still doing this

Note: Currently it looks like the `tlog_id` in the API is used in only [one place](https://github.com/sigstore/rekor/blob/adab5c53055aa020e0d70da1ad25a394376a9aa6/pkg/api/api.go#L82) in `api.go`, to check whether it is zero and determine if the program should `createAndInitTree`.

Edit: So I think my answer to the above is to add logic that will append any nonzero `tlog_id` passed in at server startup to the API's `logRange`, see code from this PR [here](https://github.com/sigstore/rekor/blob/25b2ac8c0bb61a9bf059e0fad6b011900ef404c8/pkg/api/api.go#L92). If this isn't the right way, let me know or I guess we will change it later. 

#### Ticket Link
Fixes #670
Fixes #632 
Fixes #629 