### PR TITLE
Separate create_tree functionality from tlog_id

### DIFF
--- a/cmd/rekor-server/app/root.go
+++ b/cmd/rekor-server/app/root.go
@@ -81,6 +81,8 @@ func init() {
 	rootCmd.PersistentFlags().String("attestation_storage_bucket", "", "url for attestation storage bucket")
 	rootCmd.PersistentFlags().Int("max_attestation_size", 100*1024, "max size for attestation storage, in bytes")
 
+	rootCmd.PersistentFlags().Bool("create_tree", false, "creates a new tree (shard) for the server backend")
+
 	if err := viper.BindPFlags(rootCmd.PersistentFlags()); err != nil {
 		log.Logger.Fatal(err)
 	}

--- a/cmd/rekor-server/app/serve.go
+++ b/cmd/rekor-server/app/serve.go
@@ -107,13 +107,14 @@ var serveCmd = &cobra.Command{
 		// Update logRangeMap if flag was passed in
 		shardingConfig := viper.GetString("trillian_log_server.sharding_config")
 		treeID := viper.GetUint("trillian_log_server.tlog_id")
+		createTree := viper.GetBool("create_tree")
 
 		ranges, err := sharding.NewLogRanges(shardingConfig, treeID)
 		if err != nil {
 			log.Logger.Fatalf("unable get sharding details from sharding config: %v", err)
 		}
 
-		api.ConfigureAPI(ranges, treeID)
+		api.ConfigureAPI(ranges, treeID, createTree)
 		server.ConfigureAPI()
 
 		http.Handle("/metrics", promhttp.Handler())

--- a/pkg/sharding/ranges.go
+++ b/pkg/sharding/ranges.go
@@ -43,7 +43,7 @@ type LogRange struct {
 
 func NewLogRanges(path string, treeID uint) (LogRanges, error) {
 	if path == "" {
-		log.Logger.Info("No config file specified, skipping init of logRange map")
+		log.Logger.Info("No shard config file specified, skipping init of shard map")
 		return LogRanges{}, nil
 	}
 	if treeID == 0 {


### PR DESCRIPTION
Previously, starting a local Rekor server with no tlog_id flag
would automatically create a new tree (shard). The GET by
--log-index breaks if called on a multi-shard server with no
shard config passed in (this problem remains).

This change allows users who are not deliberately using sharding
to (re)start a local Rekor server without automatically sharding,
which in turn prevents GET by --log-index from breaking for these
users. Users who are sharding or working in a multi-shard
environment MUST pass in a shard config file at server startup in
order for GET by --log-index to work.

Signed-off-by: Lily Sturmann <lsturman@redhat.com>

Related: #749 

cc @priyawadhwa 