### PR TITLE
Generate release yaml for non-CI builds.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,10 @@ before:
   hooks:
     - go mod tidy
     - /bin/bash -c 'if [ -n "$(git --no-pager diff --exit-code go.mod go.sum)" ]; then exit 1; fi'
+# if running a release we will generate the images in this step
+# if running in the CI the CI env va is set by github action runner and we dont run the ko steps
+# this is needed because we are generating files that goreleaser was not aware to push to GH project release
+    - /bin/bash -c 'if [ -z "$CI" ]; then make sign-container-release && make sign-keyless-release; fi'
 
 gomod:
   proxy: true
@@ -109,3 +113,6 @@ release:
     name: rekor
   footer: |
     ### Thanks for all contributors!
+
+  extra_files:
+    - glob: "./rekor*.yaml"

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -97,6 +97,7 @@ artifacts:
     paths:
     - "go/src/sigstore/rekor/dist/rekor*"
     - "go/src/sigstore/rekor/release/release-cosign.pub"
+    - "go/src/sigstore/rekor/rekor*.yaml"
 
 options:
   machineType: E2_HIGHCPU_8


### PR DESCRIPTION
Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

Generate a release YAML for rekor-server, based on the yaml in config/.

This will ensure users that want to run their own instance of Rekor will use the official release images and leverage the configuration available in the repo more easily.

@cpanato please take a look.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Release generates a YAML file for running the Rekor server.
```
