### PR TITLE
Make the loginfo command a bit more future/backwards proof.

### DIFF
--- a/cmd/rekor-cli/app/log_info.go
+++ b/cmd/rekor-cli/app/log_info.go
@@ -49,6 +49,7 @@ type logInfoCmdOutput struct {
 func (l *logInfoCmdOutput) String() string {
 	// Verification is always successful if we return an object.
 	ts := time.Unix(0, int64(l.TimestampNanos)).UTC().Format(time.RFC3339)
+
 	return fmt.Sprintf(`Verification Successful!
 Tree Size: %v
 Root Hash: %s
@@ -112,11 +113,18 @@ var logInfoCmd = &cobra.Command{
 			return nil, errors.New("signature on tree head did not verify")
 		}
 
+		pToInt := func(p *int64) int64 {
+			if p == nil {
+				return 0
+			}
+			return *p
+		}
+
 		cmdOutput := &logInfoCmdOutput{
-			TreeSize:       *logInfo.TreeSize,
+			TreeSize:       pToInt(logInfo.TreeSize),
 			RootHash:       *logInfo.RootHash,
 			TimestampNanos: sth.GetTimestamp(),
-			TreeID:         *logInfo.TreeID,
+			TreeID:         pToInt(logInfo.TreeID),
 		}
 
 		oldState := state.Load(serverURL)


### PR DESCRIPTION
The logid field comes back as nil (which is expected), but we break trying
to dereference that for formatting.

Looks like this was introduced in https://github.com/sigstore/rekor/pull/671

Signed-off-by: Dan Lorenc <lorenc.d@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
