### PR TITLE
Update cloudbuild to not fail when copy the images

### DIFF
--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -87,7 +87,7 @@ steps:
     - '-c'
     - |
       echo $$GITHUB_TOKEN | docker login ghcr.io -u $$GITHUB_USER --password-stdin \
-      && make copy-signed-release-to-ghcr
+      && make copy-signed-release-to-ghcr || true
 
 availableSecrets:
   secretManager:


### PR DESCRIPTION
#### Summary
- Update cloudbuild to not fail when copying the images

rehearsal: https://github.com/cpanato/rekor/releases/tag/v99.99.00


```
$ docker run gcr.io/cpanato-general/rekor-server:v99.99.00 version
Unable to find image 'gcr.io/cpanato-general/rekor-server:v99.99.00' locally
v99.99.00: Pulling from cpanato-general/rekor-server
b0b160e41cf3: Already exists
14b53aa26cd0: Already exists
afc8f3960014: Already exists
250c06f7c38e: Already exists
adbcc79b3314: Pull complete
Digest: sha256:e5fccf1dd5d599e5525f3eb442540386e8d1899800a5d36878e8f49d1f146fb4
Status: Downloaded newer image for gcr.io/cpanato-general/rekor-server:v99.99.00
2022-04-13T07:51:48.227Z        DEBUG   app/root.go:90  pprof enabled false
  ____    _____   _  __   ___    ____            ____    _____   ____   __     __  _____   ____
 |  _ \  | ____| | |/ /  / _ \  |  _ \          / ___|  | ____| |  _ \  \ \   / / | ____| |  _ \
 | |_) | |  _|   | ' /  | | | | | |_) |  _____  \___ \  |  _|   | |_) |  \ \ / /  |  _|   | |_) |
 |  _ <  | |___  | . \  | |_| | |  _ <  |_____|  ___) | | |___  |  _ <    \ V /   | |___  |  _ <
 |_| \_\ |_____| |_|\_\  \___/  |_| \_\         |____/  |_____| |_| \_\    \_/    |_____| |_| \_\
rekor-server: Rekor signature transparency log server

GitVersion:    v99.99.00
GitCommit:     5d1323bf309d4b1ca55afc4afdab366d2f0d8016
GitTreeState:  clean
BuildDate:     2022-04-13T07:28:51Z
GoVersion:     go1.17.8
Compiler:      gc
Platform:      linux/arm64

```

#### Ticket Link
n/a

#### Release Note

```release-note
NONE
```
