### PR TITLE
Allow sharding config to be written in yaml or json

### DIFF
--- a/cmd/rekor-server/app/root.go
+++ b/cmd/rekor-server/app/root.go
@@ -64,7 +64,7 @@ func init() {
 	rootCmd.PersistentFlags().String("trillian_log_server.address", "127.0.0.1", "Trillian log server address")
 	rootCmd.PersistentFlags().Uint16("trillian_log_server.port", 8090, "Trillian log server port")
 	rootCmd.PersistentFlags().Uint("trillian_log_server.tlog_id", 0, "Trillian tree id")
-	rootCmd.PersistentFlags().String("trillian_log_server.sharding_config", "", "path to config file for inactive shards")
+	rootCmd.PersistentFlags().String("trillian_log_server.sharding_config", "", "path to config file for inactive shards, in JSON or YAML")
 
 	hostname, err := os.Hostname()
 	if err != nil {

--- a/pkg/sharding/ranges.go
+++ b/pkg/sharding/ranges.go
@@ -18,6 +18,7 @@ package sharding
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -82,6 +83,10 @@ func logRangesFromPath(path string) (Ranges, error) {
 		return Ranges{}, nil
 	}
 	if err := yaml.Unmarshal(contents, &ranges); err != nil {
+		// Try to use JSON
+		if jerr := json.Unmarshal(contents, &ranges); jerr == nil {
+			return ranges, nil
+		}
 		return Ranges{}, err
 	}
 	return ranges, nil

--- a/pkg/sharding/ranges_test.go
+++ b/pkg/sharding/ranges_test.go
@@ -96,6 +96,32 @@ func TestLogRangesFromPath(t *testing.T) {
 	}
 }
 
+func TestLogRangesFromPathJSON(t *testing.T) {
+	contents := `[{"treeID": 0001, "treeLength": 3, "encodedPublicKey":"c2hhcmRpbmcK"}, {"treeID": 0002, "treeLength": 4}]`
+	file := filepath.Join(t.TempDir(), "sharding-config")
+	if err := ioutil.WriteFile(file, []byte(contents), 0644); err != nil {
+		t.Fatal(err)
+	}
+	expected := Ranges{
+		{
+			TreeID:           1,
+			TreeLength:       3,
+			EncodedPublicKey: "c2hhcmRpbmcK",
+		}, {
+			TreeID:     2,
+			TreeLength: 4,
+		},
+	}
+
+	got, err := logRangesFromPath(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(expected, got) {
+		t.Fatalf("expected %v got %v", expected, got)
+	}
+}
+
 func TestLogRanges_ResolveVirtualIndex(t *testing.T) {
 	lrs := LogRanges{
 		inactive: []LogRange{


### PR DESCRIPTION
Right now we only support yaml, which is getting annoying with Helm (Helm has a bunch of issues trying to parse it).

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->