### PR TITLE
change default value for rekor_server.hostname to server's hostname

### DIFF
--- a/cmd/rekor-server/app/root.go
+++ b/cmd/rekor-server/app/root.go
@@ -66,7 +66,11 @@ func init() {
 	rootCmd.PersistentFlags().Uint("trillian_log_server.tlog_id", 0, "Trillian tree id")
 	rootCmd.PersistentFlags().String("trillian_log_server.sharding_config", "", "path to config file for inactive shards")
 
-	rootCmd.PersistentFlags().String("rekor_server.hostname", "rekor.sigstore.dev", "public hostname of instance")
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "localhost"
+	}
+	rootCmd.PersistentFlags().String("rekor_server.hostname", hostname, "public hostname of instance")
 	rootCmd.PersistentFlags().String("rekor_server.address", "127.0.0.1", "Address to bind to")
 	rootCmd.PersistentFlags().String("rekor_server.signer", "memory", "Rekor signer to use. Current valid options include: [gcpkms, memory]")
 


### PR DESCRIPTION
While a default of `rekor.sigstore.dev` was nice for simplicity early on, we should probably reduce confusion and reset the default value of the flag `rekor_server.hostname` to be something more generic like the hostname where the instance is running.

