### PR TITLE
api.SearchLogQueryHandler thread safety

### DIFF
--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -338,7 +338,9 @@ func SearchLogQueryHandler(params entries.SearchLogQueryParams) middleware.Respo
 		}
 
 		code := http.StatusBadRequest
-		for _, e := range params.Entry.Entries() {
+		entries := params.Entry.Entries()
+		searchHashesChan := make(chan []byte, len(entries))
+		for _, e := range entries {
 			e := e // https://golang.org/doc/faq#closures_and_goroutines
 			g.Go(func() error {
 				entry, err := types.NewEntry(e)
@@ -353,13 +355,17 @@ func SearchLogQueryHandler(params entries.SearchLogQueryParams) middleware.Respo
 				}
 				hasher := rfc6962.DefaultHasher
 				leafHash := hasher.HashLeaf(leaf)
-				searchHashes = append(searchHashes, leafHash)
+				searchHashesChan <- leafHash
 				return nil
 			})
 		}
 
 		if err := g.Wait(); err != nil {
 			return handleRekorAPIError(params, code, err, err.Error())
+		}
+		close(searchHashesChan)
+		for hash := range(searchHashesChan) {
+			searchHashes = append(searchHashes, hash)
 		}
 
 		searchByHashResults := make([]*trillian.GetEntryAndProofResponse, len(searchHashes))
@@ -399,7 +405,7 @@ func SearchLogQueryHandler(params entries.SearchLogQueryParams) middleware.Respo
 
 	if len(params.Entry.LogIndexes) > 0 {
 		g, _ := errgroup.WithContext(httpReqCtx)
-
+		resultPayloadChan := make(chan models.LogEntry, len(params.Entry.LogIndexes))
 		for _, logIndex := range params.Entry.LogIndexes {
 			logIndex := logIndex // https://golang.org/doc/faq#closures_and_goroutines
 			g.Go(func() error {
@@ -407,13 +413,17 @@ func SearchLogQueryHandler(params entries.SearchLogQueryParams) middleware.Respo
 				if err != nil {
 					return err
 				}
-				resultPayload = append(resultPayload, logEntry)
+				resultPayloadChan <- logEntry
 				return nil
 			})
 		}
 
 		if err := g.Wait(); err != nil {
 			return handleRekorAPIError(params, http.StatusInternalServerError, fmt.Errorf("grpc error: %w", err), trillianUnexpectedResult)
+		}
+		close(resultPayloadChan)
+		for result := range(resultPayloadChan) {
+			resultPayload = append(resultPayload, result)
 		}
 	}
 

--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -364,7 +364,7 @@ func SearchLogQueryHandler(params entries.SearchLogQueryParams) middleware.Respo
 			return handleRekorAPIError(params, code, err, err.Error())
 		}
 		close(searchHashesChan)
-		for hash := range(searchHashesChan) {
+		for hash := range searchHashesChan {
 			searchHashes = append(searchHashes, hash)
 		}
 
@@ -422,7 +422,7 @@ func SearchLogQueryHandler(params entries.SearchLogQueryParams) middleware.Respo
 			return handleRekorAPIError(params, http.StatusInternalServerError, fmt.Errorf("grpc error: %w", err), trillianUnexpectedResult)
 		}
 		close(resultPayloadChan)
-		for result := range(resultPayloadChan) {
+		for result := range resultPayloadChan {
 			resultPayload = append(resultPayload, result)
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Ceridwen Driskill <cdriskill@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
Updated to use channels instead of appending (which is not thread safe) in goroutines.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->