### PR TITLE
all: remove dependency on deprecated github.com/pkg/errors

### DIFF
--- a/cmd/rekor-cli/app/log_info.go
+++ b/cmd/rekor-cli/app/log_info.go
@@ -118,7 +118,7 @@ func verifyInactiveTrees(rekorClient *rclient.Rekor, serverURL string, inactiveS
 		signedTreeHead := swag.StringValue(shard.SignedTreeHead)
 		treeID := swag.StringValue(shard.TreeID)
 		if err := verifyTree(rekorClient, signedTreeHead, serverURL, treeID); err != nil {
-			return errors.Wrapf(err, "verifying inactive shard with ID %s", treeID)
+			return fmt.Errorf("verifying inactive shard with ID %s: %w", treeID, err)
 		}
 	}
 	log.CliLogger.Infof("Successfully validated inactive shards")

--- a/cmd/rekor-cli/app/log_info.go
+++ b/cmd/rekor-cli/app/log_info.go
@@ -21,11 +21,11 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/go-openapi/swag"
-	"github.com/pkg/errors"
 	rclient "github.com/sigstore/rekor/pkg/generated/client"
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/spf13/cobra"

--- a/cmd/rekor-cli/app/pflags.go
+++ b/cmd/rekor-cli/app/pflags.go
@@ -29,7 +29,6 @@ import (
 	"github.com/spf13/pflag"
 
 	validator "github.com/go-playground/validator/v10"
-	"github.com/pkg/errors"
 )
 
 type FlagType string
@@ -116,7 +115,7 @@ func NewFlagValue(flagType FlagType, defaultVal string) pflag.Value {
 	val := valFunc()
 	if defaultVal != "" {
 		if err := val.Set(defaultVal); err != nil {
-			log.Fatal(errors.Wrap(err, "initializing flag"))
+			log.Fatal(fmt.Errorf("initializing flag: %w", err))
 		}
 	}
 	return val

--- a/cmd/rekor-cli/app/upload.go
+++ b/cmd/rekor-cli/app/upload.go
@@ -32,7 +32,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/pkg/errors"
 	"github.com/sigstore/rekor/cmd/rekor-cli/app/format"
 	"github.com/sigstore/rekor/pkg/client"
 	genclient "github.com/sigstore/rekor/pkg/generated/client"
@@ -140,7 +139,7 @@ var uploadCmd = &cobra.Command{
 
 		// verify log entry
 		if verified, err := verifyLogEntry(ctx, rekorClient, logEntry); err != nil || !verified {
-			return nil, errors.Wrap(err, "unable to verify entry was added to log")
+			return nil, fmt.Errorf("unable to verify entry was added to log: %w", err)
 		}
 
 		return &uploadCmdOutput{

--- a/cmd/rekor-server/app/watch.go
+++ b/cmd/rekor-server/app/watch.go
@@ -21,6 +21,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -29,7 +30,6 @@ import (
 	_ "gocloud.dev/blob/fileblob" // fileblob
 	_ "gocloud.dev/blob/gcsblob"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"gocloud.dev/blob"

--- a/cmd/rekor-server/app/watch.go
+++ b/cmd/rekor-server/app/watch.go
@@ -133,11 +133,11 @@ func init() {
 func doCheck(c *genclient.Rekor, pub crypto.PublicKey) (*SignedAndUnsignedLogRoot, error) {
 	li, err := c.Tlog.GetLogInfo(nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting log info")
+		return nil, fmt.Errorf("getting log info: %w", err)
 	}
 	sth := util.SignedCheckpoint{}
 	if err := sth.UnmarshalText([]byte(*li.Payload.SignedTreeHead)); err != nil {
-		return nil, errors.Wrap(err, "unmarshalling tree head")
+		return nil, fmt.Errorf("unmarshalling tree head: %w", err)
 	}
 
 	verifier, err := signature.LoadVerifier(pub, crypto.SHA256)
@@ -146,7 +146,7 @@ func doCheck(c *genclient.Rekor, pub crypto.PublicKey) (*SignedAndUnsignedLogRoo
 	}
 
 	if !sth.Verify(verifier) {
-		return nil, errors.Wrap(err, "signed tree head failed verification")
+		return nil, fmt.Errorf("signed tree head failed verification: %w", err)
 	}
 
 	return &SignedAndUnsignedLogRoot{

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,6 @@ require (
 	github.com/mediocregopher/radix/v4 v4.1.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.2
 	github.com/rs/cors v1.8.2
 	github.com/sassoftware/relic v0.0.0-20210427151427-dfb082b79b74

--- a/pkg/api/trillian_client.go
+++ b/pkg/api/trillian_client.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/sigstore/rekor/pkg/log"
 	"github.com/sigstore/rekor/pkg/sharding"
 	"github.com/transparency-dev/merkle/proof"
@@ -327,11 +326,11 @@ func createAndInitTree(ctx context.Context, adminClient trillian.TrillianAdminCl
 		},
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "create tree")
+		return nil, fmt.Errorf("create tree: %w", err)
 	}
 
 	if err := client.InitLog(ctx, t, logClient); err != nil {
-		return nil, errors.Wrap(err, "init log")
+		return nil, fmt.Errorf("init log: %w", err)
 	}
 	log.Logger.Infof("Created new tree with ID: %v", t.TreeId)
 	return t, nil

--- a/pkg/sharding/ranges.go
+++ b/pkg/sharding/ranges.go
@@ -18,6 +18,7 @@ package sharding
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"strconv"
@@ -26,7 +27,6 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/google/trillian"
 	"github.com/google/trillian/types"
-	"github.com/pkg/errors"
 	"github.com/sigstore/rekor/pkg/log"
 )
 
@@ -55,12 +55,12 @@ func NewLogRanges(ctx context.Context, logClient trillian.TrillianLogClient, pat
 	// otherwise, try to read contents of the sharding config
 	ranges, err := logRangesFromPath(path)
 	if err != nil {
-		return LogRanges{}, fmt.Errorf("log ranges from path: %w: %w", err)
+		return LogRanges{}, fmt.Errorf("log ranges from path: %w", err)
 	}
 	for i, r := range ranges {
 		r, err := updateRange(ctx, logClient, r)
 		if err != nil {
-			return LogRanges{}, fmt.Errorf("updating range for tree id %d: %w: %w", r.TreeID, err)
+			return LogRanges{}, fmt.Errorf("updating range for tree id %d: %w", r.TreeID, err)
 		}
 		ranges[i] = r
 	}
@@ -93,7 +93,7 @@ func updateRange(ctx context.Context, logClient trillian.TrillianLogClient, r Lo
 	if r.TreeLength == 0 {
 		resp, err := logClient.GetLatestSignedLogRoot(ctx, &trillian.GetLatestSignedLogRootRequest{LogId: r.TreeID})
 		if err != nil {
-			return LogRange{}, fmt.Errorf("getting signed log root for tree %d: %w: %w", r.TreeID, err)
+			return LogRange{}, fmt.Errorf("getting signed log root for tree %d: %w", r.TreeID, err)
 		}
 		var root types.LogRootV1
 		if err := root.UnmarshalBinary(resp.SignedLogRoot.LogRoot); err != nil {

--- a/pkg/sharding/ranges.go
+++ b/pkg/sharding/ranges.go
@@ -55,12 +55,12 @@ func NewLogRanges(ctx context.Context, logClient trillian.TrillianLogClient, pat
 	// otherwise, try to read contents of the sharding config
 	ranges, err := logRangesFromPath(path)
 	if err != nil {
-		return LogRanges{}, errors.Wrap(err, "log ranges from path")
+		return LogRanges{}, fmt.Errorf("log ranges from path: %w: %w", err)
 	}
 	for i, r := range ranges {
 		r, err := updateRange(ctx, logClient, r)
 		if err != nil {
-			return LogRanges{}, errors.Wrapf(err, "updating range for tree id %d", r.TreeID)
+			return LogRanges{}, fmt.Errorf("updating range for tree id %d: %w: %w", r.TreeID, err)
 		}
 		ranges[i] = r
 	}
@@ -93,7 +93,7 @@ func updateRange(ctx context.Context, logClient trillian.TrillianLogClient, r Lo
 	if r.TreeLength == 0 {
 		resp, err := logClient.GetLatestSignedLogRoot(ctx, &trillian.GetLatestSignedLogRootRequest{LogId: r.TreeID})
 		if err != nil {
-			return LogRange{}, errors.Wrapf(err, "getting signed log root for tree %d", r.TreeID)
+			return LogRange{}, fmt.Errorf("getting signed log root for tree %d: %w: %w", r.TreeID, err)
 		}
 		var root types.LogRootV1
 		if err := root.UnmarshalBinary(resp.SignedLogRoot.LogRoot); err != nil {

--- a/pkg/types/alpine/alpine.go
+++ b/pkg/types/alpine/alpine.go
@@ -17,6 +17,7 @@ package alpine
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/sigstore/rekor/pkg/generated/models"
@@ -63,7 +64,7 @@ func (bat *BaseAlpineType) CreateProposedEntry(ctx context.Context, version stri
 	}
 	ei, err := bat.VersionedUnmarshal(nil, version)
 	if err != nil {
-		return nil, errors.Wrap(err, "fetching Intoto version implementation")
+		return nil, fmt.Errorf("fetching Intoto version implementation: %w", err)
 	}
 	return ei.CreateFromArtifactProperties(ctx, props)
 }

--- a/pkg/types/alpine/alpine.go
+++ b/pkg/types/alpine/alpine.go
@@ -17,9 +17,9 @@ package alpine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/rekor/pkg/types"
 )

--- a/pkg/types/alpine/apk.go
+++ b/pkg/types/alpine/apk.go
@@ -25,12 +25,12 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"hash"
 	"io"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature/options"
 	"gopkg.in/ini.v1"
@@ -178,12 +178,12 @@ func (p *Package) Unmarshal(pkgReader io.Reader) error {
 		if header.Name == ".PKGINFO" {
 			pkginfoContent := make([]byte, header.Size)
 			if _, err = ctlReader.Read(pkginfoContent); err != nil && err != io.EOF {
-				return fmt.Errorf("reading .PKGINFO: %w: %w", err)
+				return fmt.Errorf("reading .PKGINFO: %w", err)
 			}
 
 			pkg.Pkginfo, err = parsePkginfo(pkginfoContent)
 			if err != nil {
-				return fmt.Errorf("parsing .PKGINFO: %w: %w", err)
+				return fmt.Errorf("parsing .PKGINFO: %w", err)
 			}
 			pkg.Datahash, err = hex.DecodeString(pkg.Pkginfo["datahash"])
 			if err != nil {

--- a/pkg/types/hashedrekord/hashedrekord.go
+++ b/pkg/types/hashedrekord/hashedrekord.go
@@ -64,7 +64,7 @@ func (rt *BaseRekordType) CreateProposedEntry(ctx context.Context, version strin
 	}
 	ei, err := rt.VersionedUnmarshal(nil, version)
 	if err != nil {
-		return nil, errors.Wrap(err, "fetching hashed Rekord version implementation")
+		return nil, fmt.Errorf("fetching hashed Rekord version implementation: %w: %w", err)
 	}
 
 	return ei.CreateFromArtifactProperties(ctx, props)

--- a/pkg/types/hashedrekord/hashedrekord.go
+++ b/pkg/types/hashedrekord/hashedrekord.go
@@ -52,7 +52,7 @@ func (rt BaseRekordType) UnmarshalEntry(pe models.ProposedEntry) (types.EntryImp
 
 	rekord, ok := pe.(*models.Hashedrekord)
 	if !ok {
-		return nil, errors.New(fmt.Sprintf("%s, %s", "cannot unmarshal non-hashed Rekord types", pe.Kind()))
+		return nil, fmt.Errorf("%s, %s", "cannot unmarshal non-hashed Rekord types", pe.Kind())
 	}
 
 	return rt.VersionedUnmarshal(rekord, *rekord.APIVersion)

--- a/pkg/types/hashedrekord/hashedrekord.go
+++ b/pkg/types/hashedrekord/hashedrekord.go
@@ -52,7 +52,7 @@ func (rt BaseRekordType) UnmarshalEntry(pe models.ProposedEntry) (types.EntryImp
 
 	rekord, ok := pe.(*models.Hashedrekord)
 	if !ok {
-		return nil, fmt.Errorf("%s, %s", "cannot unmarshal non-hashed Rekord types", pe.Kind())
+		return nil, fmt.Errorf("cannot unmarshal non-hashed Rekord types: %s", pe.Kind())
 	}
 
 	return rt.VersionedUnmarshal(rekord, *rekord.APIVersion)

--- a/pkg/types/hashedrekord/hashedrekord.go
+++ b/pkg/types/hashedrekord/hashedrekord.go
@@ -17,9 +17,9 @@ package hashedrekord
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/rekor/pkg/types"
 )
@@ -64,7 +64,7 @@ func (rt *BaseRekordType) CreateProposedEntry(ctx context.Context, version strin
 	}
 	ei, err := rt.VersionedUnmarshal(nil, version)
 	if err != nil {
-		return nil, fmt.Errorf("fetching hashed Rekord version implementation: %w: %w", err)
+		return nil, fmt.Errorf("fetching hashed Rekord version implementation: %w", err)
 	}
 
 	return ei.CreateFromArtifactProperties(ctx, props)

--- a/pkg/types/hashedrekord/v0.0.1/entry.go
+++ b/pkg/types/hashedrekord/v0.0.1/entry.go
@@ -177,7 +177,7 @@ func (v *V001Entry) validate() (pki.Signature, pki.PublicKey, error) {
 		return nil, nil, err
 	}
 	if err := sigObj.Verify(nil, keyObj, options.WithDigest(decoded)); err != nil {
-		return nil, nil, types.ValidationError(errors.Wrap(err, "verifying signature"))
+		return nil, nil, types.ValidationError(fmt.Errorf("verifying signature: %w", err))
 	}
 
 	return sigObj, keyObj, nil

--- a/pkg/types/hashedrekord/v0.0.1/entry.go
+++ b/pkg/types/hashedrekord/v0.0.1/entry.go
@@ -21,6 +21,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -29,7 +30,6 @@ import (
 	"github.com/asaskevich/govalidator"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
-	"github.com/pkg/errors"
 
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/rekor/pkg/log"

--- a/pkg/types/helm/helm.go
+++ b/pkg/types/helm/helm.go
@@ -17,9 +17,9 @@ package helm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/rekor/pkg/types"
 )

--- a/pkg/types/helm/helm.go
+++ b/pkg/types/helm/helm.go
@@ -17,6 +17,7 @@ package helm
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/sigstore/rekor/pkg/generated/models"
@@ -63,7 +64,7 @@ func (it *BaseHelmType) CreateProposedEntry(ctx context.Context, version string,
 	}
 	ei, err := it.VersionedUnmarshal(nil, version)
 	if err != nil {
-		return nil, errors.Wrap(err, "fetching Rekord version implementation")
+		return nil, fmt.Errorf("fetching Rekord version implementation: %w", err)
 	}
 	return ei.CreateFromArtifactProperties(ctx, props)
 }

--- a/pkg/types/helm/provenance.go
+++ b/pkg/types/helm/provenance.go
@@ -17,12 +17,12 @@ package helm
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
 
 	"github.com/ghodss/yaml"
-	"github.com/pkg/errors"
 
 	"golang.org/x/crypto/openpgp/clearsign"
 )

--- a/pkg/types/helm/provenance.go
+++ b/pkg/types/helm/provenance.go
@@ -17,6 +17,7 @@ package helm
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"strings"
 
@@ -56,7 +57,7 @@ func (p *Provenance) Unmarshal(reader io.Reader) error {
 	}
 
 	if err = p.parseMessageBlock(block.Plaintext); err != nil {
-		return errors.Wrap(err, "Error occurred parsing message block")
+		return fmt.Errorf("Error occurred parsing message block: %w", err)
 	}
 
 	p.Block = block
@@ -73,7 +74,7 @@ func (p *Provenance) parseMessageBlock(data []byte) error {
 	sc := &SumCollection{}
 
 	if err := yaml.Unmarshal(parts[1], sc); err != nil {
-		return errors.Wrap(err, "Error occurred parsing SumCollection")
+		return fmt.Errorf("Error occurred parsing SumCollection: %w", err)
 	}
 
 	p.SumCollection = sc

--- a/pkg/types/helm/v0.0.1/entry.go
+++ b/pkg/types/helm/v0.0.1/entry.go
@@ -21,14 +21,13 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"

--- a/pkg/types/intoto/intoto.go
+++ b/pkg/types/intoto/intoto.go
@@ -17,6 +17,7 @@ package intoto
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/sigstore/rekor/pkg/generated/models"
@@ -63,7 +64,7 @@ func (it *BaseIntotoType) CreateProposedEntry(ctx context.Context, version strin
 	}
 	ei, err := it.VersionedUnmarshal(nil, version)
 	if err != nil {
-		return nil, errors.Wrap(err, "fetching Intoto version implementation")
+		return nil, fmt.Errorf("fetching Intoto version implementation: %w", err)
 	}
 	return ei.CreateFromArtifactProperties(ctx, props)
 }

--- a/pkg/types/intoto/intoto.go
+++ b/pkg/types/intoto/intoto.go
@@ -17,9 +17,9 @@ package intoto
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/rekor/pkg/types"
 )

--- a/pkg/types/intoto/v0.0.1/entry.go
+++ b/pkg/types/intoto/v0.0.1/entry.go
@@ -23,6 +23,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -34,8 +35,6 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
-
-	"github.com/pkg/errors"
 
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/rekor/pkg/log"

--- a/pkg/types/intoto/v0.0.1/entry.go
+++ b/pkg/types/intoto/v0.0.1/entry.go
@@ -187,7 +187,7 @@ func (v *V001Entry) Canonicalize(ctx context.Context) ([]byte, error) {
 	if attestation != nil {
 		decodedAttestation, err := base64.StdEncoding.DecodeString(string(attestation))
 		if err != nil {
-			return nil, errors.Wrap(err, "decoding attestation")
+			return nil, fmt.Errorf("decoding attestation: %w", err)
 		}
 		attH := sha256.Sum256(decodedAttestation)
 		canonicalEntry.Content.PayloadHash = &models.IntotoV001SchemaContentPayloadHash{

--- a/pkg/types/jar/jar.go
+++ b/pkg/types/jar/jar.go
@@ -17,6 +17,7 @@ package jar
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/sigstore/rekor/pkg/generated/models"
@@ -63,7 +64,7 @@ func (bjt *BaseJARType) CreateProposedEntry(ctx context.Context, version string,
 	}
 	ei, err := bjt.VersionedUnmarshal(nil, version)
 	if err != nil {
-		return nil, errors.Wrap(err, "fetching JAR version implementation")
+		return nil, fmt.Errorf("fetching JAR version implementation: %w", err)
 	}
 	return ei.CreateFromArtifactProperties(ctx, props)
 }

--- a/pkg/types/jar/jar.go
+++ b/pkg/types/jar/jar.go
@@ -17,9 +17,9 @@ package jar
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/rekor/pkg/types"
 )

--- a/pkg/types/rekord/rekord.go
+++ b/pkg/types/rekord/rekord.go
@@ -17,9 +17,9 @@ package rekord
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/rekor/pkg/types"
 )

--- a/pkg/types/rekord/rekord.go
+++ b/pkg/types/rekord/rekord.go
@@ -17,6 +17,7 @@ package rekord
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/sigstore/rekor/pkg/generated/models"
@@ -63,7 +64,7 @@ func (rt *BaseRekordType) CreateProposedEntry(ctx context.Context, version strin
 	}
 	ei, err := rt.VersionedUnmarshal(nil, version)
 	if err != nil {
-		return nil, errors.Wrap(err, "fetching Rekord version implementation")
+		return nil, fmt.Errorf("fetching Rekord version implementation: %w", err)
 	}
 	return ei.CreateFromArtifactProperties(ctx, props)
 }

--- a/pkg/types/rfc3161/rfc3161.go
+++ b/pkg/types/rfc3161/rfc3161.go
@@ -17,9 +17,9 @@ package rfc3161
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/rekor/pkg/types"
 )

--- a/pkg/types/rfc3161/rfc3161.go
+++ b/pkg/types/rfc3161/rfc3161.go
@@ -17,6 +17,7 @@ package rfc3161
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/sigstore/rekor/pkg/generated/models"
@@ -63,7 +64,7 @@ func (btt *BaseTimestampType) CreateProposedEntry(ctx context.Context, version s
 	}
 	ei, err := btt.VersionedUnmarshal(nil, version)
 	if err != nil {
-		return nil, errors.Wrap(err, "fetching RFC3161 version implementation")
+		return nil, fmt.Errorf("fetching RFC3161 version implementation: %w", err)
 	}
 	return ei.CreateFromArtifactProperties(ctx, props)
 }

--- a/pkg/types/rpm/rpm.go
+++ b/pkg/types/rpm/rpm.go
@@ -17,6 +17,7 @@ package rpm
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/sigstore/rekor/pkg/generated/models"
@@ -63,7 +64,7 @@ func (brt *BaseRPMType) CreateProposedEntry(ctx context.Context, version string,
 	}
 	ei, err := brt.VersionedUnmarshal(nil, version)
 	if err != nil {
-		return nil, errors.Wrap(err, "fetching RPM version implementation")
+		return nil, fmt.Errorf("fetching RPM version implementation: %w", err)
 	}
 	return ei.CreateFromArtifactProperties(ctx, props)
 }

--- a/pkg/types/rpm/rpm.go
+++ b/pkg/types/rpm/rpm.go
@@ -17,9 +17,9 @@ package rpm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/rekor/pkg/types"
 )

--- a/pkg/types/tuf/tuf.go
+++ b/pkg/types/tuf/tuf.go
@@ -17,9 +17,9 @@ package tuf
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/sigstore/rekor/pkg/types"
 
 	"github.com/sigstore/rekor/pkg/generated/models"

--- a/pkg/types/tuf/tuf.go
+++ b/pkg/types/tuf/tuf.go
@@ -65,7 +65,7 @@ func (btt *BaseTufType) CreateProposedEntry(ctx context.Context, version string,
 	}
 	ei, err := btt.VersionedUnmarshal(nil, version)
 	if err != nil {
-		return nil, errors.Wrap(err, "fetching TUF version implementation")
+		return nil, fmt.Errorf("fetching TUF version implementation: %w", err)
 	}
 	return ei.CreateFromArtifactProperties(ctx, props)
 }

--- a/pkg/util/checkpoint.go
+++ b/pkg/util/checkpoint.go
@@ -131,11 +131,11 @@ func CheckpointValidator(strToValidate string) bool {
 func (r *SignedCheckpoint) UnmarshalText(data []byte) error {
 	s := SignedNote{}
 	if err := s.UnmarshalText([]byte(data)); err != nil {
-		return errors.Wrap(err, "unmarshalling signed note")
+		return fmt.Errorf("unmarshalling signed note: %w", err)
 	}
 	c := Checkpoint{}
 	if err := c.UnmarshalCheckpoint([]byte(s.Note)); err != nil {
-		return errors.Wrap(err, "unmarshalling checkpoint")
+		return fmt.Errorf("unmarshalling checkpoint: %w", err)
 	}
 	*r = SignedCheckpoint{Checkpoint: c, SignedNote: s}
 	return nil

--- a/pkg/util/checkpoint.go
+++ b/pkg/util/checkpoint.go
@@ -18,11 +18,10 @@ package util
 import (
 	"bytes"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // heavily borrowed from https://github.com/google/trillian-examples/blob/master/formats/log/checkpoint.go

--- a/pkg/util/pubkey.go
+++ b/pkg/util/pubkey.go
@@ -18,8 +18,8 @@ package util
 import (
 	"context"
 	"crypto/ecdsa"
+	"errors"
 
-	"github.com/pkg/errors"
 	"github.com/sigstore/rekor/pkg/generated/client"
 	"github.com/sigstore/rekor/pkg/generated/client/pubkey"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"

--- a/pkg/util/signed_note.go
+++ b/pkg/util/signed_note.go
@@ -46,16 +46,16 @@ type SignedNote struct {
 func (s *SignedNote) Sign(identity string, signer signature.Signer, opts signature.SignOption) (*note.Signature, error) {
 	sig, err := signer.SignMessage(bytes.NewReader([]byte(s.Note)), opts)
 	if err != nil {
-		return nil, errors.Wrap(err, "signing note")
+		return nil, fmt.Errorf("signing note: %w", err)
 	}
 
 	pk, err := signer.PublicKey()
 	if err != nil {
-		return nil, errors.Wrap(err, "retrieving public key")
+		return nil, fmt.Errorf("retrieving public key: %w", err)
 	}
 	pubKeyBytes, err := x509.MarshalPKIXPublicKey(pk)
 	if err != nil {
-		return nil, errors.Wrap(err, "marshalling public key")
+		return nil, fmt.Errorf("marshalling public key: %w", err)
 	}
 
 	pkSha := sha256.Sum256(pubKeyBytes)
@@ -158,12 +158,12 @@ func (s *SignedNote) UnmarshalText(data []byte) error {
 	for b.Scan() {
 		var name, signature string
 		if _, err := fmt.Fscanf(strings.NewReader(b.Text()), "\u2014 %s %s\n", &name, &signature); err != nil {
-			return errors.Wrap(err, "parsing signature")
+			return fmt.Errorf("parsing signature: %w", err)
 		}
 
 		sigBytes, err := base64.StdEncoding.DecodeString(signature)
 		if err != nil {
-			return errors.Wrap(err, "decoding signature")
+			return fmt.Errorf("decoding signature: %w", err)
 		}
 		if len(sigBytes) < 5 {
 			return errors.New("signature is too small")

--- a/pkg/util/signed_note.go
+++ b/pkg/util/signed_note.go
@@ -25,10 +25,10 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature/options"
 	"golang.org/x/mod/sumdb/note"

--- a/pkg/util/timestamp_note.go
+++ b/pkg/util/timestamp_note.go
@@ -161,11 +161,11 @@ func TimestampNoteValidator(strToValidate string) bool {
 func (r *SignedTimestampNote) UnmarshalText(data []byte) error {
 	s := SignedNote{}
 	if err := s.UnmarshalText([]byte(data)); err != nil {
-		return errors.Wrap(err, "unmarshalling signed note")
+		return fmt.Errorf("unmarshalling signed note: %w", err)
 	}
 	t := TimestampNote{}
 	if err := t.UnmarshalText([]byte(s.Note)); err != nil {
-		return errors.Wrap(err, "unmarshalling timestamp note")
+		return fmt.Errorf("unmarshalling timestamp note: %w", err)
 	}
 	*r = SignedTimestampNote{TimestampNote: t, SignedNote: s}
 	return nil

--- a/pkg/util/timestamp_note.go
+++ b/pkg/util/timestamp_note.go
@@ -18,13 +18,12 @@ package util
 import (
 	"bytes"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 // Signed note based timestamp responses


### PR DESCRIPTION
#### Summary

all: remove dependency on deprecated github.com/pkg/errors
```console
$ go install github.com/zchee/go-analyzer/pkgerrors/cmd/pkgerrors@main
$ pkgerrors -fix ./...
$ goimports -w .
```

#### Ticket Link

Update: https://github.com/sigstore/cosign/issues/1880