### PR TITLE
Configure rekor server in e2e tests via env variable

### DIFF
--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -624,7 +624,7 @@ func TestSignedEntryTimestamp(t *testing.T) {
 	}
 
 	// submit our newly signed payload to rekor
-	rekorClient, err := client.GetRekorClient("http://localhost:3000")
+	rekorClient, err := client.GetRekorClient(rekorServer())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/util.go
+++ b/tests/util.go
@@ -13,12 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build e2e
 // +build e2e
 
 package e2e
 
 import (
 	"encoding/base64"
+	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -58,12 +60,13 @@ func run(t *testing.T, stdin, cmd string, arg ...string) string {
 		t.Log(string(b))
 		t.Fatal(err)
 	}
+
 	return string(b)
 }
 
 func runCli(t *testing.T, arg ...string) string {
 	t.Helper()
-	arg = append(arg, "--rekor_server=http://localhost:3000")
+	arg = append(arg, rekorServerFlag())
 	// use a blank config file to ensure no collision
 	if os.Getenv("REKORTMPDIR") != "" {
 		arg = append(arg, "--config="+os.Getenv("REKORTMPDIR")+".rekor.yaml")
@@ -73,7 +76,7 @@ func runCli(t *testing.T, arg ...string) string {
 
 func runCliErr(t *testing.T, arg ...string) string {
 	t.Helper()
-	arg = append(arg, "--rekor_server=http://localhost:3000")
+	arg = append(arg, rekorServerFlag())
 	// use a blank config file to ensure no collision
 	if os.Getenv("REKORTMPDIR") != "" {
 		arg = append(arg, "--config="+os.Getenv("REKORTMPDIR")+".rekor.yaml")
@@ -85,6 +88,17 @@ func runCliErr(t *testing.T, arg ...string) string {
 		t.Fatalf("expected error, got %s", string(b))
 	}
 	return string(b)
+}
+
+func rekorServerFlag() string {
+	return fmt.Sprintf("--rekor_server=%s", rekorServer())
+}
+
+func rekorServer() string {
+	if s := os.Getenv("REKOR_SERVER"); s != "" {
+		return s
+	}
+	return "http://localhost:3000"
 }
 
 func readFile(t *testing.T, p string) string {


### PR DESCRIPTION
This way some of the e2e tests can be run against production to make sure it's running as expected. This will be useful for the upcoming cluster migration.

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
