### PR TITLE
Change TreeID to be of type `string` instead of `int64`

### DIFF
--- a/cmd/rekor-cli/app/log_info.go
+++ b/cmd/rekor-cli/app/log_info.go
@@ -43,7 +43,7 @@ type logInfoCmdOutput struct {
 	TreeSize       int64
 	RootHash       string
 	TimestampNanos uint64
-	TreeID         int64
+	TreeID         string
 }
 
 func (l *logInfoCmdOutput) String() string {
@@ -53,7 +53,7 @@ func (l *logInfoCmdOutput) String() string {
 Tree Size: %v
 Root Hash: %s
 Timestamp: %s
-TreeID:    %v
+TreeID:    %s
 `, l.TreeSize, l.RootHash, ts, l.TreeID)
 }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -582,8 +582,9 @@ definitions:
         format: signedCheckpoint
         description: The current signed tree head
       treeID:
-        type: integer
+        type: string
         description: The current treeID
+        pattern: '^[0-9]+$'
     required:
       - rootHash
       - treeSize

--- a/pkg/api/tlog.go
+++ b/pkg/api/tlog.go
@@ -76,10 +76,14 @@ func GetLogInfoHandler(params tlog.GetLogInfoParams) middleware.Responder {
 		RootHash:       &hashString,
 		TreeSize:       &treeSize,
 		SignedTreeHead: &scString,
-		TreeID:         &tc.logID,
+		TreeID:         stringPointer(fmt.Sprintf("%d", tc.logID)),
 	}
 
 	return tlog.NewGetLogInfoOK().WithPayload(&logInfo)
+}
+
+func stringPointer(s string) *string {
+	return &s
 }
 
 // GetLogProofHandler returns information required to compute a consistency proof between two snapshots of log

--- a/pkg/generated/models/log_info.go
+++ b/pkg/generated/models/log_info.go
@@ -46,7 +46,8 @@ type LogInfo struct {
 
 	// The current treeID
 	// Required: true
-	TreeID *int64 `json:"treeID"`
+	// Pattern: ^[0-9]+$
+	TreeID *string `json:"treeID"`
 
 	// The current number of nodes in the merkle tree
 	// Required: true
@@ -105,6 +106,10 @@ func (m *LogInfo) validateSignedTreeHead(formats strfmt.Registry) error {
 func (m *LogInfo) validateTreeID(formats strfmt.Registry) error {
 
 	if err := validate.Required("treeID", "body", m.TreeID); err != nil {
+		return err
+	}
+
+	if err := validate.Pattern("treeID", "body", *m.TreeID, `^[0-9]+$`); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
When printing the TreeID with rekor-cli loginfo, if the output is parsed through jq
then the TreeID gets rounded down as an int because it is bigger than JSON allows Numbers to be.

This is how jq works and is mentioned in the FAQ: https://github.com/stedolan/jq/wiki/FAQ#numbers

Switching this to a string will preserve the actual Tree ID.

How this used to work:
```
% go run ./cmd/rekor-cli loginfo --rekor_server http://localhost:3000 --format json
Persisted log state matches the current state of the log
{"TreeSize":0,"RootHash":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","TimestampNanos":1646669010959148926,"TreeID":1593213237895900003}

# With jq, note TreeID is rounded down
% go run ./cmd/rekor-cli loginfo --rekor_server http://localhost:3000 --format json | jq
Persisted log state matches the current state of the log
{
  "TreeSize": 0,
  "RootHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
  "TimestampNanos": 1646669014825668000,
  "TreeID": 1593213237895900000
}
```

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

cc @lkatalin 

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
