### PR TITLE
Search inactive trees for GET by UUID requests

### DIFF
--- a/pkg/sharding/sharding.go
+++ b/pkg/sharding/sharding.go
@@ -17,6 +17,7 @@ package sharding
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strconv"
 )
@@ -180,12 +181,14 @@ func ValidateEntryID(id string) error {
 	return nil
 }
 
+var ErrPlainUUID = errors.New("cannot get treeID from plain UUID")
+
 // Returns TreeID (with no appended UUID) from a TreeID or EntryID string.
 // Validates TreeID and also UUID if present.
 func GetTreeIDFromIDString(id string) (string, error) {
 	switch len(id) {
 	case UUIDHexStringLen:
-		return "", fmt.Errorf("cannot get treeID from plain UUID")
+		return "", ErrPlainUUID
 	case EntryIDHexStringLen, TreeIDHexStringLen:
 		if err := ValidateEntryID(id); err != nil {
 			return "", err


### PR DESCRIPTION
UPDATED:
This fix is useful for client v0.5 when there is more than one shard. When a GET by UUID request is made with a UUID (as opposed to the EntryID that has the prepended TreeID), this change will first check the active tree, then iterate through inactive trees to see if the UUID can be found in any of them.

Fixes the "expected bug" mentioned in #711 


~~Add temporary fix to check old prod treeID for entry if UUID is not
found in active tree. This can be removed once client v0.5 is phased
out.~~

~~Related to #711 (the "expected bug") - this fix is only needed if we plan to shard the production server before the client `v0.5` is phased out.~~