### PR TITLE
Add index to hashed intoto envelope

### DIFF
--- a/pkg/types/intoto/v0.0.1/entry.go
+++ b/pkg/types/intoto/v0.0.1/entry.go
@@ -266,18 +266,18 @@ func (v V001Entry) CreateFromArtifactProperties(_ context.Context, props types.A
 	}
 	kb := strfmt.Base64(publicKeyBytes)
 
-	h := sha256.Sum256([]byte(v.IntotoObj.Content.Envelope))
 	re := V001Entry{
 		IntotoObj: models.IntotoV001Schema{
 			Content: &models.IntotoV001SchemaContent{
 				Envelope: string(artifactBytes),
-				Hash: &models.IntotoV001SchemaContentHash{
-					Algorithm: swag.String(models.IntotoV001SchemaContentHashAlgorithmSha256),
-					Value:     swag.String(hex.EncodeToString(h[:])),
-				},
 			},
 			PublicKey: &kb,
 		},
+	}
+	h := sha256.Sum256([]byte(re.IntotoObj.Content.Envelope))
+	re.IntotoObj.Content.Hash = &models.IntotoV001SchemaContentHash{
+		Algorithm: swag.String(models.IntotoV001SchemaContentHashAlgorithmSha256),
+		Value:     swag.String(hex.EncodeToString(h[:])),
 	}
 
 	returnVal.Spec = re.IntotoObj


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Related https://github.com/sigstore/rekor/issues/646

This allows searching for a rekor entry by the signed envelope hash. E.g. if a user has `provenance.intoto.jsonl`, then currently we can't search for that provenance unless we take the hash of the payload or Subject.Digest's. This way cosign will also verify-blob the hard way by searching for the artifact file hash.

The hash is the same as the hash in the rekor entry:
```
"Body": {
    "IntotoObj": {
      "content": {
        "hash": {
          "algorithm": "sha256",
          "value": "d05ff19cea34cd451c0a3133dc44d933e706fa00a910192f28b8dbe43d373020"
        }
      },
      "publicKey": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURQRENDQXNHZ0F3SUJBZ0lUSWl6UUNLQmJGODNkU2YvYjhEdklVWUhsZ2pBS0JnZ3Foa2pPUFFRREF6QXEKTVJVd0V3WURWUVFLRXd4emFXZHpkRzl5WlM1a1pYWXhFVEFQQmdOVkJBTVRDSE5wWjNOMGIzSmxNQjRYRFRJeQpNRFF3TkRFMU1qVXdNVm9YRFRJeU1EUXdOREUxTXpVd01Gb3dBREJaTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5CkF3RUhBMElBQkJTbHNOVWZDcmtKZGh3U3lnOWc3T3c4dStpSEx5L1hFNXpCbTl2czVSZmlkbk53UGg2dVlHeUUKeDdOa2V2UVZIZHJNR0lnYzFsd2NDeFZxN3c1UDllK2pnZ0h1TUlJQjZqQU9CZ05WSFE4QkFmOEVCQU1DQjRBdwpFd1lEVlIwbEJBd3dDZ1lJS3dZQkJRVUhBd013REFZRFZSMFRBUUgvQkFJd0FEQWRCZ05WSFE0RUZnUVVlalJiCmRvbXZteTZSbEMyK0IreXdpbmlPTHpVd0h3WURWUjBqQkJnd0ZvQVVXTUFlWDVGRnBXYXBlc3lRb1pNaTBDckYKeGZvd2RnWURWUjBSQVFIL0JHd3dhb1pvYUhSMGNITTZMeTluYVhSb2RXSXVZMjl0TDNOc2MyRXRabkpoYldWMwpiM0pyTDNOc2MyRXRaMmwwYUhWaUxXZGxibVZ5WVhSdmNpMW5ieTh1WjJsMGFIVmlMM2R2Y210bWJHOTNjeTlpCmRXbHNaR1Z5TG5sdGJFQnlaV1p6TDJobFlXUnpMMjFoYVc0d0h3WUtLd1lCQkFHRHZ6QUJBZ1FSZDI5eWEyWnMKYjNkZlpHbHpjR0YwWTJnd0xnWUtLd1lCQkFHRHZ6QUJCUVFnYkdGMWNtVnVkSE5wYlc5dUwzTnNjMkV0YjI0dApaMmwwYUhWaUxYUmxjM1F3R2dZS0t3WUJCQUdEdnpBQkJBUU1VMHhUUVNCU1pXeGxZWE5sTURrR0Npc0dBUVFCCmc3OHdBUUVFSzJoMGRIQnpPaTh2ZEc5clpXNHVZV04wYVc5dWN5NW5hWFJvZFdKMWMyVnlZMjl1ZEdWdWRDNWoKYjIwd05nWUtLd1lCQkFHRHZ6QUJBd1FvWkRObVpEazBPREpsTmpoa01qYzJaVFk1WXpCaE9HSXpaamRsWVdGaQpZak5pT1dVMU5qWTVOVEFkQmdvckJnRUVBWU8vTUFFR0JBOXlaV1p6TDJobFlXUnpMMjFoYVc0d0NnWUlLb1pJCnpqMEVBd01EYVFBd1pnSXhBSndFd0lTUk1FOW10SjAzamR6ZUFMYUdaUmNSckJmaTU4bUVFNHlCaXAvSkFPTGMKd1lPamQ0a09YNjJ4ejJqaXh3SXhBSUVEWGxsTFhhY3BZSFF6eWJzQU9IUTlkblFLWDFUdlJOZkZLN1lIM2ZxVgo0TEpQazloQUJ5Qkh1dE1KVGFJb3N3PT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo="
    }

```

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
