### PR TITLE
Add rekor harness tests 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -138,6 +138,8 @@ jobs:
     needs: build
     steps:
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+    - name: Create git branch
+      run: git switch -c harness-test-branch
     - name: Extract version of Go to use
       run: echo "GOVERSION=$(cat Dockerfile|grep golang | awk ' { print $2 } ' | cut -d '@' -f 1 | cut -d ':' -f 2 | uniq)" >> $GITHUB_ENV
     - uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923 # v3.1.0

--- a/tests/harness_test.go
+++ b/tests/harness_test.go
@@ -1,0 +1,211 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/in-toto/in-toto-golang/in_toto"
+	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
+	"github.com/secure-systems-lab/go-securesystemslib/dsse"
+	"github.com/sigstore/rekor/pkg/generated/models"
+	"github.com/sigstore/rekor/pkg/types"
+)
+
+// Make sure we can add an entry
+func TestHarnessAddEntry(t *testing.T) {
+	// Create a random artifact and sign it.
+	artifactPath := filepath.Join(t.TempDir(), "artifact")
+	sigPath := filepath.Join(t.TempDir(), "signature.asc")
+
+	createdX509SignedArtifact(t, artifactPath, sigPath)
+	dataBytes, _ := ioutil.ReadFile(artifactPath)
+	h := sha256.Sum256(dataBytes)
+	dataSHA := hex.EncodeToString(h[:])
+
+	// Write the public key to a file
+	pubPath := filepath.Join(t.TempDir(), "pubKey.asc")
+	if err := ioutil.WriteFile(pubPath, []byte(rsaCert), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify should fail initially
+	runCliErr(t, "verify", "--type=hashedrekord", "--pki-format=x509", "--artifact-hash", dataSHA, "--signature", sigPath, "--public-key", pubPath)
+
+	// It should upload successfully.
+	out := runCli(t, "upload", "--type=hashedrekord", "--pki-format=x509", "--artifact-hash", dataSHA, "--signature", sigPath, "--public-key", pubPath)
+	outputContains(t, out, "Created entry at")
+
+	// Now we should be able to verify it.
+	out = runCli(t, "verify", "--type=hashedrekord", "--pki-format=x509", "--artifact-hash", dataSHA, "--signature", sigPath, "--public-key", pubPath)
+	outputContains(t, out, "Inclusion Proof:")
+}
+
+// Make sure we can add an intoto entry
+func TestHarnessAddIntoto(t *testing.T) {
+	td := t.TempDir()
+	attestationPath := filepath.Join(td, "attestation.json")
+	pubKeyPath := filepath.Join(td, "pub.pem")
+
+	// Get some random data so it's unique each run
+	d := randomData(t, 10)
+	id := base64.StdEncoding.EncodeToString(d)
+
+	it := in_toto.ProvenanceStatement{
+		StatementHeader: in_toto.StatementHeader{
+			Type:          in_toto.StatementInTotoV01,
+			PredicateType: slsa.PredicateSLSAProvenance,
+			Subject: []in_toto.Subject{
+				{
+					Name: "foobar",
+					Digest: slsa.DigestSet{
+						"foo": "bar",
+					},
+				},
+			},
+		},
+		Predicate: slsa.ProvenancePredicate{
+			Builder: slsa.ProvenanceBuilder{
+				ID: "foo" + id,
+			},
+		},
+	}
+
+	b, err := json.Marshal(it)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pb, _ := pem.Decode([]byte(ecdsaPriv))
+	priv, err := x509.ParsePKCS8PrivateKey(pb.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := dsse.NewEnvelopeSigner(&IntotoSigner{
+		priv: priv.(*ecdsa.PrivateKey),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	env, err := signer.SignPayload("application/vnd.in-toto+json", b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	eb, err := json.Marshal(env)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	write(t, string(eb), attestationPath)
+	write(t, ecdsaPub, pubKeyPath)
+
+	// If we do it twice, it should already exist
+	out := runCli(t, "upload", "--artifact", attestationPath, "--type", "intoto", "--public-key", pubKeyPath)
+	outputContains(t, out, "Created entry at")
+	uuid := getUUIDFromUploadOutput(t, out)
+
+	out = runCli(t, "get", "--uuid", uuid, "--format=json")
+	g := getOut{}
+	if err := json.Unmarshal([]byte(out), &g); err != nil {
+		t.Fatal(err)
+	}
+	// The attestation should be stored at /var/run/attestations/sha256:digest
+
+	got := in_toto.ProvenanceStatement{}
+	if err := json.Unmarshal([]byte(g.Attestation), &got); err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(it, got); diff != "" {
+		t.Errorf("diff: %s", diff)
+	}
+
+	attHash := sha256.Sum256(b)
+
+	intotoModel := &models.IntotoV001Schema{}
+	if err := types.DecodeEntry(g.Body.(map[string]interface{})["IntotoObj"], intotoModel); err != nil {
+		t.Errorf("could not convert body into intoto type: %v", err)
+	}
+	if intotoModel.Content == nil || intotoModel.Content.PayloadHash == nil {
+		t.Errorf("could not find hash over attestation %v", intotoModel)
+	}
+	recordedPayloadHash, err := hex.DecodeString(*intotoModel.Content.PayloadHash.Value)
+	if err != nil {
+		t.Errorf("error converting attestation hash to []byte: %v", err)
+	}
+
+	if !bytes.Equal(attHash[:], recordedPayloadHash) {
+		t.Fatal(fmt.Errorf("attestation hash %v doesnt match the payload we sent %v", hex.EncodeToString(attHash[:]),
+			*intotoModel.Content.PayloadHash.Value))
+	}
+
+	out = runCli(t, "upload", "--artifact", attestationPath, "--type", "intoto", "--public-key", pubKeyPath)
+	outputContains(t, out, "Entry already exists")
+}
+
+// Make sure we can get and verify all entries
+// For attestations, make sure we can see the attestation
+func TestHarnessGetAllEntriesLogIndex(t *testing.T) {
+	treeSize := activeTreeSize(t)
+	if treeSize == 0 {
+		t.Fatal("There are 0 entries in the log, there should be at least 2")
+	}
+	for i := 0; i < treeSize; i++ {
+		out := runCli(t, "get", "--log-index", fmt.Sprintf("%d", i), "--format", "json")
+		if !strings.Contains(out, "IntotoObj") {
+			continue
+		}
+		var intotoObj struct {
+			Attestation string
+		}
+		if err := json.Unmarshal([]byte(out), &intotoObj); err != nil {
+			t.Fatal(err)
+		}
+		if intotoObj.Attestation == "" {
+			t.Log(out)
+			t.Fatalf("intotoObj attestation is empty for log index %d", i)
+		}
+		t.Log("Got IntotoObj type with attestation")
+	}
+}
+
+func activeTreeSize(t *testing.T) int {
+	out := runCliStdout(t, "loginfo", "--format", "json", "--store_tree_state", "false")
+	t.Log(string(out))
+	var s struct {
+		ActiveTreeSize int
+	}
+	if err := json.Unmarshal([]byte(out), &s); err != nil {
+		t.Fatal(err)
+	}
+	return s.ActiveTreeSize
+}

--- a/tests/util.go
+++ b/tests/util.go
@@ -74,6 +74,23 @@ func runCli(t *testing.T, arg ...string) string {
 	return run(t, "", cli, arg...)
 }
 
+func runCliStdout(t *testing.T, arg ...string) string {
+	t.Helper()
+	arg = append(arg, rekorServerFlag())
+	c := exec.Command(cli, arg...)
+
+	if os.Getenv("REKORTMPDIR") != "" {
+		// ensure that we use a clean state.json file for each run
+		c.Env = append(c.Env, "HOME="+os.Getenv("REKORTMPDIR"))
+	}
+	b, err := c.Output()
+	if err != nil {
+		t.Log(string(b))
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
 func runCliErr(t *testing.T, arg ...string) string {
 	t.Helper()
 	arg = append(arg, rekorServerFlag())


### PR DESCRIPTION
This PR adds in tests specifically for the test harness. Instead of running tests we already have, the harness will run specific tests:

1. `TestHarnessAddEntry` -- adds in the standard HashedRekord type
2.  `TestHarnessAddIntoto` -- adds in an intoto attestation
3.  `TestHarnessGetAllEntriesLogIndex` -- makes sure the current combo of rekor-server/rekor-cli can get every entry in the log by log index. If the entry is an attestation, confirms that the "Attestation" field is not empty.

We still test against the 3 most recent versions of the server, against the 3 most recent versions of the CLI. We  start the server, run the tests, and then upgrade. At the end, we make sure there are 18 entries in the log as expected.

TODO: We want to make sure that getting entries by UUID/EntryID will also work. Will add that in an upcoming PR.

cc @bobcallaway 