### PR TITLE
build trillian container to existing release.

### DIFF
--- a/release/release.mk
+++ b/release/release.mk
@@ -24,8 +24,16 @@ sign-rekor-server-release:
 sign-rekor-cli-release:
 	cosign sign --key "gcpkms://projects/$(PROJECT_ID)/locations/$(KEY_LOCATION)/keyRings/$(KEY_RING)/cryptoKeys/$(KEY_NAME)/versions/$(KEY_VERSION)" -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) $(KO_PREFIX)/rekor-cli:$(GIT_VERSION)
 
+.PHONY: sign-trillian-server-release
+sign-trillian-server-release:
+	cosign sign --key "gcpkms://projects/$(PROJECT_ID)/locations/$(KEY_LOCATION)/keyRings/$(KEY_RING)/cryptoKeys/$(KEY_NAME)/versions/$(KEY_VERSION)" -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) $(KO_PREFIX)/trillian_log_server:$(GIT_VERSION)
+
+.PHONY: sign-trillian-signer-release
+sign-trillian-signer-release:
+	cosign sign --key "gcpkms://projects/$(PROJECT_ID)/locations/$(KEY_LOCATION)/keyRings/$(KEY_RING)/cryptoKeys/$(KEY_NAME)/versions/$(KEY_VERSION)" -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) $(KO_PREFIX)/trillian_log_signer:$(GIT_VERSION)
+
 .PHONY: sign-container-release
-sign-container-release: ko sign-rekor-server-release sign-rekor-cli-release
+sign-container-release: ko sign-rekor-server-release sign-rekor-cli-release ko-trillian sign-trillian-server-release sign-trillian-signer-release
 
 ######################
 # sign keyless section
@@ -39,8 +47,16 @@ sign-keyless-rekor-server-release:
 sign-keyless-rekor-cli-release:
 	cosign sign --force -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) $(KO_PREFIX)/rekor-cli:$(GIT_VERSION)
 
+.PHONY: sign-keyless-trillian-server-release
+sign-keyless-trillian-server-release:
+	cosign sign --force -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) $(KO_PREFIX)/trillian_log_server:$(GIT_VERSION)
+
+.PHONY: sign-keyless-trillian-signer-release
+sign-keyless-trillian-signer-release:
+	cosign sign --force -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) $(KO_PREFIX)/trillian_log_signer:$(GIT_VERSION)
+
 .PHONY: sign-keyless-release
-sign-keyless-release: sign-keyless-rekor-server-release sign-keyless-rekor-cli-release
+sign-keyless-release: sign-keyless-rekor-server-release sign-keyless-rekor-cli-release sign-keyless-trillian-server-release sign-keyless-trillian-signer-release
 
 ####################
 # copy image to GHCR


### PR DESCRIPTION
Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

Add Trillian server and signer container as part of Rekor release.
This would provide a multi-platform image that is signed.
The image from github.com/google/trillian also runs the image as root, when it is not necessary.

Once github.com/google/trillian provides signed images and stops running as root, we should consider moving back to using images from them.

Thanks to @nsmith5 for discovering that the image from github.com/google/trillian runs as root. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
