### PR TITLE
Check if intoto hash is available before accessing it as an index key

### DIFF
--- a/pkg/types/intoto/v0.0.1/entry.go
+++ b/pkg/types/intoto/v0.0.1/entry.go
@@ -80,6 +80,10 @@ func (v V001Entry) IndexKeys() ([]string, error) {
 
 	switch v.env.PayloadType {
 	case in_toto.PayloadType:
+		if v.IntotoObj.Content == nil || v.IntotoObj.Content.Hash == nil {
+			log.Logger.Info("IntotoObj content or hash is nil")
+			return result, nil
+		}
 		hashkey := strings.ToLower(fmt.Sprintf("%s:%s", *v.IntotoObj.Content.Hash.Algorithm, *v.IntotoObj.Content.Hash.Value))
 		result = append(result, hashkey)
 


### PR DESCRIPTION
From what I understand, we use these keys to help enable lookup in Redis. Some attestations don't have a hash associated with them, and so this errors out.

You can see this bug when trying to upload a custom predicate (not type `slsaprovenance`) with `cosign` to production (older version of Rekor) vs HEAD:

Production works:
```
cosign attest  --predicate predicate  ttl.sh/priya/busybox   
Generating ephemeral keys...
Retrieving signed certificate...
Your browser will now be opened to:
https://oauth2.sigstore.dev/auth/auth?access_type=online&client_id=sigstore&code_challenge=3Dz_am0xYk62oKDMhfNV2oqDxsB9HfFFelLP_YLeR1w&code_challenge_method=S256&nonce=28UPOzf1vYJwNIufLnvfb4lrCMv&redirect_uri=http%3A%2F%2Flocalhost%3A63151%2Fauth%2Fcallback&response_type=code&scope=openid+email&state=28UPOu8yR4CZ4udOKv1msOfOWuu
Successfully verified SCT...
Using payload from: predicate
tlog entry created with index: 2193004
```

but HEAD doesn't:

```
cosign attest  --predicate predicate --rekor-url http://localhost:3000  ttl.sh/priya/busybox
Generating ephemeral keys...
Retrieving signed certificate...
Your browser will now be opened to:
https://oauth2.sigstore.dev/auth/auth?access_type=online&client_id=sigstore&code_challenge=iXgmMTHsZOlnQsrV8_JghIY50qdQPImTKt1nejRk7To&code_challenge_method=S256&nonce=28UPcXVob3Qaoa83VL1ynX28KCA&redirect_uri=http%3A%2F%2Flocalhost%3A63190%2Fauth%2Fcallback&response_type=code&scope=openid+email&state=28UPcXfAhqAfJk744QEGYZOfWtR
Successfully verified SCT...
Using payload from: predicate
Error: signing ttl.sh/priya/busybox: Post "http://localhost:3000/api/v1/log/entries": EOF
main.go:52: error during command execution: signing ttl.sh/priya/busybox: Post "http://localhost:3000/api/v1/log/entries": EOF
```

and the server crashes with this nil pointer exception:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1a192e9]

goroutine 98 [running]:
github.com/sigstore/rekor/pkg/types/intoto/v0%2e0%2e1.V001Entry.IndexKeys({{0xc0001bff40, 0xc000cc2678}, {0x1e78908, 0xc000cce690}, {{0xc0003cf1e0, 0x1c}, {0xc000cf6800, 0x35d4}, {0xc000b69100, 0x1, ...}}})
        /Users/priyawadhwa/rekor/pkg/types/intoto/v0.0.1/entry.go:87 +0x229
github.com/sigstore/rekor/pkg/api.createLogEntry.func1()
        /Users/priyawadhwa/rekor/pkg/api/entries.go:211 +0x55
created by github.com/sigstore/rekor/pkg/api.createLogEntry
        /Users/priyawadhwa/rekor/pkg/api/entries.go:210 +0x1074
exit status 2
```

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

cc @strongjz @asraa 
