### PR TITLE
Add in configmap to release for sharding config

### DIFF
--- a/config/rekor.yaml
+++ b/config/rekor.yaml
@@ -57,10 +57,14 @@ spec:
           "--trillian_log_server.tlog_id=3904496407287907110",
           "--log_type=prod",
           "--rekor_server.signer=$(KMS)",
+          "--trillian_log_server.sharding_config=/sharding/sharding-config.yaml",
           "--enable_attestation_storage=$(ENABLE_ATTESTATION_STORAGE)",
           "--attestation_storage_bucket=$(ATTESTATION_BUCKET)",
           "--rekor_server.timestamp_chain=$(TIMESTAMP_CHAIN)"
         ]
+        volumeMounts:
+        - name: sharding-config
+          mountPath: /sharding
         env:
         - name: KMS
           valueFrom:
@@ -92,6 +96,10 @@ spec:
           capabilities:
             drop:
             - all
+      volumes:
+        - name: sharding-config
+          configMap:
+            name: sharding-config
 ---
 apiVersion: v1
 kind: Service
@@ -106,4 +114,12 @@ spec:
     - protocol: TCP
       port: 80
       targetPort: 3000
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sharding-config
+  namespace: rekor-system
+data:
+  sharding-config.yaml: "" 
 ---

--- a/pkg/sharding/ranges.go
+++ b/pkg/sharding/ranges.go
@@ -55,6 +55,10 @@ func NewLogRanges(path string, treeID uint) (LogRanges, error) {
 	if err != nil {
 		return LogRanges{}, err
 	}
+	if string(contents) == "" {
+		log.Logger.Info("Sharding config file contents empty, skipping init of logRange map")
+		return LogRanges{}, nil
+	}
 	if err := yaml.Unmarshal(contents, &ranges); err != nil {
 		return LogRanges{}, err
 	}


### PR DESCRIPTION
Eventually when we shard, we just have to update the config map with sharding details.

Right now it's just empty and shouldn't change functionality at all. Tested locally and it looks good.

ref https://github.com/sigstore/rekor/issues/711

cc @lkatalin 

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
