### PR TITLE
Remove unnecessary lookup of non-existent attestations from storage layer

### DIFF
--- a/pkg/types/alpine/v0.0.1/entry.go
+++ b/pkg/types/alpine/v0.0.1/entry.go
@@ -287,14 +287,6 @@ func (v V001Entry) validate() error {
 	return nil
 }
 
-func (v V001Entry) AttestationKey() string {
-	return ""
-}
-
-func (v V001Entry) AttestationKeyValue() (string, []byte) {
-	return "", nil
-}
-
 func (v V001Entry) CreateFromArtifactProperties(ctx context.Context, props types.ArtifactProperties) (models.ProposedEntry, error) {
 	returnVal := models.Alpine{}
 	re := V001Entry{}

--- a/pkg/types/entries.go
+++ b/pkg/types/entries.go
@@ -35,9 +35,14 @@ type EntryImpl interface {
 	IndexKeys() ([]string, error)                     // the keys that should be added to the external index for this entry
 	Canonicalize(ctx context.Context) ([]byte, error) // marshal the canonical entry to be put into the tlog
 	Unmarshal(e models.ProposedEntry) error           // unmarshal the abstract entry into the specific struct for this versioned type
-	AttestationKey() string                           // returns the key used to look up the attestation from storage (should be sha256:digest)
-	AttestationKeyValue() (string, []byte)            // returns the key to be used when storing the attestation as well as the attestation itself
 	CreateFromArtifactProperties(context.Context, ArtifactProperties) (models.ProposedEntry, error)
+}
+
+// EntryWithAttestationImpl specifies the behavior of a versioned type that also stores attestations
+type EntryWithAttestationImpl interface {
+	EntryImpl
+	AttestationKey() string                // returns the key used to look up the attestation from storage (should be sha256:digest)
+	AttestationKeyValue() (string, []byte) // returns the key to be used when storing the attestation as well as the attestation itself
 }
 
 // EntryFactory describes a factory function that can generate structs for a specific versioned type

--- a/pkg/types/hashedrekord/v0.0.1/entry.go
+++ b/pkg/types/hashedrekord/v0.0.1/entry.go
@@ -189,14 +189,6 @@ func (v *V001Entry) validate() (pki.Signature, pki.PublicKey, error) {
 	return sigObj, keyObj, nil
 }
 
-func (v V001Entry) AttestationKey() string {
-	return ""
-}
-
-func (v V001Entry) AttestationKeyValue() (string, []byte) {
-	return "", nil
-}
-
 func (v V001Entry) CreateFromArtifactProperties(ctx context.Context, props types.ArtifactProperties) (models.ProposedEntry, error) {
 	returnVal := models.Hashedrekord{}
 	re := V001Entry{}

--- a/pkg/types/helm/v0.0.1/entry.go
+++ b/pkg/types/helm/v0.0.1/entry.go
@@ -280,14 +280,6 @@ func (v V001Entry) validate() error {
 	return nil
 }
 
-func (v V001Entry) AttestationKey() string {
-	return ""
-}
-
-func (v V001Entry) AttestationKeyValue() (string, []byte) {
-	return "", nil
-}
-
 func (v V001Entry) CreateFromArtifactProperties(ctx context.Context, props types.ArtifactProperties) (models.ProposedEntry, error) {
 	//TODO: how to select version of item to create
 	returnVal := models.Helm{}

--- a/pkg/types/jar/v0.0.1/entry.go
+++ b/pkg/types/jar/v0.0.1/entry.go
@@ -271,14 +271,6 @@ func extractPKCS7SignatureFromJAR(inz *zip.Reader) ([]byte, error) {
 	return nil, errors.New("unable to locate signature in JAR file")
 }
 
-func (v V001Entry) AttestationKey() string {
-	return ""
-}
-
-func (v V001Entry) AttestationKeyValue() (string, []byte) {
-	return "", nil
-}
-
 func (v *V001Entry) CreateFromArtifactProperties(ctx context.Context, props types.ArtifactProperties) (models.ProposedEntry, error) {
 	returnVal := models.Jar{}
 	re := V001Entry{}

--- a/pkg/types/rekord/v0.0.1/entry.go
+++ b/pkg/types/rekord/v0.0.1/entry.go
@@ -332,14 +332,6 @@ func (v V001Entry) validate() error {
 	return nil
 }
 
-func (v V001Entry) AttestationKey() string {
-	return ""
-}
-
-func (v V001Entry) AttestationKeyValue() (string, []byte) {
-	return "", nil
-}
-
 func (v V001Entry) CreateFromArtifactProperties(ctx context.Context, props types.ArtifactProperties) (models.ProposedEntry, error) {
 	returnVal := models.Rekord{}
 	re := V001Entry{}

--- a/pkg/types/rfc3161/v0.0.1/entry.go
+++ b/pkg/types/rfc3161/v0.0.1/entry.go
@@ -173,14 +173,6 @@ func (v V001Entry) validate() error {
 	return nil
 }
 
-func (v V001Entry) AttestationKey() string {
-	return ""
-}
-
-func (v V001Entry) AttestationKeyValue() (string, []byte) {
-	return "", nil
-}
-
 func (v V001Entry) CreateFromArtifactProperties(_ context.Context, props types.ArtifactProperties) (models.ProposedEntry, error) {
 	returnVal := models.Rfc3161{}
 

--- a/pkg/types/rpm/v0.0.1/entry.go
+++ b/pkg/types/rpm/v0.0.1/entry.go
@@ -307,14 +307,6 @@ func (v V001Entry) validate() error {
 	return nil
 }
 
-func (v V001Entry) AttestationKey() string {
-	return ""
-}
-
-func (v V001Entry) AttestationKeyValue() (string, []byte) {
-	return "", nil
-}
-
 func (v V001Entry) CreateFromArtifactProperties(ctx context.Context, props types.ArtifactProperties) (models.ProposedEntry, error) {
 	returnVal := models.Rpm{}
 	re := V001Entry{}

--- a/pkg/types/tuf/v0.0.1/entry.go
+++ b/pkg/types/tuf/v0.0.1/entry.go
@@ -294,14 +294,6 @@ func (v V001Entry) Validate() error {
 	return nil
 }
 
-func (v V001Entry) AttestationKey() string {
-	return ""
-}
-
-func (v V001Entry) AttestationKeyValue() (string, []byte) {
-	return "", nil
-}
-
 func (v V001Entry) CreateFromArtifactProperties(ctx context.Context, props types.ArtifactProperties) (models.ProposedEntry, error) {
 	// This will do only syntactic checks of the metablock, not signature verification.
 	// Signature verification occurs in FetchExternalEntries()


### PR DESCRIPTION
Currently only two Rekor pluggable types support the storage of attestations (`intoto`, `cose`); the previous code to fetch attestations was type-agnostic, but due to the fix #878, the server was doing unnecessary lookups for all types, regardless of whether they store attestation content or not.

This makes the attestation storage an explicit interface, which we can test casting for and avoid a round trip to the storage layer for types that don't support storing attestations.

Signed-off-by: Bob Callaway <bcallaway@google.com>