### PR TITLE
Include checkpoint (STH) in entry upload and retrieve responses

### DIFF
--- a/cmd/rekor-cli/app/get.go
+++ b/cmd/rekor-cli/app/get.go
@@ -120,7 +120,7 @@ var getCmd = &cobra.Command{
 
 				// verify checkpoint
 				if entry.Verification.InclusionProof.Checkpoint != nil {
-					if err := verify.VerifyCheckpointSignature(&entry, verifier); err != nil {
+					if err := verify.VerifyCheckpointSignature(&e, verifier); err != nil {
 						return nil, err
 					}
 				}

--- a/cmd/rekor-cli/app/get.go
+++ b/cmd/rekor-cli/app/get.go
@@ -118,6 +118,13 @@ var getCmd = &cobra.Command{
 					return nil, fmt.Errorf("unable to verify entry was added to log: %w", err)
 				}
 
+				// verify checkpoint
+				if entry.Verification.InclusionProof.Checkpoint != nil {
+					if err := verify.VerifyCheckpointSignature(&entry, verifier); err != nil {
+						return nil, err
+					}
+				}
+
 				return parseEntry(ix, entry)
 			}
 		}

--- a/cmd/rekor-cli/app/upload.go
+++ b/cmd/rekor-cli/app/upload.go
@@ -141,6 +141,16 @@ var uploadCmd = &cobra.Command{
 		if err := verify.VerifySignedEntryTimestamp(ctx, &logEntry, verifier); err != nil {
 			return nil, fmt.Errorf("unable to verify entry was added to log: %w", err)
 		}
+		if logEntry.Verification.InclusionProof != nil {
+			// verify inclusion proof
+			if err := verify.VerifyInclusion(ctx, &logEntry); err != nil {
+				return nil, fmt.Errorf("error verifying inclusion proof: %w", err)
+			}
+			// verify checkpoint
+			if err := verify.VerifyCheckpointSignature(&logEntry, verifier); err != nil {
+				return nil, err
+			}
+		}
 
 		return &uploadCmdOutput{
 			Location: string(resp.Location),

--- a/cmd/rekor-cli/app/upload.go
+++ b/cmd/rekor-cli/app/upload.go
@@ -141,6 +141,7 @@ var uploadCmd = &cobra.Command{
 		if err := verify.VerifySignedEntryTimestamp(ctx, &logEntry, verifier); err != nil {
 			return nil, fmt.Errorf("unable to verify entry was added to log: %w", err)
 		}
+		// TODO: Remove conditional once inclusion proof/checkpoint is always returned by server.
 		if logEntry.Verification.InclusionProof != nil {
 			// verify inclusion proof
 			if err := verify.VerifyInclusion(ctx, &logEntry); err != nil {

--- a/cmd/rekor-cli/app/verify.go
+++ b/cmd/rekor-cli/app/verify.go
@@ -176,15 +176,9 @@ var verifyCmd = &cobra.Command{
 			return nil, err
 		}
 
+		// verify inclusion proof, checkpoint, and SET
 		if err := verify.VerifyLogEntry(ctx, &entry, verifier); err != nil {
 			return nil, fmt.Errorf("validating entry: %w", err)
-		}
-
-		// verify checkpoint
-		if entry.Verification.InclusionProof.Checkpoint != nil {
-			if err := verify.VerifyCheckpointSignature(&entry, verifier); err != nil {
-				return nil, err
-			}
 		}
 
 		return o, err

--- a/cmd/rekor-cli/app/verify.go
+++ b/cmd/rekor-cli/app/verify.go
@@ -153,6 +153,9 @@ var verifyCmd = &cobra.Command{
 				Size:      *v.Verification.InclusionProof.TreeSize,
 				Hashes:    v.Verification.InclusionProof.Hashes,
 			}
+			if v.Verification.InclusionProof.Checkpoint != nil {
+				o.Checkpoint = *v.Verification.InclusionProof.Checkpoint
+			}
 			entry = v
 		}
 
@@ -175,6 +178,13 @@ var verifyCmd = &cobra.Command{
 
 		if err := verify.VerifyLogEntry(ctx, &entry, verifier); err != nil {
 			return nil, fmt.Errorf("validating entry: %w", err)
+		}
+
+		// verify checkpoint
+		if entry.Verification.InclusionProof.Checkpoint != nil {
+			if err := verify.VerifyCheckpointSignature(&entry, verifier); err != nil {
+				return nil, err
+			}
 		}
 
 		return o, err

--- a/cmd/rekor-cli/app/verify.go
+++ b/cmd/rekor-cli/app/verify.go
@@ -37,18 +37,24 @@ import (
 )
 
 type verifyCmdOutput struct {
-	RootHash  string
-	EntryUUID string
-	Index     int64
-	Size      int64
-	Hashes    []string
+	RootHash   string
+	EntryUUID  string
+	Index      int64
+	Size       int64
+	Hashes     []string
+	Checkpoint string
 }
 
 func (v *verifyCmdOutput) String() string {
 	s := fmt.Sprintf("Current Root Hash: %v\n", v.RootHash)
 	s += fmt.Sprintf("Entry Hash: %v\n", v.EntryUUID)
 	s += fmt.Sprintf("Entry Index: %v\n", v.Index)
-	s += fmt.Sprintf("Current Tree Size: %v\n\n", v.Size)
+	s += fmt.Sprintf("Current Tree Size: %v\n", v.Size)
+	if len(v.Checkpoint) > 0 {
+		s += fmt.Sprintf("Checkpoint:\n%v\n\n", v.Checkpoint)
+	} else {
+		s += "\n"
+	}
 
 	s += "Inclusion Proof:\n"
 	hasher := rfc6962.DefaultHasher

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -631,11 +631,16 @@ definitions:
           type: string
           description: SHA256 hash value expressed in hexadecimal format
           pattern: '^[0-9a-fA-F]{64}$'
+      checkpoint:
+        type: string
+        format: signedCheckpoint
+        description: The checkpoint (signed tree head) that the inclusion proof is based on
     required:
       - logIndex
       - rootHash
       - treeSize
       - hashes
+      - checkpoint
 
   Error:
     type: object

--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -93,7 +93,7 @@ func logEntryFromLeaf(ctx context.Context, signer signature.Signer, tc TrillianC
 		return nil, fmt.Errorf("signing entry error: %w", err)
 	}
 
-	scBytes, err := util.CreateAndSignCheckpoint(viper.GetString("rekor_server.hostname"), tc.logID, root, api.signer, ctx)
+	scBytes, err := util.CreateAndSignCheckpoint(ctx, viper.GetString("rekor_server.hostname"), tc.logID, root, api.signer)
 	if err != nil {
 		return nil, err
 	}
@@ -277,7 +277,7 @@ func createLogEntry(params entries.CreateLogEntryParams) (models.LogEntry, middl
 		hashes = append(hashes, hex.EncodeToString(hash))
 	}
 
-	scBytes, err := util.CreateAndSignCheckpoint(viper.GetString("rekor_server.hostname"), tc.logID, root, api.signer, ctx)
+	scBytes, err := util.CreateAndSignCheckpoint(ctx, viper.GetString("rekor_server.hostname"), tc.logID, root, api.signer)
 	if err != nil {
 		return nil, handleRekorAPIError(params, http.StatusInternalServerError, err, sthGenerateError)
 	}

--- a/pkg/api/tlog.go
+++ b/pkg/api/tlog.go
@@ -66,8 +66,8 @@ func GetLogInfoHandler(params tlog.GetLogInfoParams) middleware.Responder {
 	hashString := hex.EncodeToString(root.RootHash)
 	treeSize := int64(root.TreeSize)
 
-	scBytes, err := util.CreateAndSignCheckpoint(viper.GetString("rekor_server.hostname"),
-		tc.ranges.ActiveTreeID(), root, api.signer, params.HTTPRequest.Context())
+	scBytes, err := util.CreateAndSignCheckpoint(params.HTTPRequest.Context(),
+		viper.GetString("rekor_server.hostname"), tc.ranges.ActiveTreeID(), root, api.signer)
 	if err != nil {
 		return handleRekorAPIError(params, http.StatusInternalServerError, err, sthGenerateError)
 	}
@@ -151,7 +151,7 @@ func inactiveShardLogInfo(ctx context.Context, tid int64) (*models.InactiveShard
 	hashString := hex.EncodeToString(root.RootHash)
 	treeSize := int64(root.TreeSize)
 
-	scBytes, err := util.CreateAndSignCheckpoint(viper.GetString("rekor_server.hostname"), tid, root, api.signer, ctx)
+	scBytes, err := util.CreateAndSignCheckpoint(ctx, viper.GetString("rekor_server.hostname"), tid, root, api.signer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api/trillian_client.go
+++ b/pkg/api/trillian_client.go
@@ -185,6 +185,8 @@ func (t *TrillianClient) addLeaf(byteValue []byte) *Response {
 		status:       status.Code(err),
 		err:          err,
 		getAddResult: resp,
+		// include getLeafAndProofResult for inclusion proof
+		getLeafAndProofResult: leafResp.getLeafAndProofResult,
 	}
 }
 

--- a/pkg/generated/models/inclusion_proof.go
+++ b/pkg/generated/models/inclusion_proof.go
@@ -36,6 +36,10 @@ import (
 // swagger:model InclusionProof
 type InclusionProof struct {
 
+	// The checkpoint (signed tree head) that the inclusion proof is based on
+	// Required: true
+	Checkpoint *string `json:"checkpoint"`
+
 	// A list of hashes required to compute the inclusion proof, sorted in order from leaf to root
 	// Required: true
 	Hashes []string `json:"hashes"`
@@ -60,6 +64,10 @@ type InclusionProof struct {
 func (m *InclusionProof) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateCheckpoint(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateHashes(formats); err != nil {
 		res = append(res, err)
 	}
@@ -79,6 +87,15 @@ func (m *InclusionProof) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *InclusionProof) validateCheckpoint(formats strfmt.Registry) error {
+
+	if err := validate.Required("checkpoint", "body", m.Checkpoint); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/generated/restapi/embedded_spec.go
+++ b/pkg/generated/restapi/embedded_spec.go
@@ -432,9 +432,15 @@ func init() {
         "logIndex",
         "rootHash",
         "treeSize",
-        "hashes"
+        "hashes",
+        "checkpoint"
       ],
       "properties": {
+        "checkpoint": {
+          "description": "The checkpoint (signed tree head) that the inclusion proof is based on",
+          "type": "string",
+          "format": "signedCheckpoint"
+        },
         "hashes": {
           "description": "A list of hashes required to compute the inclusion proof, sorted in order from leaf to root",
           "type": "array",
@@ -1831,9 +1837,15 @@ func init() {
         "logIndex",
         "rootHash",
         "treeSize",
-        "hashes"
+        "hashes",
+        "checkpoint"
       ],
       "properties": {
+        "checkpoint": {
+          "description": "The checkpoint (signed tree head) that the inclusion proof is based on",
+          "type": "string",
+          "format": "signedCheckpoint"
+        },
         "hashes": {
           "description": "A list of hashes required to compute the inclusion proof, sorted in order from leaf to root",
           "type": "array",

--- a/pkg/util/checkpoint.go
+++ b/pkg/util/checkpoint.go
@@ -168,7 +168,7 @@ func (r *SignedCheckpoint) GetTimestamp() uint64 {
 }
 
 // CreateAndSignCheckpoint creates a signed checkpoint as a commitment to the current root hash
-func CreateAndSignCheckpoint(hostname string, treeID int64, root *types.LogRootV1, signer signature.Signer, ctx context.Context) ([]byte, error) {
+func CreateAndSignCheckpoint(ctx context.Context, hostname string, treeID int64, root *types.LogRootV1, signer signature.Signer) ([]byte, error) {
 	sth, err := CreateSignedCheckpoint(Checkpoint{
 		Origin: fmt.Sprintf("%s - %d", hostname, treeID),
 		Size:   root.TreeSize,

--- a/pkg/util/checkpoint.go
+++ b/pkg/util/checkpoint.go
@@ -17,11 +17,17 @@ package util
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"errors"
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
+
+	"github.com/google/trillian/types"
+	"github.com/sigstore/sigstore/pkg/signature"
+	"github.com/sigstore/sigstore/pkg/signature/options"
 )
 
 // heavily borrowed from https://github.com/google/trillian-examples/blob/master/formats/log/checkpoint.go
@@ -159,4 +165,25 @@ func (r *SignedCheckpoint) GetTimestamp() uint64 {
 		}
 	}
 	return ts
+}
+
+// CreateAndSignCheckpoint creates a signed checkpoint as a commitment to the current root hash
+func CreateAndSignCheckpoint(hostname string, treeID int64, root *types.LogRootV1, signer signature.Signer, ctx context.Context) ([]byte, error) {
+	sth, err := CreateSignedCheckpoint(Checkpoint{
+		Origin: fmt.Sprintf("%s - %d", hostname, treeID),
+		Size:   root.TreeSize,
+		Hash:   root.RootHash,
+	})
+	if err != nil {
+		return []byte{}, fmt.Errorf("error creating checkpoint: %v", err)
+	}
+	sth.SetTimestamp(uint64(time.Now().UnixNano()))
+	if _, err := sth.Sign(hostname, signer, options.WithContext(ctx)); err != nil {
+		return []byte{}, fmt.Errorf("error signing checkpoint: %v", err)
+	}
+	scBytes, err := sth.SignedNote.MarshalText()
+	if err != nil {
+		return []byte{}, fmt.Errorf("error marshalling checkpoint: %v", err)
+	}
+	return scBytes, nil
 }

--- a/pkg/util/checkpoint.go
+++ b/pkg/util/checkpoint.go
@@ -175,15 +175,15 @@ func CreateAndSignCheckpoint(ctx context.Context, hostname string, treeID int64,
 		Hash:   root.RootHash,
 	})
 	if err != nil {
-		return []byte{}, fmt.Errorf("error creating checkpoint: %v", err)
+		return nil, fmt.Errorf("error creating checkpoint: %v", err)
 	}
 	sth.SetTimestamp(uint64(time.Now().UnixNano()))
 	if _, err := sth.Sign(hostname, signer, options.WithContext(ctx)); err != nil {
-		return []byte{}, fmt.Errorf("error signing checkpoint: %v", err)
+		return nil, fmt.Errorf("error signing checkpoint: %v", err)
 	}
 	scBytes, err := sth.SignedNote.MarshalText()
 	if err != nil {
-		return []byte{}, fmt.Errorf("error marshalling checkpoint: %v", err)
+		return nil, fmt.Errorf("error marshalling checkpoint: %v", err)
 	}
 	return scBytes, nil
 }

--- a/pkg/util/checkpoint_test.go
+++ b/pkg/util/checkpoint_test.go
@@ -458,7 +458,7 @@ func TestSignCheckpoint(t *testing.T) {
 		t.Fatalf("error generating signer: %v", err)
 	}
 	ctx := context.Background()
-	scBytes, err := CreateAndSignCheckpoint(hostname, treeID, &types.LogRootV1{TreeSize: treeSize, RootHash: rootHash[:]}, signer, ctx)
+	scBytes, err := CreateAndSignCheckpoint(ctx, hostname, treeID, &types.LogRootV1{TreeSize: treeSize, RootHash: rootHash[:]}, signer)
 	if err != nil {
 		t.Fatalf("error creating signed checkpoint: %v", err)
 	}

--- a/pkg/verify/verify.go
+++ b/pkg/verify/verify.go
@@ -75,7 +75,7 @@ func ProveConsistency(ctx context.Context, rClient *client.Rekor,
 
 // VerifyCurrentCheckpoint verifies the provided checkpoint by verifying consistency
 // against a newly fetched Checkpoint.
-//nolint
+// nolint
 func VerifyCurrentCheckpoint(ctx context.Context, rClient *client.Rekor, verifier signature.Verifier,
 	oldSTH *util.SignedCheckpoint) (*util.SignedCheckpoint, error) {
 	// The oldSTH should already be verified, but check for robustness.
@@ -108,10 +108,24 @@ func VerifyCurrentCheckpoint(ctx context.Context, rClient *client.Rekor, verifie
 	return &sth, nil
 }
 
+// VerifyCheckpointSignature verifies the signature on a checkpoint (signed tree head). It does
+// not verify consistency against other checkpoints.
+// nolint
+func VerifyCheckpointSignature(e *models.LogEntryAnon, verifier signature.Verifier) error {
+	sth := &util.SignedCheckpoint{}
+	if err := sth.UnmarshalText([]byte(*e.Verification.InclusionProof.Checkpoint)); err != nil {
+		return fmt.Errorf("unmarshalling log entry checkpoint to SignedCheckpoint: %w", err)
+	}
+	if !sth.Verify(verifier) {
+		return errors.New("signature on checkpoint did not verify")
+	}
+	return nil
+}
+
 // VerifyInclusion verifies an entry's inclusion proof. Clients MUST either verify
 // the root hash against a new STH (via VerifyCurrentCheckpoint) or against a
 // trusted, existing STH (via ProveConsistency).
-//nolint
+// nolint
 func VerifyInclusion(ctx context.Context, e *models.LogEntryAnon) error {
 	if e.Verification == nil || e.Verification.InclusionProof == nil {
 		return errors.New("inclusion proof not provided")
@@ -145,7 +159,7 @@ func VerifyInclusion(ctx context.Context, e *models.LogEntryAnon) error {
 
 // VerifySignedEntryTimestamp verifies the entry's SET against the provided
 // public key.
-//nolint
+// nolint
 func VerifySignedEntryTimestamp(ctx context.Context, e *models.LogEntryAnon, verifier signature.Verifier) error {
 	if e.Verification == nil {
 		return fmt.Errorf("missing verification")
@@ -187,7 +201,7 @@ func VerifySignedEntryTimestamp(ctx context.Context, e *models.LogEntryAnon, ver
 // VerifyLogEntry performs verification of a LogEntry given a Rekor verifier.
 // Performs inclusion proof verification up to a verified root hash and
 // SignedEntryTimestamp verification.
-//nolint
+// nolint
 func VerifyLogEntry(ctx context.Context, e *models.LogEntryAnon, verifier signature.Verifier) error {
 	// Verify the inclusion proof using the body's leaf hash.
 	if err := VerifyInclusion(ctx, e); err != nil {

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -154,6 +154,7 @@ func TestUploadVerifyRekord(t *testing.T) {
 	// Now we should be able to verify it.
 	out = runCli(t, "verify", "--artifact", artifactPath, "--signature", sigPath, "--public-key", pubPath)
 	outputContains(t, out, "Inclusion Proof:")
+	outputContains(t, out, "Checkpoint:")
 }
 
 func TestUploadVerifyHashedRekord(t *testing.T) {
@@ -183,6 +184,7 @@ func TestUploadVerifyHashedRekord(t *testing.T) {
 	// Now we should be able to verify it.
 	out = runCli(t, "verify", "--type=hashedrekord", "--pki-format=x509", "--artifact-hash", dataSHA, "--signature", sigPath, "--public-key", pubPath)
 	outputContains(t, out, "Inclusion Proof:")
+	outputContains(t, out, "Checkpoint:")
 }
 
 func TestUploadVerifyRpm(t *testing.T) {


### PR DESCRIPTION
This associates a root hash in an inclusion proof with a signed
commitment from the log. Previously, without this included, there was no
connection between an inclusion proof and the log. An inclusion proof
and checkpoint can be an alternative proof of inclusion instead of a
SET.

Ref #988

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
Added a signed checkpoint when requesting an inclusion proof

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->