### PR TITLE
Fix search without sha prefix

### DIFF
--- a/cmd/rekor-cli/app/search.go
+++ b/cmd/rekor-cli/app/search.go
@@ -37,6 +37,7 @@ import (
 	"github.com/sigstore/rekor/pkg/generated/client/index"
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/rekor/pkg/log"
+	"github.com/sigstore/rekor/pkg/util"
 )
 
 type searchCmdOutput struct {
@@ -108,15 +109,7 @@ var searchCmd = &cobra.Command{
 		artifactStr := viper.GetString("artifact")
 		sha := viper.GetString("sha")
 		if sha != "" {
-			var prefix string
-			if !strings.HasPrefix(sha, "sha256:") && !strings.HasPrefix(sha, "sha1:") {
-				if len(sha) == 40 {
-					prefix = "sha1:"
-				} else {
-					prefix = "sha256:"
-				}
-			}
-			params.Query.Hash = fmt.Sprintf("%v%v", prefix, sha)
+			params.Query.Hash = util.PrefixSHA(sha)
 		} else if artifactStr != "" {
 			hasher := sha256.New()
 			var tee io.Reader

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -38,8 +38,9 @@ func SearchIndexHandler(params index.SearchIndexParams) middleware.Responder {
 	var result []string
 	if params.Query.Hash != "" {
 		// This must be a valid sha256 hash
+		sha := util.PrefixSHA(params.Query.Hash)
 		var resultUUIDs []string
-		if err := redisClient.Do(httpReqCtx, radix.Cmd(&resultUUIDs, "LRANGE", strings.ToLower(params.Query.Hash), "0", "-1")); err != nil {
+		if err := redisClient.Do(httpReqCtx, radix.Cmd(&resultUUIDs, "LRANGE", strings.ToLower(sha), "0", "-1")); err != nil {
 			return handleRekorAPIError(params, http.StatusInternalServerError, err, redisUnexpectedResult)
 		}
 		result = append(result, resultUUIDs...)

--- a/pkg/util/sha.go
+++ b/pkg/util/sha.go
@@ -1,0 +1,33 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+	"strings"
+)
+
+// PrefixSHA sets the prefix of a sha hash to match how it is stored based on the length.
+func PrefixSHA(sha string) string {
+	var prefix string
+	if !strings.HasPrefix(sha, "sha256:") && !strings.HasPrefix(sha, "sha1:") {
+		if len(sha) == 40 {
+			prefix = "sha1:"
+		} else {
+			prefix = "sha256:"
+		}
+	}
+	return fmt.Sprintf("%v%v", prefix, sha)
+}


### PR DESCRIPTION
#### Summary

Rekor API searches without a SHA prefix (sha1:, sha256:) do not  currently work as the hash is stored in Redis with the prefix. rekor-cli infers the prefix when using --sha.

This PR reuses that logic when searching with `/index/retrieve`.

#### Ticket Link

Fixes #699 

#### Release Note

```release-note
Fixed searching the index by SHA without a prefix.
```
