### PR TITLE
Set rekor-cli User-Agent header on requests

### DIFF
--- a/cmd/rekor-cli/app/get.go
+++ b/cmd/rekor-cli/app/get.go
@@ -79,7 +79,7 @@ var getCmd = &cobra.Command{
 		}
 	},
 	Run: format.WrapCmd(func(args []string) (interface{}, error) {
-		rekorClient, err := client.GetRekorClient(viper.GetString("rekor_server"))
+		rekorClient, err := client.GetRekorClient(viper.GetString("rekor_server"), client.WithUserAgent(UserAgent()))
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/rekor-cli/app/log_info.go
+++ b/cmd/rekor-cli/app/log_info.go
@@ -62,7 +62,7 @@ var logInfoCmd = &cobra.Command{
 	Long:  `Prints info about the transparency log`,
 	Run: format.WrapCmd(func(args []string) (interface{}, error) {
 		serverURL := viper.GetString("rekor_server")
-		rekorClient, err := client.GetRekorClient(serverURL)
+		rekorClient, err := client.GetRekorClient(serverURL, client.WithUserAgent(UserAgent()))
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/rekor-cli/app/log_proof.go
+++ b/cmd/rekor-cli/app/log_proof.go
@@ -72,7 +72,7 @@ var logProofCmd = &cobra.Command{
 		return nil
 	},
 	Run: format.WrapCmd(func(args []string) (interface{}, error) {
-		rekorClient, err := client.GetRekorClient(viper.GetString("rekor_server"))
+		rekorClient, err := client.GetRekorClient(viper.GetString("rekor_server"), client.WithUserAgent(UserAgent()))
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/rekor-cli/app/search.go
+++ b/cmd/rekor-cli/app/search.go
@@ -96,7 +96,7 @@ var searchCmd = &cobra.Command{
 	},
 	Run: format.WrapCmd(func(args []string) (interface{}, error) {
 		log := log.CliLogger
-		rekorClient, err := client.GetRekorClient(viper.GetString("rekor_server"))
+		rekorClient, err := client.GetRekorClient(viper.GetString("rekor_server"), client.WithUserAgent(UserAgent()))
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/rekor-cli/app/timestamp.go
+++ b/cmd/rekor-cli/app/timestamp.go
@@ -139,7 +139,7 @@ var timestampCmd = &cobra.Command{
 		return nil
 	},
 	Run: format.WrapCmd(func(args []string) (interface{}, error) {
-		rekorClient, err := client.GetRekorClient(viper.GetString("rekor_server"))
+		rekorClient, err := client.GetRekorClient(viper.GetString("rekor_server"), client.WithUserAgent(UserAgent()))
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/rekor-cli/app/upload.go
+++ b/cmd/rekor-cli/app/upload.go
@@ -73,7 +73,7 @@ var uploadCmd = &cobra.Command{
 	Long: `This command takes the public key, signature and URL of the release artifact and uploads it to the rekor server.`,
 	Run: format.WrapCmd(func(args []string) (interface{}, error) {
 		ctx := context.Background()
-		rekorClient, err := client.GetRekorClient(viper.GetString("rekor_server"))
+		rekorClient, err := client.GetRekorClient(viper.GetString("rekor_server"), client.WithUserAgent(UserAgent()))
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/rekor-cli/app/useragent.go
+++ b/cmd/rekor-cli/app/useragent.go
@@ -1,0 +1,34 @@
+//
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"fmt"
+	"runtime"
+
+	"sigs.k8s.io/release-utils/version"
+)
+
+var (
+	// uaString is meant to resemble the User-Agent sent by browsers with requests.
+	// See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent
+	uaString = fmt.Sprintf("rekor-cli/%s (%s; %s)", version.GetVersionInfo().GitVersion, runtime.GOOS, runtime.GOARCH)
+)
+
+// UserAgent returns the User-Agent string which `rekor-cli` should send with HTTP requests.
+func UserAgent() string {
+	return uaString
+}

--- a/cmd/rekor-cli/app/verify.go
+++ b/cmd/rekor-cli/app/verify.go
@@ -87,7 +87,7 @@ var verifyCmd = &cobra.Command{
 		return nil
 	},
 	Run: format.WrapCmd(func(args []string) (interface{}, error) {
-		rekorClient, err := client.GetRekorClient(viper.GetString("rekor_server"))
+		rekorClient, err := client.GetRekorClient(viper.GetString("rekor_server"), client.WithUserAgent(UserAgent()))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This sets the User-Agent header to match the format used in cosign of

`rekor-cli/vX.Y.Z (OS) (ARCH)`

Signed-off-by: Bob Callaway <bob.callaway@gmail.com>

#### Release Note
User-Agent HTTP request header set with specific version information rather than generic `Go/http-client` value

