### PR TITLE
Move k8s objects out of the default namespace

### DIFF
--- a/config/rekor.yaml
+++ b/config/rekor.yaml
@@ -16,6 +16,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: rekor
   name: rekor-server
   labels:
     app: rekor-server
@@ -82,6 +83,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: rekor
   name: rekor-server
 spec:
   selector:

--- a/config/rekor.yaml
+++ b/config/rekor.yaml
@@ -16,7 +16,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: rekor
+  namespace: rekor-system
   name: rekor-server
   labels:
     app: rekor-server
@@ -83,7 +83,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: rekor
+  namespace: rekor-system
   name: rekor-server
 spec:
   selector:

--- a/config/watcher.yaml
+++ b/config/watcher.yaml
@@ -16,6 +16,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: rekor
   name: rekor-watcher
   labels:
     app: rekor-watcher

--- a/config/watcher.yaml
+++ b/config/watcher.yaml
@@ -16,7 +16,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: rekor
+  namespace: rekor-system
   name: rekor-watcher
   labels:
     app: rekor-watcher


### PR DESCRIPTION
Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

Update config yamls to create rekor objects in its own namespace.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes #673

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
rekor objects will now be created in the rekor namespace instead of the default namespace.
```
