### PR TITLE
Use active tree on server startup

### DIFF
--- a/cmd/rekor-server/app/serve.go
+++ b/cmd/rekor-server/app/serve.go
@@ -113,7 +113,7 @@ var serveCmd = &cobra.Command{
 			log.Logger.Fatalf("unable get sharding details from sharding config: %v", err)
 		}
 
-		api.ConfigureAPI(ranges)
+		api.ConfigureAPI(ranges, treeID)
 		server.ConfigureAPI()
 
 		http.Handle("/metrics", promhttp.Handler())

--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -281,7 +281,7 @@ func GetLogEntryByUUIDHandler(params entries.GetLogEntryByUUIDParams) middleware
 	var tid int64
 	tidString, err := sharding.GetTreeIDFromIDString(params.EntryUUID)
 	if err != nil {
-		// If EntryID is plain UUID, assume no sharding and use ActiveIndex. The ActiveIndex
+		// If EntryID is plain UUID, assume no sharding and use ActiveTreeID. The ActiveTreeID
 		// will == the tlog_id if a tlog_id is passed in at server startup.
 		if err.Error() == "cannot get treeID from plain UUID" {
 			tid = api.logRanges.ActiveTreeID()

--- a/pkg/api/trillian_client.go
+++ b/pkg/api/trillian_client.go
@@ -320,21 +320,6 @@ func (t *TrillianClient) getConsistencyProof(firstSize, lastSize int64) *Respons
 }
 
 func createAndInitTree(ctx context.Context, adminClient trillian.TrillianAdminClient, logClient trillian.TrillianLogClient) (*trillian.Tree, error) {
-	// First look for and use an existing tree
-	trees, err := adminClient.ListTrees(ctx, &trillian.ListTreesRequest{})
-	if err != nil {
-		return nil, errors.Wrap(err, "list trees")
-	}
-
-	for _, t := range trees.Tree {
-		if t.TreeType == trillian.TreeType_LOG {
-			log.Logger.Infof("Found existing tree with ID: %v", t.TreeId)
-			return t, nil
-		}
-	}
-
-	log.Logger.Infof("No existing tree found, attempting to create a new one")
-	// Otherwise create and initialize one
 	t, err := adminClient.CreateTree(ctx, &trillian.CreateTreeRequest{
 		Tree: &trillian.Tree{
 			TreeType:        trillian.TreeType_LOG,

--- a/pkg/sharding/ranges.go
+++ b/pkg/sharding/ranges.go
@@ -16,12 +16,13 @@
 package sharding
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"strings"
 
 	"github.com/ghodss/yaml"
-	"github.com/pkg/errors"
+	"github.com/sigstore/rekor/pkg/log"
 )
 
 type LogRanges struct {
@@ -38,6 +39,7 @@ type LogRange struct {
 
 func NewLogRanges(path string, treeID uint) (LogRanges, error) {
 	if path == "" {
+		log.Logger.Info("No config file specified, skipping init of logRange map")
 		return LogRanges{}, nil
 	}
 	if treeID == 0 {


### PR DESCRIPTION
#### Summary
- ~~Fixes logic in `createAndInitTree()` to use in order of precedence: 1. the `ActiveIndex` tree passed in via the `logRanges` flag, 2. the most recently created tree, 3. create a new tree~~
- ~~Adds safeguards for `ActiveTreeID()` in case the `range` is empty and adds a unit test~~

Create a new tree if there is no active tree specified with the `tlog_id` flag. Do not look for existing trees to use because these may be inactive.

#### Ticket Link

Fixes #726 
