### PR TITLE
'docker compose' to 'docker-compose'

### DIFF
--- a/tests/rekor-harness.sh
+++ b/tests/rekor-harness.sh
@@ -94,7 +94,7 @@ VERSIONS=$(git tag --sort=-version:refname | head -n $NUM_VERSIONS_TO_TEST | tac
 echo $VERSIONS
 
 export REKOR_HARNESS_TMPDIR="$(mktemp -d -t rekor_test_harness.XXXXXX)"
-docker compose down
+docker-compose down
 
 for server_version in $VERSIONS 
 do


### PR DESCRIPTION
fix typo (doesn't typically affect github actions b/c the runner doesn't have any pre-existing containers running)

Signed-off-by: Bob Callaway <bcallaway@google.com>
