### PR TITLE
WIP: fix harness tests

### DIFF
--- a/cmd/rekor-cli/app/pflags_test.go
+++ b/cmd/rekor-cli/app/pflags_test.go
@@ -762,7 +762,7 @@ func TestParseTypeFlag(t *testing.T) {
 		{
 			caseDesc:      "explicit intoto v0.0.1",
 			typeStr:       "intoto:0.0.1",
-			expectSuccess: false,
+			expectSuccess: true,
 		},
 		{
 			caseDesc:      "explicit intoto v0.0.2",

--- a/pkg/types/intoto/intoto.go
+++ b/pkg/types/intoto/intoto.go
@@ -78,7 +78,7 @@ func (it BaseIntotoType) DefaultVersion() string {
 // it deliberately omits 0.0.1 from the list of supported versions as that
 // version did not persist signatures inside the log entry
 func (it BaseIntotoType) SupportedVersions() []string {
-	return []string{"0.0.2"}
+	return []string{"0.0.1", "0.0.2"}
 }
 
 // IsSupportedVersion returns true if the version can be inserted into the log, and false if not


### PR DESCRIPTION
`rekor-cli` v0.12.0 is backwards incompatible with older server versions since it only allows uploading and getting intoto type v0.0.2

trying to find the smallest fix for this and we can cut 0.12.1 afterwards

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>
