### PR TITLE
Add documentation about Alpine type

### DIFF
--- a/pkg/types/alpine/README.md
+++ b/pkg/types/alpine/README.md
@@ -1,0 +1,12 @@
+**Alpine Type Data Documentation**
+
+This document notes additional information (beyond that found in the Alpine schema) about the values associated with
+each field such as the format in which the data is stored and any necessary transformations.
+
+Further information about pkginfo fields and the .PKGINFO file can be found on the [Alpine documentation website](https://wiki.alpinelinux.org/wiki/Alpine_package_format#.PKGINFO).
+
+The value of the `publicKey` `content` field ought to be Base64-encoded.
+
+**How do you identify an object as an Alpine object?**
+
+The "Body" field will include an "AlpineModel" field.


### PR DESCRIPTION
Signed-off-by: John Speed Meyers <jsmeyers@chainguard.dev>

#### Summary

Adds some documentation related to the Alpine type. Pinging @bobcallaway for review. And @nsmith5 for situational awareness.

Question: When `Attestation` and `AttestationType` fields are blank, should the consumer of the results from `rekor-cli` assume that that entry is a vanilla signature? If so, should this blank field value interpretation be documented?
 
#### Ticket Link

Refers to issue #665. 

#### Release Note

```release-note
NONE
```
