### PR TITLE
feat: add subject URIs to index for x509 certificates

### DIFF
--- a/pkg/pki/minisign/minisign.go
+++ b/pkg/pki/minisign/minisign.go
@@ -177,3 +177,8 @@ func (k PublicKey) CanonicalValue() ([]byte, error) {
 func (k PublicKey) EmailAddresses() []string {
 	return nil
 }
+
+// Subjects implements the pki.PublicKey interface
+func (k PublicKey) Subjects() []string {
+	return nil
+}

--- a/pkg/pki/pgp/pgp.go
+++ b/pkg/pki/pgp/pgp.go
@@ -296,3 +296,8 @@ func (k PublicKey) EmailAddresses() []string {
 	}
 	return names
 }
+
+// Subjects implements the pki.PublicKey interface
+func (k PublicKey) Subjects() []string {
+	return k.EmailAddresses()
+}

--- a/pkg/pki/pgp/pgp_test.go
+++ b/pkg/pki/pgp/pgp_test.go
@@ -347,18 +347,18 @@ func TestEmailAddresses(t *testing.T) {
 	type test struct {
 		caseDesc  string
 		inputFile string
-		emails    []string
+		subjects  []string
 	}
 
 	var k PublicKey
-	if len(k.EmailAddresses()) != 0 {
-		t.Errorf("EmailAddresses for unitialized key should give empty slice")
+	if len(k.Subjects()) != 0 {
+		t.Errorf("Subjects for unitialized key should give empty slice")
 	}
 	tests := []test{
-		{caseDesc: "Valid armored public key", inputFile: "testdata/valid_armored_public.pgp", emails: []string{}},
-		{caseDesc: "Valid armored public key with multiple subentries", inputFile: "testdata/valid_armored_complex_public.pgp", emails: []string{"linux-packages-keymaster@google.com", "linux-packages-keymaster@google.com"}},
-		{caseDesc: "Valid binary public key", inputFile: "testdata/valid_binary_public.pgp", emails: []string{}},
-		{caseDesc: "Valid binary public key with multiple subentries", inputFile: "testdata/valid_binary_complex_public.pgp", emails: []string{"linux-packages-keymaster@google.com", "linux-packages-keymaster@google.com"}},
+		{caseDesc: "Valid armored public key", inputFile: "testdata/valid_armored_public.pgp", subjects: []string{}},
+		{caseDesc: "Valid armored public key with multiple subentries", inputFile: "testdata/valid_armored_complex_public.pgp", subjects: []string{"linux-packages-keymaster@google.com", "linux-packages-keymaster@google.com"}},
+		{caseDesc: "Valid binary public key", inputFile: "testdata/valid_binary_public.pgp", subjects: []string{}},
+		{caseDesc: "Valid binary public key with multiple subentries", inputFile: "testdata/valid_binary_complex_public.pgp", subjects: []string{"linux-packages-keymaster@google.com", "linux-packages-keymaster@google.com"}},
 	}
 
 	for _, tc := range tests {
@@ -374,18 +374,18 @@ func TestEmailAddresses(t *testing.T) {
 			t.Errorf("%v: Error reading input for TestEmailAddresses: %v", tc.caseDesc, err)
 		}
 
-		emails := inputKey.EmailAddresses()
+		subjects := inputKey.Subjects()
 
-		if len(emails) == len(tc.emails) {
-			if len(emails) > 0 {
-				sort.Strings(emails)
-				sort.Strings(tc.emails)
-				if !reflect.DeepEqual(emails, tc.emails) {
-					t.Errorf("%v: Error getting email addresses from keys, got %v, expected %v", tc.caseDesc, emails, tc.emails)
+		if len(subjects) == len(tc.subjects) {
+			if len(subjects) > 0 {
+				sort.Strings(subjects)
+				sort.Strings(tc.subjects)
+				if !reflect.DeepEqual(subjects, tc.subjects) {
+					t.Errorf("%v: Error getting subjects from keys, got %v, expected %v", tc.caseDesc, subjects, tc.subjects)
 				}
 			}
 		} else {
-			t.Errorf("%v: Error getting email addresses from keys length, got %v, expected %v", tc.caseDesc, len(emails), len(tc.emails))
+			t.Errorf("%v: Error getting subjects from keys length, got %v, expected %v", tc.caseDesc, len(subjects), len(tc.subjects))
 		}
 
 	}

--- a/pkg/pki/pkcs7/pkcs7.go
+++ b/pkg/pki/pkcs7/pkcs7.go
@@ -209,3 +209,8 @@ func (k PublicKey) EmailAddresses() []string {
 
 	return names
 }
+
+// Subjects implements the pki.PublicKey interface
+func (k PublicKey) Subjects() []string {
+	return k.EmailAddresses()
+}

--- a/pkg/pki/pkcs7/pkcs7_test.go
+++ b/pkg/pki/pkcs7/pkcs7_test.go
@@ -292,7 +292,7 @@ func TestEmailAddresses(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			emails := pub.EmailAddresses()
+			emails := pub.Subjects()
 
 			if len(emails) == len(tt.emails) {
 				if len(emails) > 0 {

--- a/pkg/pki/pki.go
+++ b/pkg/pki/pki.go
@@ -24,7 +24,10 @@ import (
 // PublicKey Generic object representing a public key (regardless of format & algorithm)
 type PublicKey interface {
 	CanonicalValue() ([]byte, error)
+	// Deprecated: EmailAddresses() will be deprecated in favor of Subjects() which will
+	// also return Subject URIs present in public keys.
 	EmailAddresses() []string
+	Subjects() []string
 }
 
 // Signature Generic object representing a signature (regardless of format & algorithm)

--- a/pkg/pki/ssh/ssh.go
+++ b/pkg/pki/ssh/ssh.go
@@ -102,3 +102,8 @@ func (k PublicKey) CanonicalValue() ([]byte, error) {
 func (k PublicKey) EmailAddresses() []string {
 	return nil
 }
+
+// Subjects implements the pki.PublicKey interface
+func (k PublicKey) Subjects() []string {
+	return nil
+}

--- a/pkg/pki/tuf/tuf.go
+++ b/pkg/pki/tuf/tuf.go
@@ -169,3 +169,8 @@ func (k PublicKey) SpecVersion() (string, error) {
 func (k PublicKey) EmailAddresses() []string {
 	return nil
 }
+
+// Subjects implements the pki.PublicKey interface
+func (k PublicKey) Subjects() []string {
+	return nil
+}

--- a/pkg/pki/x509/testutils/cert_test_utils.go
+++ b/pkg/pki/x509/testutils/cert_test_utils.go
@@ -23,6 +23,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"math/big"
+	"net/url"
 	"time"
 )
 
@@ -115,7 +116,7 @@ func GenerateSubordinateCa(rootTemplate *x509.Certificate, rootPriv crypto.Signe
 	return cert, priv, nil
 }
 
-func GenerateLeafCert(subject string, oidcIssuer string, parentTemplate *x509.Certificate, parentPriv crypto.Signer) (*x509.Certificate, *ecdsa.PrivateKey, error) {
+func GenerateLeafCert(subject, oidcIssuer string, uri *url.URL, parentTemplate *x509.Certificate, parentPriv crypto.Signer) (*x509.Certificate, *ecdsa.PrivateKey, error) {
 	certTemplate := &x509.Certificate{
 		SerialNumber:   big.NewInt(1),
 		EmailAddresses: []string{subject},
@@ -130,6 +131,9 @@ func GenerateLeafCert(subject string, oidcIssuer string, parentTemplate *x509.Ce
 			Critical: false,
 			Value:    []byte(oidcIssuer),
 		}},
+	}
+	if uri != nil {
+		certTemplate.URIs = []*url.URL{uri}
 	}
 
 	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)

--- a/pkg/pki/x509/x509.go
+++ b/pkg/pki/x509/x509.go
@@ -204,14 +204,12 @@ func (k PublicKey) Subjects() []string {
 	if cert != nil {
 		validate := validator.New()
 		for _, name := range cert.EmailAddresses {
-			errs := validate.Var(name, "required,email")
-			if errs == nil {
+			if errs := validate.Var(name, "required,email"); errs == nil {
 				names = append(names, strings.ToLower(name))
 			}
 		}
 		for _, name := range cert.URIs {
-			errs := validate.Var(name.String(), "required,uri")
-			if errs == nil {
+			if errs := validate.Var(name.String(), "required,uri"); errs == nil {
 				names = append(names, strings.ToLower(name.String()))
 			}
 		}

--- a/pkg/pki/x509/x509.go
+++ b/pkg/pki/x509/x509.go
@@ -188,6 +188,13 @@ func (k PublicKey) EmailAddresses() []string {
 				names = append(names, strings.ToLower(name))
 			}
 		}
+		for _, name := range cert.URIs {
+			validate := validator.New()
+			errs := validate.Var(name.String(), "required,uri")
+			if errs == nil {
+				names = append(names, strings.ToLower(name.String()))
+			}
+		}
 	}
 	return names
 }

--- a/pkg/pki/x509/x509.go
+++ b/pkg/pki/x509/x509.go
@@ -181,15 +181,35 @@ func (k PublicKey) EmailAddresses() []string {
 		cert = k.certs[0]
 	}
 	if cert != nil {
+		validate := validator.New()
 		for _, name := range cert.EmailAddresses {
-			validate := validator.New()
+			errs := validate.Var(name, "required,email")
+			if errs == nil {
+				names = append(names, strings.ToLower(name))
+			}
+		}
+	}
+	return names
+}
+
+// Subjects implements the pki.PublicKey interface
+func (k PublicKey) Subjects() []string {
+	var names []string
+	var cert *x509.Certificate
+	if k.cert != nil {
+		cert = k.cert.c
+	} else if len(k.certs) > 0 {
+		cert = k.certs[0]
+	}
+	if cert != nil {
+		validate := validator.New()
+		for _, name := range cert.EmailAddresses {
 			errs := validate.Var(name, "required,email")
 			if errs == nil {
 				names = append(names, strings.ToLower(name))
 			}
 		}
 		for _, name := range cert.URIs {
-			validate := validator.New()
 			errs := validate.Var(name.String(), "required,uri")
 			if errs == nil {
 				names = append(names, strings.ToLower(name.String()))

--- a/pkg/pki/x509/x509_test.go
+++ b/pkg/pki/x509/x509_test.go
@@ -225,7 +225,8 @@ func TestPublicKeyWithCertChain(t *testing.T) {
 		t.Fatalf("expected matching subjects, expected %v, got %v", leafCert.EmailAddresses, pub.EmailAddresses())
 	}
 
-	expectedSubjects := append(leafCert.EmailAddresses, leafCert.URIs[0].String())
+	expectedSubjects := leafCert.EmailAddresses
+	expectedSubjects = append(expectedSubjects, leafCert.URIs[0].String())
 	if !reflect.DeepEqual(pub.Subjects(), expectedSubjects) {
 		t.Fatalf("expected matching subjects, expected %v, got %v", expectedSubjects, pub.Subjects())
 	}

--- a/pkg/pki/x509/x509_test.go
+++ b/pkg/pki/x509/x509_test.go
@@ -221,8 +221,13 @@ func TestPublicKeyWithCertChain(t *testing.T) {
 		t.Fatal("expected public keys to match")
 	}
 
-	if !reflect.DeepEqual(pub.EmailAddresses(), append(leafCert.EmailAddresses, leafCert.URIs[0].String())) {
-		t.Fatalf("expected matching email addresses, expected %v, got %v", leafCert.EmailAddresses, pub.EmailAddresses())
+	if !reflect.DeepEqual(pub.EmailAddresses(), leafCert.EmailAddresses) {
+		t.Fatalf("expected matching subjects, expected %v, got %v", leafCert.EmailAddresses, pub.EmailAddresses())
+	}
+
+	expectedSubjects := append(leafCert.EmailAddresses, leafCert.URIs[0].String())
+	if !reflect.DeepEqual(pub.Subjects(), expectedSubjects) {
+		t.Fatalf("expected matching subjects, expected %v, got %v", expectedSubjects, pub.Subjects())
 	}
 
 	canonicalValue, err := pub.CanonicalValue()

--- a/pkg/types/alpine/v0.0.1/entry.go
+++ b/pkg/types/alpine/v0.0.1/entry.go
@@ -78,7 +78,7 @@ func (v V001Entry) IndexKeys() ([]string, error) {
 	keyHash := sha256.Sum256(key)
 	result = append(result, strings.ToLower(hex.EncodeToString(keyHash[:])))
 
-	result = append(result, keyObj.EmailAddresses()...)
+	result = append(result, keyObj.Subjects()...)
 
 	if v.AlpineModel.Package.Hash != nil {
 		hashKey := strings.ToLower(fmt.Sprintf("%s:%s", *v.AlpineModel.Package.Hash.Algorithm, *v.AlpineModel.Package.Hash.Value))

--- a/pkg/types/cose/v0.0.1/entry.go
+++ b/pkg/types/cose/v0.0.1/entry.go
@@ -90,7 +90,7 @@ func (v V001Entry) IndexKeys() ([]string, error) {
 		keyHash := sha256.Sum256(key)
 		result = append(result, strings.ToLower(hex.EncodeToString(keyHash[:])))
 	}
-	result = append(result, keyObj.EmailAddresses()...)
+	result = append(result, keyObj.Subjects()...)
 
 	// 2. Overall envelope
 	result = append(result, formatKey(v.CoseObj.Message))

--- a/pkg/types/cose/v0.0.1/entry_test.go
+++ b/pkg/types/cose/v0.0.1/entry_test.go
@@ -84,6 +84,10 @@ func (t testPublicKey) EmailAddresses() []string {
 	return nil
 }
 
+func (t testPublicKey) Subjects() []string {
+	return nil
+}
+
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }

--- a/pkg/types/hashedrekord/v0.0.1/entry.go
+++ b/pkg/types/hashedrekord/v0.0.1/entry.go
@@ -74,7 +74,7 @@ func (v V001Entry) IndexKeys() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	result = append(result, pub.EmailAddresses()...)
+	result = append(result, pub.Subjects()...)
 
 	if v.HashedRekordObj.Data.Hash != nil {
 		hashKey := strings.ToLower(fmt.Sprintf("%s:%s", *v.HashedRekordObj.Data.Hash.Algorithm, *v.HashedRekordObj.Data.Hash.Value))

--- a/pkg/types/helm/v0.0.1/entry.go
+++ b/pkg/types/helm/v0.0.1/entry.go
@@ -82,7 +82,7 @@ func (v V001Entry) IndexKeys() ([]string, error) {
 	keyHash := sha256.Sum256(key)
 	result = append(result, strings.ToLower(hex.EncodeToString(keyHash[:])))
 
-	result = append(result, keyObj.EmailAddresses()...)
+	result = append(result, keyObj.Subjects()...)
 
 	algorithm, chartHash, err := provenance.GetChartAlgorithmHash()
 

--- a/pkg/types/intoto/v0.0.1/entry.go
+++ b/pkg/types/intoto/v0.0.1/entry.go
@@ -88,8 +88,8 @@ func (v V001Entry) IndexKeys() ([]string, error) {
 			keyHash := sha256.Sum256(key)
 			result = append(result, fmt.Sprintf("sha256:%s", strings.ToLower(hex.EncodeToString(keyHash[:]))))
 
-			// add digest over any email addresses within signing certificate
-			result = append(result, v.keyObj.EmailAddresses()...)
+			// add digest over any subjects within signing certificate
+			result = append(result, v.keyObj.Subjects()...)
 		} else {
 			log.Logger.Errorf("could not canonicalize public key to include in index keys: %w", err)
 		}

--- a/pkg/types/rekord/v0.0.1/entry.go
+++ b/pkg/types/rekord/v0.0.1/entry.go
@@ -84,7 +84,7 @@ func (v V001Entry) IndexKeys() ([]string, error) {
 		result = append(result, strings.ToLower(hex.EncodeToString(keyHash[:])))
 	}
 
-	result = append(result, keyObj.EmailAddresses()...)
+	result = append(result, keyObj.Subjects()...)
 
 	if v.RekordObj.Data.Hash != nil {
 		hashKey := strings.ToLower(fmt.Sprintf("%s:%s", *v.RekordObj.Data.Hash.Algorithm, *v.RekordObj.Data.Hash.Value))

--- a/pkg/types/rpm/v0.0.1/entry.go
+++ b/pkg/types/rpm/v0.0.1/entry.go
@@ -80,7 +80,7 @@ func (v V001Entry) IndexKeys() ([]string, error) {
 	keyHash := sha256.Sum256(key)
 	result = append(result, strings.ToLower(hex.EncodeToString(keyHash[:])))
 
-	result = append(result, keyObj.EmailAddresses()...)
+	result = append(result, keyObj.Subjects()...)
 
 	if v.RPMModel.Package.Hash != nil {
 		hashKey := strings.ToLower(fmt.Sprintf("%s:%s", *v.RPMModel.Package.Hash.Algorithm, *v.RPMModel.Package.Hash.Value))


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->
Adds URIs to x509 certificate "email addresses". This picks up on job workflow ref for Fulcio issued certificates.

Ideally I'd like to deprecate `EmailAddresses()` in favor of `Subjects()` -- should I add `Subjects()` and mark `EmailAddresses()` as deprecated? I'm not sure there's much external usage.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
* pki: Deprecates `pki.PublicKey.EmailAddresses()`. Use `pki.PublicKey.Subjects()` instead to include subject URIs from public keys like x509 certificates.
```
