### PR TITLE
Allow an expired certificate chain to be uploaded and verified

### DIFF
--- a/pkg/pki/x509/testutils/cert_test_utils.go
+++ b/pkg/pki/x509/testutils/cert_test_utils.go
@@ -67,7 +67,7 @@ func GenerateRootCa() (*x509.Certificate, *ecdsa.PrivateKey, error) {
 			CommonName:   "sigstore",
 			Organization: []string{"sigstore.dev"},
 		},
-		NotBefore:             time.Now().Add(-5 * time.Minute),
+		NotBefore:             time.Now().Add(-10 * time.Minute),
 		NotAfter:              time.Now().Add(5 * time.Hour),
 		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
 		BasicConstraintsValid: true,
@@ -94,7 +94,7 @@ func GenerateSubordinateCa(rootTemplate *x509.Certificate, rootPriv crypto.Signe
 			CommonName:   "sigstore-sub",
 			Organization: []string{"sigstore.dev"},
 		},
-		NotBefore:             time.Now().Add(-2 * time.Minute),
+		NotBefore:             time.Now().Add(-9 * time.Minute),
 		NotAfter:              time.Now().Add(2 * time.Hour),
 		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
@@ -121,6 +121,36 @@ func GenerateLeafCert(subject string, oidcIssuer string, parentTemplate *x509.Ce
 		EmailAddresses: []string{subject},
 		NotBefore:      time.Now().Add(-1 * time.Minute),
 		NotAfter:       time.Now().Add(time.Hour),
+		KeyUsage:       x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:    []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+		IsCA:           false,
+		ExtraExtensions: []pkix.Extension{{
+			// OID for OIDC Issuer extension
+			Id:       asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 1},
+			Critical: false,
+			Value:    []byte(oidcIssuer),
+		}},
+	}
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cert, err := createCertificate(certTemplate, parentTemplate, &priv.PublicKey, parentPriv)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return cert, priv, nil
+}
+
+func GenerateExpiredLeafCert(subject string, oidcIssuer string, parentTemplate *x509.Certificate, parentPriv crypto.Signer) (*x509.Certificate, *ecdsa.PrivateKey, error) {
+	certTemplate := &x509.Certificate{
+		SerialNumber:   big.NewInt(1),
+		EmailAddresses: []string{subject},
+		NotBefore:      time.Now().Add(-5 * time.Minute),
+		NotAfter:       time.Now().Add(-2 * time.Minute),
 		KeyUsage:       x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:    []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
 		IsCA:           false,

--- a/pkg/pki/x509/x509.go
+++ b/pkg/pki/x509/x509.go
@@ -211,6 +211,8 @@ func verifyCertChain(certChain []*x509.Certificate) error {
 		Intermediates: subPool,
 		// Allow any key usage
 		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+		// Expired certificates can be uploaded and should be verifiable
+		CurrentTime: certChain[0].NotBefore,
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
This causes issues when trying to look up an entry where the chain was
valid/unexpired when uploaded, but has since expired when it's
retreived.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Fixed bug with uploading and verifying certificate chains with expired certificates
```
