### PR TITLE
Updates on the release job/makefile cleanup

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -72,7 +72,7 @@ builds:
       - -trimpath
     mod_timestamp: '{{ .CommitTimestamp }}'
     ldflags:
-     - "{{ .Env.CLIENT_LDFLAGS }}"
+     - "{{ .Env.CLI_LDFLAGS }}"
 
 signs:
   - id: rekor

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -32,7 +32,7 @@ steps:
     echo "Checking out ${_GIT_TAG}"
     git checkout ${_GIT_TAG}
 
-- name: 'gcr.io/projectsigstore/cosign:v1.8.0@sha256:12b4d428529654c95a7550a936cbb5c6fe93a046ea7454676cb6fb0ce566d78c'
+- name: 'gcr.io/projectsigstore/cosign:v1.9.0@sha256:ef2d14e16dbb7786d8713e4898a8512e69ace4105f5b371a9c115ffcc3e85d84'
   dir: "go/src/sigstore/rekor"
   env:
   - COSIGN_EXPERIMENTAL=true

--- a/release/release.mk
+++ b/release/release.mk
@@ -5,12 +5,12 @@
 # used when releasing together with GCP CloudBuild
 .PHONY: release
 release:
-	CLIENT_LDFLAGS="$(CLI_LDFLAGS)" SERVER_LDFLAGS="$(SERVER_LDFLAGS)" goreleaser release --rm-dist --timeout 60m
+	CLI_LDFLAGS="$(CLI_LDFLAGS)" SERVER_LDFLAGS="$(SERVER_LDFLAGS)" goreleaser release --rm-dist --timeout 60m
 
 # used when need to validate the goreleaser
 .PHONY: snapshot
 snapshot:
-	CLIENT_LDFLAGS="$(CLI_LDFLAGS)" SERVER_LDFLAGS="$(SERVER_LDFLAGS)" goreleaser release --skip-sign --skip-publish --snapshot --rm-dist
+	CLI_LDFLAGS="$(CLI_LDFLAGS)" SERVER_LDFLAGS="$(SERVER_LDFLAGS)" goreleaser release --skip-sign --skip-publish --snapshot --rm-dist
 
 ###########################
 # sign section


### PR DESCRIPTION
#### Summary
- using go1.18 we dont need to pass some ldflags anymore, the only one is the git tag which there is an open issues in the go library for that (dont recall the number, but will find it)
- clean up of the makefile and update cosign image


#### Documentation
n/a