### PR TITLE
Mirror signed release images from GCR to GHCR as part of release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ endif
 KO_PREFIX ?= gcr.io/projectsigstore
 export KO_DOCKER_REPO=$(KO_PREFIX)
 REKOR_YAML ?= rekor-$(GIT_TAG).yaml
+GHCR_PREFIX ?= ghcr.io/sigstore/rekor
 
 # Binaries
 SWAGGER := $(TOOLS_BIN_DIR)/swagger

--- a/release/README.md
+++ b/release/README.md
@@ -31,7 +31,7 @@ $ git push origin ${RELEASE_TAG}
 
 ```shell
 $ gcloud builds submit --config <PATH_TO_CLOUDBUILD> \
-   --substitutions _GIT_TAG=<_GIT_TAG>,_TOOL_ORG=sigstore,_TOOL_REPO=rekor,_STORAGE_LOCATION=rekor-releases,_KEY_RING=<KEY_RING>,_KEY_NAME=<KEY_NAME> \
+   --substitutions _GIT_TAG=<_GIT_TAG>,_TOOL_ORG=sigstore,_TOOL_REPO=rekor,_STORAGE_LOCATION=rekor-releases,_KEY_RING=<KEY_RING>,_KEY_NAME=<KEY_NAME>,_GITHUB_USER=<GITHUB_USER> \
    --project <GCP_PROJECT>
 ```
 
@@ -47,6 +47,7 @@ Where:
 - `_KEY_NAME` key name of your  cosign key.
 - `_KEY_VERSION` version of the key storaged in KMS. Default `1`.
 - `_KEY_LOCATION` location in GCP where the key is storaged. Default `global`.
+- `_GITHUB_USER` GitHub user to authenticate for pushing to GHCR.
 
 4. When the job finish, whithout issues, you should be able to see in GitHub a draft release.
 You now can review the release, make any changes if needed and then publish to make it an official release.

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -86,6 +86,30 @@ steps:
       && make sign-container-release \
       && make sign-keyless-release
 
+- name: gcr.io/cloud-builders/docker
+  entrypoint: 'bash'
+  dir: "go/src/sigstore/fulcio"
+  env:
+  - "GOPATH=/workspace/go"
+  - "GOBIN=/workspace/bin"
+  - PROJECT_ID=${PROJECT_ID}
+  - KEY_LOCATION=${_KEY_LOCATION}
+  - KEY_RING=${_KEY_RING}
+  - KEY_NAME=${_KEY_NAME}
+  - KEY_VERSION=${_KEY_VERSION}
+  - GIT_TAG=${_GIT_TAG}
+  - KO_PREFIX=gcr.io/${PROJECT_ID}
+  - COSIGN_EXPERIMENTAL=true
+  - GOOGLE_SERVICE_ACCOUNT_NAME=keyless@${PROJECT_ID}.iam.gserviceaccount.com
+  - GITHUB_USER=${_GITHUB_USER}
+  secretEnv:
+  - GITHUB_TOKEN
+  args:
+    - '-c'
+    - |
+      echo $$GITHUB_TOKEN | docker login ghcr.io -u $$GITHUB_USER --password-stdin \
+      && make copy-signed-release-to-ghcr
+
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_NUMBER}/secrets/GITHUB_TOKEN/versions/latest
@@ -117,3 +141,4 @@ substitutions:
   _KEY_NAME: 'honk-crypto'
   _KEY_VERSION: '1'
   _KEY_LOCATION: 'global'
+  _GITHUB_USER: 'placeholder'

--- a/release/release.mk
+++ b/release/release.mk
@@ -42,6 +42,21 @@ sign-keyless-rekor-cli-release:
 .PHONY: sign-keyless-release
 sign-keyless-release: sign-keyless-rekor-server-release sign-keyless-rekor-cli-release
 
+####################
+# copy image to GHCR
+####################
+
+.PHONY: copy-rekor-server-signed-release-to-ghcr
+copy-cosign-signed-release-to-ghcr:
+	cosign copy $(KO_PREFIX)/rekor-server:$(GIT_VERSION) $(GHCR_PREFIX)/rekor-server:$(GIT_VERSION)
+
+.PHONY: copy-rekor-cli-signed-release-to-ghcr
+copy-cosigned-signed-release-to-ghcr:
+	cosign copy $(KO_PREFIX)/rekor-cli:$(GIT_VERSION) $(GHCR_PREFIX)/rekor-cli:$(GIT_VERSION)
+
+.PHONY: copy-signed-release-to-ghcr
+copy-signed-release-to-ghcr: copy-rekor-server-signed-release-to-ghcr copy-rekor-cli-signed-release-to-ghcr
+
 ## --------------------------------------
 ## Dist / maybe we can deprecate
 ## --------------------------------------


### PR DESCRIPTION
Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

Copy signed released image from GCR to GHCR using cosign cli copy command.
This will ensure the signature will be the same between the two registry.

This keep consistent with Fulcio, https://github.com/sigstore/fulcio/issues/421, to publish to GCR and GHCR.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes #681 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Signed release images are mirrored to GHCR.
```
