### PR TITLE
Print total tree size, including inactive shards in `rekor-cli loginfo`

### DIFF
--- a/cmd/rekor-cli/app/log_info.go
+++ b/cmd/rekor-cli/app/log_info.go
@@ -44,6 +44,7 @@ import (
 
 type logInfoCmdOutput struct {
 	TreeSize       int64
+	TotalTreeSize  int64
 	RootHash       string
 	TimestampNanos uint64
 	TreeID         string
@@ -54,11 +55,12 @@ func (l *logInfoCmdOutput) String() string {
 	ts := time.Unix(0, int64(l.TimestampNanos)).UTC().Format(time.RFC3339)
 
 	return fmt.Sprintf(`Verification Successful!
-Tree Size: %v
-Root Hash: %s
-Timestamp: %s
-TreeID:    %s
-`, l.TreeSize, l.RootHash, ts, l.TreeID)
+Tree Size:       %v
+Total Tree Size: %v
+Root Hash:       %s
+Timestamp:       %s
+TreeID:          %s
+`, l.TreeSize, l.TotalTreeSize, l.RootHash, ts, l.TreeID)
 }
 
 // logInfoCmd represents the current information about the transparency log
@@ -101,6 +103,7 @@ var logInfoCmd = &cobra.Command{
 
 		cmdOutput := &logInfoCmdOutput{
 			TreeSize:       swag.Int64Value(logInfo.TreeSize),
+			TotalTreeSize:  totalTreeSize(logInfo, logInfo.InactiveShards),
 			RootHash:       swag.StringValue(logInfo.RootHash),
 			TimestampNanos: sth.GetTimestamp(),
 			TreeID:         swag.StringValue(logInfo.TreeID),
@@ -220,6 +223,14 @@ func loadVerifier(rekorClient *rclient.Rekor) (signature.Verifier, error) {
 	}
 
 	return signature.LoadVerifier(pub, crypto.SHA256)
+}
+
+func totalTreeSize(activeShard *models.LogInfo, inactiveShards []*models.InactiveShardLogInfo) int64 {
+	total := swag.Int64Value(activeShard.TreeSize)
+	for _, i := range inactiveShards {
+		total += swag.Int64Value(i.TreeSize)
+	}
+	return total
 }
 
 func init() {

--- a/cmd/rekor-cli/app/log_info.go
+++ b/cmd/rekor-cli/app/log_info.go
@@ -43,7 +43,7 @@ import (
 )
 
 type logInfoCmdOutput struct {
-	TreeSize       int64
+	ActiveTreeSize int64
 	TotalTreeSize  int64
 	RootHash       string
 	TimestampNanos uint64
@@ -55,12 +55,12 @@ func (l *logInfoCmdOutput) String() string {
 	ts := time.Unix(0, int64(l.TimestampNanos)).UTC().Format(time.RFC3339)
 
 	return fmt.Sprintf(`Verification Successful!
-Tree Size:       %v
-Total Tree Size: %v
-Root Hash:       %s
-Timestamp:       %s
-TreeID:          %s
-`, l.TreeSize, l.TotalTreeSize, l.RootHash, ts, l.TreeID)
+Active Tree Size:       %v
+Total Tree Size:        %v
+Root Hash:              %s
+Timestamp:              %s
+TreeID:                 %s
+`, l.ActiveTreeSize, l.TotalTreeSize, l.RootHash, ts, l.TreeID)
 }
 
 // logInfoCmd represents the current information about the transparency log
@@ -102,7 +102,7 @@ var logInfoCmd = &cobra.Command{
 		}
 
 		cmdOutput := &logInfoCmdOutput{
-			TreeSize:       swag.Int64Value(logInfo.TreeSize),
+			ActiveTreeSize: swag.Int64Value(logInfo.TreeSize),
 			TotalTreeSize:  totalTreeSize(logInfo, logInfo.InactiveShards),
 			RootHash:       swag.StringValue(logInfo.RootHash),
 			TimestampNanos: sth.GetTimestamp(),

--- a/tests/sharding-e2e-test.sh
+++ b/tests/sharding-e2e-test.sh
@@ -194,6 +194,15 @@ popd
 # Pass in the universal log_index & make sure it resolves 
 check_log_index 3
 
+# Make sure the shard tree size is 1 and the total tree size is 4
+rm $HOME/.rekor/state.json # We have to remove this since we can't prove consistency between entry 0 and entry 1
+TREE_SIZE=$($REKOR_CLI loginfo --rekor_server http://localhost:3000 --format json | jq -r .TreeSize)
+stringsMatch $TREE_SIZE "1"
+
+TOTAL_TREE_SIZE=$($REKOR_CLI loginfo --rekor_server http://localhost:3000 --format json | jq -r .TotalTreeSize)
+stringsMatch $TOTAL_TREE_SIZE "4"
+
+
 # Make sure we can still get logproof for the now-inactive shard
 $REKOR_CLI logproof --last-size 2 --tree-id $INITIAL_TREE_ID --rekor_server http://localhost:3000
 # And the logproof for the now active shard
@@ -214,7 +223,6 @@ if [[ "$ENCODED_PUBLIC_KEY" == "$NEW_PUB_KEY" ]]; then
     echo "Active Shard Public Key: $NEW_PUB_KEY"
     exit 1
 fi
-
 
 # TODO: Try to get the entry via Entry ID (Tree ID in hex + UUID)
 UUID=$($REKOR_CLI get --log-index 2 --rekor_server http://localhost:3000 --format json | jq -r .UUID)

--- a/tests/sharding-e2e-test.sh
+++ b/tests/sharding-e2e-test.sh
@@ -196,7 +196,7 @@ check_log_index 3
 
 # Make sure the shard tree size is 1 and the total tree size is 4
 rm $HOME/.rekor/state.json # We have to remove this since we can't prove consistency between entry 0 and entry 1
-TREE_SIZE=$($REKOR_CLI loginfo --rekor_server http://localhost:3000 --format json | jq -r .TreeSize)
+TREE_SIZE=$($REKOR_CLI loginfo --rekor_server http://localhost:3000 --format json | jq -r .ActiveTreeSize)
 stringsMatch $TREE_SIZE "1"
 
 TOTAL_TREE_SIZE=$($REKOR_CLI loginfo --rekor_server http://localhost:3000 --format json | jq -r .TotalTreeSize)


### PR DESCRIPTION
Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
BREAKING CHANGE: Rename `TreeSize` in `rekor-cli loginfo` output to `ActiveTreeSize`. This helps clarify that this is the length of the active tree. Also add in `TotalTreeSize`, which is the length of the entire log across all inactive and active shards.
```
