### PR TITLE
Get log proofs by Tree ID

### DIFF
--- a/cmd/rekor-cli/app/log_proof.go
+++ b/cmd/rekor-cli/app/log_proof.go
@@ -79,10 +79,12 @@ var logProofCmd = &cobra.Command{
 
 		firstSize := int64(viper.GetUint64("first-size"))
 		lastSize := int64(viper.GetUint64("last-size"))
+		treeID := viper.GetString("tree-id")
 
 		params := tlog.NewGetLogProofParams()
 		params.FirstSize = &firstSize
 		params.LastSize = lastSize
+		params.TreeID = &treeID
 		params.SetTimeout(viper.GetDuration("timeout"))
 
 		result, err := rekorClient.Tlog.GetLogProof(params)
@@ -102,6 +104,8 @@ func init() {
 	initializePFlagMap()
 	logProofCmd.Flags().Uint64("first-size", 1, "the size of the log where the proof should begin")
 	logProofCmd.Flags().Uint64("last-size", 0, "the size of the log where the proof should end")
+	logProofCmd.Flags().String("tree-id", "", "the tree id of the log (defaults to active tree)")
+
 	if err := logProofCmd.MarkFlagRequired("last-size"); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -125,6 +125,11 @@ paths:
           required: true
           minimum: 1
           description: The size of the tree that you wish to prove consistency to
+        - in: query
+          name: treeID
+          type: string
+          pattern: '^[0-9]+$'
+          description: The tree ID of the tree that you wish to prove consistency for
       responses:
         200:
           description: All hashes required to compute the consistency proof

--- a/pkg/generated/client/tlog/get_log_proof_parameters.go
+++ b/pkg/generated/client/tlog/get_log_proof_parameters.go
@@ -91,6 +91,12 @@ type GetLogProofParams struct {
 	*/
 	LastSize int64
 
+	/* TreeID.
+
+	   The tree ID of the tree that you wish to prove consistency for
+	*/
+	TreeID *string
+
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
@@ -177,6 +183,17 @@ func (o *GetLogProofParams) SetLastSize(lastSize int64) {
 	o.LastSize = lastSize
 }
 
+// WithTreeID adds the treeID to the get log proof params
+func (o *GetLogProofParams) WithTreeID(treeID *string) *GetLogProofParams {
+	o.SetTreeID(treeID)
+	return o
+}
+
+// SetTreeID adds the treeId to the get log proof params
+func (o *GetLogProofParams) SetTreeID(treeID *string) {
+	o.TreeID = treeID
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *GetLogProofParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -209,6 +226,23 @@ func (o *GetLogProofParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.R
 
 		if err := r.SetQueryParam("lastSize", qLastSize); err != nil {
 			return err
+		}
+	}
+
+	if o.TreeID != nil {
+
+		// query param treeID
+		var qrTreeID string
+
+		if o.TreeID != nil {
+			qrTreeID = *o.TreeID
+		}
+		qTreeID := qrTreeID
+		if qTreeID != "" {
+
+			if err := r.SetQueryParam("treeID", qTreeID); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pkg/generated/restapi/operations/tlog/get_log_proof_parameters.go
+++ b/pkg/generated/restapi/operations/tlog/get_log_proof_parameters.go
@@ -69,6 +69,11 @@ type GetLogProofParams struct {
 	  In: query
 	*/
 	LastSize int64
+	/*The tree ID of the tree that you wish to prove consistency for
+	  Pattern: ^[0-9]+$
+	  In: query
+	*/
+	TreeID *string
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -89,6 +94,11 @@ func (o *GetLogProofParams) BindRequest(r *http.Request, route *middleware.Match
 
 	qLastSize, qhkLastSize, _ := qs.GetOK("lastSize")
 	if err := o.bindLastSize(qLastSize, qhkLastSize, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qTreeID, qhkTreeID, _ := qs.GetOK("treeID")
+	if err := o.bindTreeID(qTreeID, qhkTreeID, route.Formats); err != nil {
 		res = append(res, err)
 	}
 	if len(res) > 0 {
@@ -169,6 +179,38 @@ func (o *GetLogProofParams) bindLastSize(rawData []string, hasKey bool, formats 
 func (o *GetLogProofParams) validateLastSize(formats strfmt.Registry) error {
 
 	if err := validate.MinimumInt("lastSize", "query", o.LastSize, 1, false); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// bindTreeID binds and validates parameter TreeID from query.
+func (o *GetLogProofParams) bindTreeID(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+	o.TreeID = &raw
+
+	if err := o.validateTreeID(formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateTreeID carries on validations for parameter TreeID
+func (o *GetLogProofParams) validateTreeID(formats strfmt.Registry) error {
+
+	if err := validate.Pattern("treeID", "query", *o.TreeID, `^[0-9]+$`); err != nil {
 		return err
 	}
 

--- a/pkg/generated/restapi/operations/tlog/get_log_proof_urlbuilder.go
+++ b/pkg/generated/restapi/operations/tlog/get_log_proof_urlbuilder.go
@@ -33,6 +33,7 @@ import (
 type GetLogProofURL struct {
 	FirstSize *int64
 	LastSize  int64
+	TreeID    *string
 
 	_basePath string
 	// avoid unkeyed usage
@@ -76,6 +77,14 @@ func (o *GetLogProofURL) Build() (*url.URL, error) {
 	lastSizeQ := swag.FormatInt64(o.LastSize)
 	if lastSizeQ != "" {
 		qs.Set("lastSize", lastSizeQ)
+	}
+
+	var treeIDQ string
+	if o.TreeID != nil {
+		treeIDQ = *o.TreeID
+	}
+	if treeIDQ != "" {
+		qs.Set("treeID", treeIDQ)
 	}
 
 	_result.RawQuery = qs.Encode()


### PR DESCRIPTION
We will need this so we can get proofs for inactive shards. This will be used by `loginfo`.

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
