### PR TITLE
Add the SHA256 digest of the intoto payload into the rekor entry

### DIFF
--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -221,6 +221,7 @@ func createLogEntry(params entries.CreateLogEntryParams) (models.LogEntry, middl
 				log.RequestIDLogger(params.HTTPRequest).Infof("no attestation for %s", uuid)
 				return
 			}
+			//TODO stop using uuid and use attestation hash
 			if err := storeAttestation(context.Background(), uuid, attestation); err != nil {
 				log.RequestIDLogger(params.HTTPRequest).Errorf("error storing attestation: %s", err)
 			}

--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -221,7 +221,7 @@ func createLogEntry(params entries.CreateLogEntryParams) (models.LogEntry, middl
 				log.RequestIDLogger(params.HTTPRequest).Infof("no attestation for %s", uuid)
 				return
 			}
-			//TODO stop using uuid and use attestation hash
+			// TODO stop using uuid and use attestation hash
 			if err := storeAttestation(context.Background(), uuid, attestation); err != nil {
 				log.RequestIDLogger(params.HTTPRequest).Errorf("error storing attestation: %s", err)
 			}

--- a/pkg/generated/models/intoto_v001_schema.go
+++ b/pkg/generated/models/intoto_v001_schema.go
@@ -148,6 +148,9 @@ func (m *IntotoV001Schema) UnmarshalBinary(b []byte) error {
 // swagger:model IntotoV001SchemaContent
 type IntotoV001SchemaContent struct {
 
+	// attestation hash
+	AttestationHash *IntotoV001SchemaContentAttestationHash `json:"attestationHash,omitempty"`
+
 	// envelope
 	Envelope string `json:"envelope,omitempty"`
 
@@ -159,6 +162,10 @@ type IntotoV001SchemaContent struct {
 func (m *IntotoV001SchemaContent) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateAttestationHash(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateHash(formats); err != nil {
 		res = append(res, err)
 	}
@@ -166,6 +173,25 @@ func (m *IntotoV001SchemaContent) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *IntotoV001SchemaContent) validateAttestationHash(formats strfmt.Registry) error {
+	if swag.IsZero(m.AttestationHash) { // not required
+		return nil
+	}
+
+	if m.AttestationHash != nil {
+		if err := m.AttestationHash.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("content" + "." + "attestationHash")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("content" + "." + "attestationHash")
+			}
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -192,6 +218,10 @@ func (m *IntotoV001SchemaContent) validateHash(formats strfmt.Registry) error {
 func (m *IntotoV001SchemaContent) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.contextValidateAttestationHash(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateHash(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -199,6 +229,22 @@ func (m *IntotoV001SchemaContent) ContextValidate(ctx context.Context, formats s
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *IntotoV001SchemaContent) contextValidateAttestationHash(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.AttestationHash != nil {
+		if err := m.AttestationHash.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("content" + "." + "attestationHash")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("content" + "." + "attestationHash")
+			}
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -229,6 +275,116 @@ func (m *IntotoV001SchemaContent) MarshalBinary() ([]byte, error) {
 // UnmarshalBinary interface implementation
 func (m *IntotoV001SchemaContent) UnmarshalBinary(b []byte) error {
 	var res IntotoV001SchemaContent
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*m = res
+	return nil
+}
+
+// IntotoV001SchemaContentAttestationHash Specifies the hash algorithm and value encompassing the stored attestation
+//
+// swagger:model IntotoV001SchemaContentAttestationHash
+type IntotoV001SchemaContentAttestationHash struct {
+
+	// The hashing function used to compute the hash value
+	// Required: true
+	// Enum: [sha256]
+	Algorithm *string `json:"algorithm"`
+
+	// The hash value for the archive
+	// Required: true
+	Value *string `json:"value"`
+}
+
+// Validate validates this intoto v001 schema content attestation hash
+func (m *IntotoV001SchemaContentAttestationHash) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.validateAlgorithm(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateValue(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+var intotoV001SchemaContentAttestationHashTypeAlgorithmPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["sha256"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		intotoV001SchemaContentAttestationHashTypeAlgorithmPropEnum = append(intotoV001SchemaContentAttestationHashTypeAlgorithmPropEnum, v)
+	}
+}
+
+const (
+
+	// IntotoV001SchemaContentAttestationHashAlgorithmSha256 captures enum value "sha256"
+	IntotoV001SchemaContentAttestationHashAlgorithmSha256 string = "sha256"
+)
+
+// prop value enum
+func (m *IntotoV001SchemaContentAttestationHash) validateAlgorithmEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, intotoV001SchemaContentAttestationHashTypeAlgorithmPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *IntotoV001SchemaContentAttestationHash) validateAlgorithm(formats strfmt.Registry) error {
+
+	if err := validate.Required("content"+"."+"attestationHash"+"."+"algorithm", "body", m.Algorithm); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := m.validateAlgorithmEnum("content"+"."+"attestationHash"+"."+"algorithm", "body", *m.Algorithm); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *IntotoV001SchemaContentAttestationHash) validateValue(formats strfmt.Registry) error {
+
+	if err := validate.Required("content"+"."+"attestationHash"+"."+"value", "body", m.Value); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validate this intoto v001 schema content attestation hash based on the context it is used
+func (m *IntotoV001SchemaContentAttestationHash) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (m *IntotoV001SchemaContentAttestationHash) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation
+func (m *IntotoV001SchemaContentAttestationHash) UnmarshalBinary(b []byte) error {
+	var res IntotoV001SchemaContentAttestationHash
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}

--- a/pkg/generated/models/intoto_v001_schema.go
+++ b/pkg/generated/models/intoto_v001_schema.go
@@ -148,50 +148,31 @@ func (m *IntotoV001Schema) UnmarshalBinary(b []byte) error {
 // swagger:model IntotoV001SchemaContent
 type IntotoV001SchemaContent struct {
 
-	// attestation hash
-	AttestationHash *IntotoV001SchemaContentAttestationHash `json:"attestationHash,omitempty"`
-
 	// envelope
 	Envelope string `json:"envelope,omitempty"`
 
 	// hash
 	Hash *IntotoV001SchemaContentHash `json:"hash,omitempty"`
+
+	// payload hash
+	PayloadHash *IntotoV001SchemaContentPayloadHash `json:"payloadHash,omitempty"`
 }
 
 // Validate validates this intoto v001 schema content
 func (m *IntotoV001SchemaContent) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.validateAttestationHash(formats); err != nil {
+	if err := m.validateHash(formats); err != nil {
 		res = append(res, err)
 	}
 
-	if err := m.validateHash(formats); err != nil {
+	if err := m.validatePayloadHash(formats); err != nil {
 		res = append(res, err)
 	}
 
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
-	return nil
-}
-
-func (m *IntotoV001SchemaContent) validateAttestationHash(formats strfmt.Registry) error {
-	if swag.IsZero(m.AttestationHash) { // not required
-		return nil
-	}
-
-	if m.AttestationHash != nil {
-		if err := m.AttestationHash.Validate(formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("content" + "." + "attestationHash")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("content" + "." + "attestationHash")
-			}
-			return err
-		}
-	}
-
 	return nil
 }
 
@@ -214,37 +195,40 @@ func (m *IntotoV001SchemaContent) validateHash(formats strfmt.Registry) error {
 	return nil
 }
 
+func (m *IntotoV001SchemaContent) validatePayloadHash(formats strfmt.Registry) error {
+	if swag.IsZero(m.PayloadHash) { // not required
+		return nil
+	}
+
+	if m.PayloadHash != nil {
+		if err := m.PayloadHash.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("content" + "." + "payloadHash")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("content" + "." + "payloadHash")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 // ContextValidate validate this intoto v001 schema content based on the context it is used
 func (m *IntotoV001SchemaContent) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.contextValidateAttestationHash(ctx, formats); err != nil {
+	if err := m.contextValidateHash(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateHash(ctx, formats); err != nil {
+	if err := m.contextValidatePayloadHash(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
-	return nil
-}
-
-func (m *IntotoV001SchemaContent) contextValidateAttestationHash(ctx context.Context, formats strfmt.Registry) error {
-
-	if m.AttestationHash != nil {
-		if err := m.AttestationHash.ContextValidate(ctx, formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("content" + "." + "attestationHash")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("content" + "." + "attestationHash")
-			}
-			return err
-		}
-	}
-
 	return nil
 }
 
@@ -264,6 +248,22 @@ func (m *IntotoV001SchemaContent) contextValidateHash(ctx context.Context, forma
 	return nil
 }
 
+func (m *IntotoV001SchemaContent) contextValidatePayloadHash(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.PayloadHash != nil {
+		if err := m.PayloadHash.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("content" + "." + "payloadHash")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("content" + "." + "payloadHash")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
 // MarshalBinary interface implementation
 func (m *IntotoV001SchemaContent) MarshalBinary() ([]byte, error) {
 	if m == nil {
@@ -275,116 +275,6 @@ func (m *IntotoV001SchemaContent) MarshalBinary() ([]byte, error) {
 // UnmarshalBinary interface implementation
 func (m *IntotoV001SchemaContent) UnmarshalBinary(b []byte) error {
 	var res IntotoV001SchemaContent
-	if err := swag.ReadJSON(b, &res); err != nil {
-		return err
-	}
-	*m = res
-	return nil
-}
-
-// IntotoV001SchemaContentAttestationHash Specifies the hash algorithm and value encompassing the stored attestation
-//
-// swagger:model IntotoV001SchemaContentAttestationHash
-type IntotoV001SchemaContentAttestationHash struct {
-
-	// The hashing function used to compute the hash value
-	// Required: true
-	// Enum: [sha256]
-	Algorithm *string `json:"algorithm"`
-
-	// The hash value for the archive
-	// Required: true
-	Value *string `json:"value"`
-}
-
-// Validate validates this intoto v001 schema content attestation hash
-func (m *IntotoV001SchemaContentAttestationHash) Validate(formats strfmt.Registry) error {
-	var res []error
-
-	if err := m.validateAlgorithm(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateValue(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if len(res) > 0 {
-		return errors.CompositeValidationError(res...)
-	}
-	return nil
-}
-
-var intotoV001SchemaContentAttestationHashTypeAlgorithmPropEnum []interface{}
-
-func init() {
-	var res []string
-	if err := json.Unmarshal([]byte(`["sha256"]`), &res); err != nil {
-		panic(err)
-	}
-	for _, v := range res {
-		intotoV001SchemaContentAttestationHashTypeAlgorithmPropEnum = append(intotoV001SchemaContentAttestationHashTypeAlgorithmPropEnum, v)
-	}
-}
-
-const (
-
-	// IntotoV001SchemaContentAttestationHashAlgorithmSha256 captures enum value "sha256"
-	IntotoV001SchemaContentAttestationHashAlgorithmSha256 string = "sha256"
-)
-
-// prop value enum
-func (m *IntotoV001SchemaContentAttestationHash) validateAlgorithmEnum(path, location string, value string) error {
-	if err := validate.EnumCase(path, location, value, intotoV001SchemaContentAttestationHashTypeAlgorithmPropEnum, true); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (m *IntotoV001SchemaContentAttestationHash) validateAlgorithm(formats strfmt.Registry) error {
-
-	if err := validate.Required("content"+"."+"attestationHash"+"."+"algorithm", "body", m.Algorithm); err != nil {
-		return err
-	}
-
-	// value enum
-	if err := m.validateAlgorithmEnum("content"+"."+"attestationHash"+"."+"algorithm", "body", *m.Algorithm); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *IntotoV001SchemaContentAttestationHash) validateValue(formats strfmt.Registry) error {
-
-	if err := validate.Required("content"+"."+"attestationHash"+"."+"value", "body", m.Value); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// ContextValidate validate this intoto v001 schema content attestation hash based on the context it is used
-func (m *IntotoV001SchemaContentAttestationHash) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
-	var res []error
-
-	if len(res) > 0 {
-		return errors.CompositeValidationError(res...)
-	}
-	return nil
-}
-
-// MarshalBinary interface implementation
-func (m *IntotoV001SchemaContentAttestationHash) MarshalBinary() ([]byte, error) {
-	if m == nil {
-		return nil, nil
-	}
-	return swag.WriteJSON(m)
-}
-
-// UnmarshalBinary interface implementation
-func (m *IntotoV001SchemaContentAttestationHash) UnmarshalBinary(b []byte) error {
-	var res IntotoV001SchemaContentAttestationHash
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}
@@ -495,6 +385,116 @@ func (m *IntotoV001SchemaContentHash) MarshalBinary() ([]byte, error) {
 // UnmarshalBinary interface implementation
 func (m *IntotoV001SchemaContentHash) UnmarshalBinary(b []byte) error {
 	var res IntotoV001SchemaContentHash
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*m = res
+	return nil
+}
+
+// IntotoV001SchemaContentPayloadHash Specifies the hash algorithm and value covering the payload within the DSSE envelope
+//
+// swagger:model IntotoV001SchemaContentPayloadHash
+type IntotoV001SchemaContentPayloadHash struct {
+
+	// The hashing function used to compute the hash value
+	// Required: true
+	// Enum: [sha256]
+	Algorithm *string `json:"algorithm"`
+
+	// The hash value for the envelope's payload
+	// Required: true
+	Value *string `json:"value"`
+}
+
+// Validate validates this intoto v001 schema content payload hash
+func (m *IntotoV001SchemaContentPayloadHash) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.validateAlgorithm(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateValue(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+var intotoV001SchemaContentPayloadHashTypeAlgorithmPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["sha256"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		intotoV001SchemaContentPayloadHashTypeAlgorithmPropEnum = append(intotoV001SchemaContentPayloadHashTypeAlgorithmPropEnum, v)
+	}
+}
+
+const (
+
+	// IntotoV001SchemaContentPayloadHashAlgorithmSha256 captures enum value "sha256"
+	IntotoV001SchemaContentPayloadHashAlgorithmSha256 string = "sha256"
+)
+
+// prop value enum
+func (m *IntotoV001SchemaContentPayloadHash) validateAlgorithmEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, intotoV001SchemaContentPayloadHashTypeAlgorithmPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *IntotoV001SchemaContentPayloadHash) validateAlgorithm(formats strfmt.Registry) error {
+
+	if err := validate.Required("content"+"."+"payloadHash"+"."+"algorithm", "body", m.Algorithm); err != nil {
+		return err
+	}
+
+	// value enum
+	if err := m.validateAlgorithmEnum("content"+"."+"payloadHash"+"."+"algorithm", "body", *m.Algorithm); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *IntotoV001SchemaContentPayloadHash) validateValue(formats strfmt.Registry) error {
+
+	if err := validate.Required("content"+"."+"payloadHash"+"."+"value", "body", m.Value); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validate this intoto v001 schema content payload hash based on the context it is used
+func (m *IntotoV001SchemaContentPayloadHash) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (m *IntotoV001SchemaContentPayloadHash) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(m)
+}
+
+// UnmarshalBinary interface implementation
+func (m *IntotoV001SchemaContentPayloadHash) UnmarshalBinary(b []byte) error {
+	var res IntotoV001SchemaContentPayloadHash
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}

--- a/pkg/types/intoto/v0.0.1/entry.go
+++ b/pkg/types/intoto/v0.0.1/entry.go
@@ -150,6 +150,14 @@ func (v *V001Entry) Canonicalize(ctx context.Context) ([]byte, error) {
 			},
 		},
 	}
+	attestation := v.Attestation()
+	if attestation != nil {
+		attH := sha256.Sum256(attestation)
+		canonicalEntry.Content.AttestationHash = &models.IntotoV001SchemaContentAttestationHash{
+			Algorithm: swag.String(models.IntotoV001SchemaContentHashAlgorithmSha256),
+			Value:     swag.String(hex.EncodeToString(attH[:])),
+		}
+	}
 
 	itObj := models.Intoto{}
 	itObj.APIVersion = swag.String(APIVERSION)

--- a/pkg/types/intoto/v0.0.1/entry.go
+++ b/pkg/types/intoto/v0.0.1/entry.go
@@ -23,7 +23,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -34,6 +33,8 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+
+	"github.com/pkg/errors"
 
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/rekor/pkg/log"
@@ -152,7 +153,11 @@ func (v *V001Entry) Canonicalize(ctx context.Context) ([]byte, error) {
 	}
 	attestation := v.Attestation()
 	if attestation != nil {
-		attH := sha256.Sum256(attestation)
+		decodedAttestation, err := base64.StdEncoding.DecodeString(string(attestation))
+		if err != nil {
+			return nil, errors.Wrap(err, "decoding attestation")
+		}
+		attH := sha256.Sum256(decodedAttestation)
 		canonicalEntry.Content.AttestationHash = &models.IntotoV001SchemaContentAttestationHash{
 			Algorithm: swag.String(models.IntotoV001SchemaContentHashAlgorithmSha256),
 			Value:     swag.String(hex.EncodeToString(attH[:])),
@@ -202,8 +207,9 @@ func (v *V001Entry) validate() error {
 }
 
 func (v *V001Entry) Attestation() []byte {
-	if len(v.env.Payload) > viper.GetInt("max_attestation_size") {
-		log.Logger.Infof("Skipping attestation storage, size %d is greater than max %d", len(v.env.Payload), viper.GetInt("max_attestation_size"))
+	storageSize := base64.StdEncoding.DecodedLen(len(v.env.Payload))
+	if storageSize > viper.GetInt("max_attestation_size") {
+		log.Logger.Infof("Skipping attestation storage, size %d is greater than max %d", storageSize, viper.GetInt("max_attestation_size"))
 		return nil
 	}
 	return []byte(v.env.Payload)

--- a/pkg/types/intoto/v0.0.1/entry.go
+++ b/pkg/types/intoto/v0.0.1/entry.go
@@ -158,7 +158,7 @@ func (v *V001Entry) Canonicalize(ctx context.Context) ([]byte, error) {
 			return nil, errors.Wrap(err, "decoding attestation")
 		}
 		attH := sha256.Sum256(decodedAttestation)
-		canonicalEntry.Content.AttestationHash = &models.IntotoV001SchemaContentAttestationHash{
+		canonicalEntry.Content.PayloadHash = &models.IntotoV001SchemaContentPayloadHash{
 			Algorithm: swag.String(models.IntotoV001SchemaContentHashAlgorithmSha256),
 			Value:     swag.String(hex.EncodeToString(attH[:])),
 		}

--- a/pkg/types/intoto/v0.0.1/intoto_v0_0_1_schema.json
+++ b/pkg/types/intoto/v0.0.1/intoto_v0_0_1_schema.json
@@ -34,6 +34,26 @@
                         "value"
                     ],
                     "readOnly": true
+                },
+                "attestationHash": {
+                    "description": "Specifies the hash algorithm and value encompassing the stored attestation",
+                    "type": "object",
+                    "properties": {
+                        "algorithm": {
+                            "description": "The hashing function used to compute the hash value",
+                            "type": "string",
+                            "enum": [ "sha256" ]
+                        },
+                        "value": {
+                            "description": "The hash value for the archive",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "algorithm",
+                        "value"
+                    ],
+                    "readOnly": true
                 }
             }
         },

--- a/pkg/types/intoto/v0.0.1/intoto_v0_0_1_schema.json
+++ b/pkg/types/intoto/v0.0.1/intoto_v0_0_1_schema.json
@@ -35,8 +35,8 @@
                     ],
                     "readOnly": true
                 },
-                "attestationHash": {
-                    "description": "Specifies the hash algorithm and value encompassing the stored attestation",
+                "payloadHash": {
+                    "description": "Specifies the hash algorithm and value covering the payload within the DSSE envelope",
                     "type": "object",
                     "properties": {
                         "algorithm": {
@@ -45,7 +45,7 @@
                             "enum": [ "sha256" ]
                         },
                         "value": {
-                            "description": "The hash value for the archive",
+                            "description": "The hash value for the envelope's payload",
                             "type": "string"
                         }
                     },

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -461,28 +461,22 @@ func TestIntoto(t *testing.T) {
 	}
 
 	attHash := sha256.Sum256(g.Attestation)
-	bHash := sha256.Sum256(g.Attestation)
-	fmt.Printf("len of g.Attestation %d, len of b %d\n", len(g.Attestation), len(b))
-	fmt.Printf("g %v\n", string(g.Attestation))
-	fmt.Printf("b %v\n", string(b))
-	fmt.Printf("g %v\n", hex.EncodeToString(attHash[:]))
-	fmt.Printf("b %v\n", hex.EncodeToString(bHash[:]))
 
 	intotoModel := &models.IntotoV001Schema{}
 	if err := types.DecodeEntry(g.Body.(map[string]interface{})["IntotoObj"], intotoModel); err != nil {
 		t.Errorf("could not convert body into intoto type: %v", err)
 	}
-	if intotoModel.Content == nil || intotoModel.Content.AttestationHash == nil {
+	if intotoModel.Content == nil || intotoModel.Content.PayloadHash == nil {
 		t.Errorf("could not find hash over attestation %v", intotoModel)
 	}
-	recordedAttHash, err := hex.DecodeString(*intotoModel.Content.AttestationHash.Value)
+	recordedPayloadHash, err := hex.DecodeString(*intotoModel.Content.PayloadHash.Value)
 	if err != nil {
 		t.Errorf("error converting attestation hash to []byte: %v", err)
 	}
 
-	if !bytes.Equal(attHash[:], recordedAttHash) {
-		t.Fatal(fmt.Errorf("attestation hash %v doesnt match the one we sent %v", hex.EncodeToString(attHash[:]),
-		 *intotoModel.Content.AttestationHash.Value))
+	if !bytes.Equal(attHash[:], recordedPayloadHash) {
+		t.Fatal(fmt.Errorf("attestation hash %v doesnt match the payload we sent %v", hex.EncodeToString(attHash[:]),
+			*intotoModel.Content.PayloadHash.Value))
 	}
 
 	out = runCli(t, "upload", "--artifact", attestationPath, "--type", "intoto", "--public-key", pubKeyPath)


### PR DESCRIPTION
Currently we are storing the digest over the entire intoto envelope in the corresponding Rekor entry. This PR adds the SHA256 digest for the envelope's payload (the base64 decoded bytes) into the log entry as well. 

This also fixes the length check in `Attestation` to measure against the length of bytes after base64 decoding the payload, instead of the payload itself.

@asraa @haydentherapper @SantiagoTorres 
