### PR TITLE
api: fix inclusion proof verification flake

### DIFF
--- a/pkg/api/trillian_client.go
+++ b/pkg/api/trillian_client.go
@@ -221,11 +221,12 @@ func (t *TrillianClient) getLeafAndProofByIndex(index int64) *Response {
 			err:    rootResp.err,
 		}
 	}
-	var root types.LogRootV1
-	if err := root.UnmarshalBinary(rootResp.getLatestResult.SignedLogRoot.LogRoot); err != nil {
+
+	root, err := unmarshalLogRoot(rootResp.getLatestResult.SignedLogRoot.LogRoot)
+	if err != nil {
 		return &Response{
-			status: status.Code(err),
-			err:    err,
+			status: status.Code(rootResp.err),
+			err:    rootResp.err,
 		}
 	}
 
@@ -271,11 +272,11 @@ func (t *TrillianClient) getProofByHash(hashValue []byte) *Response {
 			err:    rootResp.err,
 		}
 	}
-	var root types.LogRootV1
-	if err := root.UnmarshalBinary(rootResp.getLatestResult.SignedLogRoot.LogRoot); err != nil {
+	root, err := unmarshalLogRoot(rootResp.getLatestResult.SignedLogRoot.LogRoot)
+	if err != nil {
 		return &Response{
-			status: status.Code(err),
-			err:    err,
+			status: status.Code(rootResp.err),
+			err:    rootResp.err,
 		}
 	}
 

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -30,6 +30,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"golang.org/x/sync/errgroup"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -757,4 +758,67 @@ func TestTufVerifyUpload(t *testing.T) {
 
 	out = runCli(t, "search", "--public-key", rootPath, "--pki-format", "tuf")
 	outputContains(t, out, uuid)
+}
+
+// Regression test for https://github.com/sigstore/rekor/pull/956
+// Requesting an inclusion proof concurrently with an entry write triggers
+// a race where the inclusion proof returned does not verify because the
+// tree head changes.
+func TestInclusionProofRace(t *testing.T) {
+	// Create a random artifact and sign it.
+	artifactPath := filepath.Join(t.TempDir(), "artifact")
+	sigPath := filepath.Join(t.TempDir(), "signature.asc")
+
+	createdX509SignedArtifact(t, artifactPath, sigPath)
+	dataBytes, _ := ioutil.ReadFile(artifactPath)
+	h := sha256.Sum256(dataBytes)
+	dataSHA := hex.EncodeToString(h[:])
+
+	// Write the public key to a file
+	pubPath := filepath.Join(t.TempDir(), "pubKey.asc")
+	if err := ioutil.WriteFile(pubPath, []byte(rsaCert), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Upload an entry
+	runCli(t, "upload", "--type=hashedrekord", "--pki-format=x509", "--artifact-hash", dataSHA, "--signature", sigPath, "--public-key", pubPath)
+
+	// Constantly uploads new signatures on an entry.
+	var uploadRoutine = func(pubPath string) error {
+		// Create a random artifact and sign it.
+		artifactPath := filepath.Join(t.TempDir(), "artifact")
+		sigPath := filepath.Join(t.TempDir(), "signature.asc")
+
+		createdX509SignedArtifact(t, artifactPath, sigPath)
+		dataBytes, _ := ioutil.ReadFile(artifactPath)
+		h := sha256.Sum256(dataBytes)
+		dataSHA := hex.EncodeToString(h[:])
+
+		// Upload an entry
+		out := runCli(t, "upload", "--type=hashedrekord", "--pki-format=x509", "--artifact-hash", dataSHA, "--signature", sigPath, "--public-key", pubPath)
+		outputContains(t, out, "Created entry at")
+
+		return nil
+	}
+
+	// Attempts to verify the original entry.
+	var verifyRoutine = func(dataSHA, sigPath, pubPath string) error {
+		out := runCli(t, "verify", "--type=hashedrekord", "--pki-format=x509", "--artifact-hash", dataSHA, "--signature", sigPath, "--public-key", pubPath)
+
+		if strings.Contains(out, "calculated root") || strings.Contains(out, "wrong") {
+			return fmt.Errorf(out)
+		}
+
+		return nil
+	}
+
+	var g errgroup.Group
+	for i := 0; i < 50; i++ {
+		g.Go(func() error { return uploadRoutine(pubPath) })
+		g.Go(func() error { return verifyRoutine(dataSHA, sigPath, pubPath) })
+	}
+
+	if err := g.Wait(); err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

Fixes:
* https://github.com/sigstore/cosign/issues/2123
* https://github.com/slsa-framework/slsa-github-generator/issues/658
* https://github.com/slsa-framework/slsa-github-generator/issues/601

#### Summary
This fixes a flakey problem with Rekor entry verification.

Every once in a while, we receive errors in validating the inclusion proof from Rekor:

it may either be an error verifying the inclusion proof:
```
 validating log entry 37: verifying inclusion proof: calculated root:
[73 180 215 55 7 58 247 212 29 155 130 228 142 72 218 20 131 130 3 179 61 150 19 180 243 114 50 157 177 182 130 69]
 does not match expected root:
[237 220 193 22 243 233 200 112 169 46 110 170 96 240 121 161 104 148 224 127 132 219 64 234 88 87 57 75 232 144 114 197]
```

or may be caught earlier than that with incorrect inclusion proof size:
```
2022/08/04 15:00:38 validating log entry 25: verifying inclusion proof: wrong proof size 3, want 4
```

This happens because we
1.  get the current tree size X
2.  ANOTHER client uploads an entry increasing the tree size to Y and then
3.  trillian returns an inclusion proof for the index for tree size X.

See code [here](https://github.com/sigstore/rekor/blob/45fd37dca40a910910c3292f1f3384b470c7c937/pkg/api/trillian_client.go#L213-L235)

The trillian response for the inclusion proof includes a `SignedLogRoot` for the tree size at size Y.
https://github.com/google/trillian/blob/44841b0bad99d6b7ed5ab20ff24cfa5ca6add9d3/trillian_log_api.proto#L231-L235

The Rekor server validates the inclusion proof at size X, returning the proof response successfully.
https://github.com/sigstore/rekor/blob/547eb3cef9690bc97e73e35eb3bf1f40b18a3504/pkg/api/trillian_client.go#L229

Rekor returns the proof response with the `SignedLogRoot` at tree size Y, client attempts to validate with this. This errors out.
https://github.com/sigstore/rekor/blob/45fd37dca40a910910c3292f1f3384b470c7c937/pkg/api/entries.go#L445

This PR returns the SignedLogRoot for the tree size in the requested proof.

On a side note, I dislike very much that Trillian's proof response does not contain the requested tree size X.


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
* bug fix: fix inclusion proof response in Rekor server that causes flakey verification problems 

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->