### PR TITLE
Fix indexing bug for intoto attestations

### DIFF
--- a/pkg/types/intoto/v0.0.1/entry.go
+++ b/pkg/types/intoto/v0.0.1/entry.go
@@ -79,12 +79,10 @@ func (v V001Entry) IndexKeys() ([]string, error) {
 
 	switch v.env.PayloadType {
 	case in_toto.PayloadType:
-		if v.IntotoObj.Content == nil || v.IntotoObj.Content.Hash == nil {
-			log.Logger.Info("IntotoObj content or hash is nil")
-			return result, nil
+		if v.IntotoObj.Content != nil && v.IntotoObj.Content.Hash != nil {
+			hashkey := strings.ToLower(fmt.Sprintf("%s:%s", swag.StringValue(v.IntotoObj.Content.Hash.Algorithm), swag.StringValue(v.IntotoObj.Content.Hash.Value)))
+			result = append(result, hashkey)
 		}
-		hashkey := strings.ToLower(fmt.Sprintf("%s:%s", *v.IntotoObj.Content.Hash.Algorithm, *v.IntotoObj.Content.Hash.Value))
-		result = append(result, hashkey)
 
 		statement, err := parseStatement(v.env.Payload)
 		if err != nil {


### PR DESCRIPTION
If the `IntotoObj.Content` field isn't specified, we end up returning too soon instead of adding provenance subject digests as indexing keys. `cosign attest` never sets the Content field, so searching for attestations uploaded with cosign isn't working.

This should fix it and adds in a unit test.

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

