### PR TITLE
Fix link in types README

### DIFF
--- a/pkg/types/README.md
+++ b/pkg/types/README.md
@@ -21,4 +21,4 @@ Rekor supports pluggable types (aka different schemas) for entries stored in the
 - RPM Packages [schema](rpm/rpm_schema.json)
   - Versions: 0.0.1
 
-Refer to [Rekor docs](https://docs.sigstore.dev/rekor/plugable-types) for adding support for new types.
+Refer to [Rekor docs](https://docs.sigstore.dev/rekor/pluggable-types) for adding support for new types.


### PR DESCRIPTION
#### Summary

This PR fixes a link in the types README.

#### Release Note

```release-note
NONE
```
