### PR TITLE
ensure log messages have requestID where possible 

### DIFF
--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -67,10 +67,11 @@ func handleRekorAPIError(params interface{}, code int, err error, message string
 	handler := re.FindStringSubmatch(typeStr)[1]
 
 	logMsg := func(r *http.Request) {
-		log.RequestIDLogger(r).Errorw("exiting with error", append([]interface{}{"handler", handler, "statusCode", code, "clientMessage", message, "error", err}, fields...)...)
+		ctx := r.Context()
+		log.ContextLogger(ctx).Errorw("error processing request", append([]interface{}{"handler", handler, "statusCode", code, "clientMessage", message, "error", err}, fields...)...)
 		paramsFields := map[string]interface{}{}
 		if err := mapstructure.Decode(params, &paramsFields); err == nil {
-			log.RequestIDLogger(r).Debug(paramsFields)
+			log.ContextLogger(ctx).Debug(paramsFields)
 		}
 	}
 

--- a/pkg/generated/restapi/configure_rekor_server.go
+++ b/pkg/generated/restapi/configure_rekor_server.go
@@ -159,7 +159,7 @@ func setupGlobalMiddleware(handler http.Handler) http.Handler {
 		ctx := r.Context()
 		r = r.WithContext(log.WithRequestID(ctx, middleware.GetReqID(ctx)))
 		defer func() {
-			_ = log.RequestIDLogger(r).Sync()
+			_ = log.ContextLogger(ctx).Sync()
 		}()
 
 		returnHandler.ServeHTTP(w, r)
@@ -196,14 +196,15 @@ func cacheForever(handler http.Handler) http.Handler {
 }
 
 func logAndServeError(w http.ResponseWriter, r *http.Request, err error) {
+	ctx := r.Context()
 	if apiErr, ok := err.(errors.Error); ok && apiErr.Code() == http.StatusNotFound {
-		log.RequestIDLogger(r).Warn(err)
+		log.ContextLogger(ctx).Warn(err)
 	} else {
-		log.RequestIDLogger(r).Error(err)
+		log.ContextLogger(ctx).Error(err)
 	}
 	requestFields := map[string]interface{}{}
 	if err := mapstructure.Decode(r, &requestFields); err == nil {
-		log.RequestIDLogger(r).Debug(requestFields)
+		log.ContextLogger(ctx).Debug(requestFields)
 	}
 	errors.ServeError(w, r, err)
 }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -18,7 +18,6 @@ package log
 import (
 	"context"
 	"log"
-	"net/http"
 
 	"github.com/go-chi/chi/middleware"
 	"go.uber.org/zap"
@@ -69,10 +68,10 @@ func WithRequestID(ctx context.Context, id string) context.Context {
 	return context.WithValue(ctx, middleware.RequestIDKey, id)
 }
 
-func RequestIDLogger(r *http.Request) *zap.SugaredLogger {
+func ContextLogger(ctx context.Context) *zap.SugaredLogger {
 	proposedLogger := Logger
-	if r != nil {
-		if ctxRequestID, ok := r.Context().Value(middleware.RequestIDKey).(string); ok {
+	if ctx != nil {
+		if ctxRequestID, ok := ctx.Value(middleware.RequestIDKey).(string); ok {
 			proposedLogger = proposedLogger.With(zap.String("requestID", ctxRequestID))
 		}
 	}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -55,7 +55,7 @@ type Blob struct {
 }
 
 func (b *Blob) StoreAttestation(ctx context.Context, key string, attestation []byte) error {
-	log.Logger.Infof("storing attestation at %s", key)
+	log.ContextLogger(ctx).Infof("storing attestation at %s", key)
 	w, err := b.bucket.NewWriter(ctx, key, nil)
 	if err != nil {
 		return err
@@ -67,7 +67,7 @@ func (b *Blob) StoreAttestation(ctx context.Context, key string, attestation []b
 }
 
 func (b *Blob) FetchAttestation(ctx context.Context, key string) ([]byte, error) {
-	log.Logger.Infof("fetching attestation %s", key)
+	log.ContextLogger(ctx).Infof("fetching attestation %s", key)
 	exists, err := b.bucket.Exists(ctx, key)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
by using `ContextLogger`, we will have a unique request ID in the logs which allows us to more easily correlate events to an incoming request.