### PR TITLE
Specify public key for inactive shards in shard config

### DIFF
--- a/cmd/rekor-server/app/serve.go
+++ b/cmd/rekor-server/app/serve.go
@@ -16,10 +16,13 @@
 package app
 
 import (
+	"context"
+	"crypto/x509"
 	"flag"
 	"net/http"
 
 	"github.com/go-openapi/loads"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -30,6 +33,7 @@ import (
 	"github.com/sigstore/rekor/pkg/generated/restapi/operations"
 	"github.com/sigstore/rekor/pkg/log"
 	"github.com/sigstore/rekor/pkg/sharding"
+	"github.com/sigstore/rekor/pkg/signer"
 	"github.com/sigstore/rekor/pkg/types/alpine"
 	alpine_v001 "github.com/sigstore/rekor/pkg/types/alpine/v0.0.1"
 	hashedrekord "github.com/sigstore/rekor/pkg/types/hashedrekord"
@@ -48,6 +52,8 @@ import (
 	rpm_v001 "github.com/sigstore/rekor/pkg/types/rpm/v0.0.1"
 	"github.com/sigstore/rekor/pkg/types/tuf"
 	tuf_v001 "github.com/sigstore/rekor/pkg/types/tuf/v0.0.1"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
+	"github.com/sigstore/sigstore/pkg/signature/options"
 )
 
 // serveCmd represents the serve command
@@ -108,7 +114,12 @@ var serveCmd = &cobra.Command{
 		shardingConfig := viper.GetString("trillian_log_server.sharding_config")
 		treeID := viper.GetUint("trillian_log_server.tlog_id")
 
-		ranges, err := sharding.NewLogRanges(shardingConfig, treeID)
+		pubkey, err := getPublicKey()
+		if err != nil {
+			log.Logger.Fatalf("unable to get public key from rekor signer: %v", err)
+		}
+
+		ranges, err := sharding.NewLogRanges(shardingConfig, treeID, pubkey)
 		if err != nil {
 			log.Logger.Fatalf("unable get sharding details from sharding config: %v", err)
 		}
@@ -125,6 +136,25 @@ var serveCmd = &cobra.Command{
 			log.Logger.Fatal(err)
 		}
 	},
+}
+
+func getPublicKey() (string, error) {
+	ctx := context.TODO()
+	// Get the active public key
+	rekorSigner, err := signer.New(ctx, viper.GetString("rekor_server.signer"))
+	if err != nil {
+		return "", errors.Wrap(err, "getting new signer")
+	}
+	pk, err := rekorSigner.PublicKey(options.WithContext(ctx))
+	if err != nil {
+		return "", errors.Wrap(err, "getting public key")
+	}
+	b, err := x509.MarshalPKIXPublicKey(pk)
+	if err != nil {
+		return "", errors.Wrap(err, "marshalling public key")
+	}
+	pubkey := cryptoutils.PEMEncode(cryptoutils.PublicKeyPEMType, b)
+	return string(pubkey), nil
 }
 
 func init() {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -93,6 +93,12 @@ paths:
       operationId: getPublicKey
       tags:
         - pubkey
+      parameters:
+        - in: query
+          name: treeID
+          type: string
+          pattern: '^[0-9]+$'
+          description: The tree ID of the tree that you wish to prove consistency for
       produces:
         - application/x-pem-file
       responses:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -98,7 +98,7 @@ paths:
           name: treeID
           type: string
           pattern: '^[0-9]+$'
-          description: The tree ID of the tree that you wish to prove consistency for
+          description: The tree ID of the tree you wish to get a public key for
       produces:
         - application/x-pem-file
       responses:

--- a/pkg/api/public_key.go
+++ b/pkg/api/public_key.go
@@ -18,7 +18,6 @@ package api
 
 import (
 	"net/http"
-	"strconv"
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/swag"
@@ -26,15 +25,12 @@ import (
 )
 
 func GetPublicKeyHandler(params pubkey.GetPublicKeyParams) middleware.Responder {
+	ctx := params.HTTPRequest.Context()
 	treeID := swag.StringValue(params.TreeID)
-	if treeID == "" {
-		return pubkey.NewGetPublicKeyOK().WithPayload(api.pubkey)
-	}
-	tid, err := strconv.Atoi(treeID)
+	tc := NewTrillianClient(ctx)
+	pk, err := tc.ranges.PublicKey(api.pubkey, treeID)
 	if err != nil {
 		return handleRekorAPIError(params, http.StatusBadRequest, err, "")
 	}
-	ctx := params.HTTPRequest.Context()
-	tc := NewTrillianClientFromTreeID(ctx, int64(tid))
-	return pubkey.NewGetPublicKeyOK().WithPayload(tc.ranges.PublicKey(int64(tid)))
+	return pubkey.NewGetPublicKeyOK().WithPayload(pk)
 }

--- a/pkg/generated/client/pubkey/get_public_key_parameters.go
+++ b/pkg/generated/client/pubkey/get_public_key_parameters.go
@@ -74,6 +74,13 @@ func NewGetPublicKeyParamsWithHTTPClient(client *http.Client) *GetPublicKeyParam
    Typically these are written to a http.Request.
 */
 type GetPublicKeyParams struct {
+
+	/* TreeID.
+
+	   The tree ID of the tree that you wish to prove consistency for
+	*/
+	TreeID *string
+
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
@@ -127,6 +134,17 @@ func (o *GetPublicKeyParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithTreeID adds the treeID to the get public key params
+func (o *GetPublicKeyParams) WithTreeID(treeID *string) *GetPublicKeyParams {
+	o.SetTreeID(treeID)
+	return o
+}
+
+// SetTreeID adds the treeId to the get public key params
+func (o *GetPublicKeyParams) SetTreeID(treeID *string) {
+	o.TreeID = treeID
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *GetPublicKeyParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -134,6 +152,23 @@ func (o *GetPublicKeyParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.
 		return err
 	}
 	var res []error
+
+	if o.TreeID != nil {
+
+		// query param treeID
+		var qrTreeID string
+
+		if o.TreeID != nil {
+			qrTreeID = *o.TreeID
+		}
+		qTreeID := qrTreeID
+		if qTreeID != "" {
+
+			if err := r.SetQueryParam("treeID", qTreeID); err != nil {
+				return err
+			}
+		}
+	}
 
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)

--- a/pkg/generated/client/pubkey/get_public_key_parameters.go
+++ b/pkg/generated/client/pubkey/get_public_key_parameters.go
@@ -77,7 +77,7 @@ type GetPublicKeyParams struct {
 
 	/* TreeID.
 
-	   The tree ID of the tree that you wish to prove consistency for
+	   The tree ID of the tree you wish to get a public key for
 	*/
 	TreeID *string
 

--- a/pkg/generated/restapi/operations/pubkey/get_public_key_parameters.go
+++ b/pkg/generated/restapi/operations/pubkey/get_public_key_parameters.go
@@ -48,7 +48,7 @@ type GetPublicKeyParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*The tree ID of the tree that you wish to prove consistency for
+	/*The tree ID of the tree you wish to get a public key for
 	  Pattern: ^[0-9]+$
 	  In: query
 	*/

--- a/pkg/generated/restapi/operations/pubkey/get_public_key_parameters.go
+++ b/pkg/generated/restapi/operations/pubkey/get_public_key_parameters.go
@@ -25,7 +25,10 @@ import (
 	"net/http"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/validate"
 )
 
 // NewGetPublicKeyParams creates a new GetPublicKeyParams object
@@ -44,6 +47,12 @@ type GetPublicKeyParams struct {
 
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
+
+	/*The tree ID of the tree that you wish to prove consistency for
+	  Pattern: ^[0-9]+$
+	  In: query
+	*/
+	TreeID *string
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -55,8 +64,46 @@ func (o *GetPublicKeyParams) BindRequest(r *http.Request, route *middleware.Matc
 
 	o.HTTPRequest = r
 
+	qs := runtime.Values(r.URL.Query())
+
+	qTreeID, qhkTreeID, _ := qs.GetOK("treeID")
+	if err := o.bindTreeID(qTreeID, qhkTreeID, route.Formats); err != nil {
+		res = append(res, err)
+	}
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+// bindTreeID binds and validates parameter TreeID from query.
+func (o *GetPublicKeyParams) bindTreeID(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+	o.TreeID = &raw
+
+	if err := o.validateTreeID(formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateTreeID carries on validations for parameter TreeID
+func (o *GetPublicKeyParams) validateTreeID(formats strfmt.Registry) error {
+
+	if err := validate.Pattern("treeID", "query", *o.TreeID, `^[0-9]+$`); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/pkg/generated/restapi/operations/pubkey/get_public_key_urlbuilder.go
+++ b/pkg/generated/restapi/operations/pubkey/get_public_key_urlbuilder.go
@@ -29,7 +29,11 @@ import (
 
 // GetPublicKeyURL generates an URL for the get public key operation
 type GetPublicKeyURL struct {
+	TreeID *string
+
 	_basePath string
+	// avoid unkeyed usage
+	_ struct{}
 }
 
 // WithBasePath sets the base path for this url builder, only required when it's different from the
@@ -55,6 +59,18 @@ func (o *GetPublicKeyURL) Build() (*url.URL, error) {
 
 	_basePath := o._basePath
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
+
+	qs := make(url.Values)
+
+	var treeIDQ string
+	if o.TreeID != nil {
+		treeIDQ = *o.TreeID
+	}
+	if treeIDQ != "" {
+		qs.Set("treeID", treeIDQ)
+	}
+
+	_result.RawQuery = qs.Encode()
 
 	return &_result, nil
 }

--- a/pkg/sharding/ranges_test.go
+++ b/pkg/sharding/ranges_test.go
@@ -123,11 +123,11 @@ func TestPublicKey(t *testing.T) {
 			description:    "empty tree ID",
 			expectedPubKey: "activekey",
 		}, {
-			description:    "tree id with encoded public key",
+			description:    "tree id with decoded public key",
 			treeID:         "10",
 			expectedPubKey: "sharding",
 		}, {
-			description:    "tree id without encoded public key",
+			description:    "tree id without decoded public key",
 			treeID:         "20",
 			expectedPubKey: "activekey",
 		}, {

--- a/pkg/sharding/ranges_test.go
+++ b/pkg/sharding/ranges_test.go
@@ -26,6 +26,7 @@ func TestNewLogRanges(t *testing.T) {
 	contents := `
 - treeID: 0001
   treeLength: 3
+  encodedPublicKey: c2hhcmRpbmcK
 - treeID: 0002
   treeLength: 4`
 	file := filepath.Join(t.TempDir(), "sharding-config")
@@ -36,15 +37,18 @@ func TestNewLogRanges(t *testing.T) {
 	expected := LogRanges{
 		inactive: []LogRange{
 			{
-				TreeID:     1,
-				TreeLength: 3,
+				TreeID:           1,
+				TreeLength:       3,
+				EncodedPublicKey: "c2hhcmRpbmcK",
+				decodedPublicKey: "sharding\n",
 			}, {
 				TreeID:     2,
 				TreeLength: 4,
 			}},
 		active: int64(45),
 	}
-	got, err := NewLogRanges(file, treeID)
+	activePubKey := "mypub"
+	got, err := NewLogRanges(file, treeID, activePubKey)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/sharding-e2e-test.sh
+++ b/tests/sharding-e2e-test.sh
@@ -116,7 +116,7 @@ echo "the new shard ID is $SHARD_TREE_ID"
 $REKOR_CLI loginfo --rekor_server http://localhost:3000
 
 # Get the public key for the active tree for later
-ENCODED_PUBLIC_KEY=$(curl http://localhost:3000/api/v1/log/publicKey | base64)
+ENCODED_PUBLIC_KEY=$(curl http://localhost:3000/api/v1/log/publicKey | base64 -w 0)
 
 # Spin down the rekor server
 echo "stopping the rekor server..."
@@ -132,6 +132,7 @@ cat << EOF > $SHARDING_CONFIG
   encodedPublicKey: $ENCODED_PUBLIC_KEY
 EOF
 
+cat $SHARDING_CONFIG
 
 COMPOSE_FILE=docker-compose-sharding.yaml
 cat << EOF > $COMPOSE_FILE
@@ -200,12 +201,12 @@ $REKOR_CLI logproof --last-size 2 --tree-id $INITIAL_TREE_ID --rekor_server http
 $REKOR_CLI logproof --last-size 1 --rekor_server http://localhost:3000
 
 echo "Getting public key for inactive shard..."
-GOT_PUB_KEY=$(curl "http://localhost:3000/api/v1/log/publicKey?treeID=$INITIAL_TREE_ID" | base64)
+GOT_PUB_KEY=$(curl "http://localhost:3000/api/v1/log/publicKey?treeID=$INITIAL_TREE_ID" | base64 -w 0)
 echo "Got encoded public key $GOT_PUB_KEY, making sure this matches the public key we got earlier..."
 stringsMatch $ENCODED_PUBLIC_KEY $GOT_PUB_KEY
 
 echo "Getting the public key for the active tree..."
-NEW_PUB_KEY=$(curl "http://localhost:3000/api/v1/log/publicKey" | base64)
+NEW_PUB_KEY=$(curl "http://localhost:3000/api/v1/log/publicKey" | base64 -w 0)
 echo "Making sure the public key for the active shard is different from the inactive shard..."
 if [[ "$ENCODED_PUBLIC_KEY" == "$NEW_PUB_KEY" ]]; then
     echo


### PR DESCRIPTION
This is pretty much the last item we need for sharding! Specify a public key for inactive shards in the sharding config in case we are rotating signers; this way users can request the public key for a specific shard from the API

cc @lkatalin and @asraa 

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
