### PR TITLE
fix: make rekor verify work with sharded uuids

### DIFF
--- a/tests/sharding-e2e-test.sh
+++ b/tests/sharding-e2e-test.sh
@@ -269,4 +269,14 @@ stringsMatch $NUM_ELEMENTS "2"
 RETRIEVE_LOGINDEX1=$(curl -f http://localhost:3000/api/v1/log/entries/retrieve -H "Content-Type: application/json" -H "Accept: application/json" -d "{ \"logIndexes\": [1]}" | jq '.[0]' | jq  -r .$UUID1.logIndex)
 stringsMatch $RETRIEVE_LOGINDEX1 "1"
 
+# Make sure that verification succeeds via UUID
+echo
+echo "Testing rekor-cli verification via UUID..."
+$REKOR_CLI verify --uuid $UUID1 --rekor_server http://localhost:3000
+
+# Make sure that verification succeeds via Entry ID (Tree ID in hex + UUID)
+echo
+echo "Testing rekor-cli verification via Entry ID..."
+DEBUG=1 $REKOR_CLI verify --uuid $ENTRY_ID_1 --rekor_server http://localhost:3000
+
 echo "Test passed successfully :)"


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Fixes https://github.com/sigstore/rekor/issues/877

See issue for the problem: `rekor verify` didn't work with sharding: If the requested UUID was a sharded Entry UUID (Tree ID + UUID), then we would fail because the return keys of `models.LogEntryAnon` are always plain UUIDs. When we would compare the returned response UUID with the requested, we would fail on mismatch.

**Question**

Entry UUID = Tree ID + UUID
UUID = UUID

Why aren't the returned key UUIDs not the Entry UUIDs? It feels weird to me that if clients are requesting Entry UUIDs, and we are making clients aware of sharded UUIDs, then we better also return those in responses. 

Meanwhile, we expose virtual log indices. Aren't Entry UUIDs the equivalent of virtual log indices for uuids?

On the other hand, it makes sense to return the actual UUID because that is the hash of the leaf value, and clients are expected to verify that. In that case, why are Entry UUIDs exposed at all? All of our endpoints handle them, see this bug in question.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->