### PR TITLE
Fix rekor-cli backwards incompatibility & run harness tests against HEAD 

### DIFF
--- a/cmd/rekor-cli/app/pflag_groups.go
+++ b/cmd/rekor-cli/app/pflag_groups.go
@@ -199,3 +199,22 @@ func ParseTypeFlag(typeStr string) (string, string, error) {
 	}
 	return "", "", errors.New("malformed type string")
 }
+
+func GetSupportedVersions(typeStr string) ([]string, error) {
+	typeStrings := strings.SplitN(typeStr, ":", 2)
+	tf, ok := types.TypeMap.Load(typeStrings[0])
+	if !ok {
+		return nil, fmt.Errorf("unknown type %v", typeStrings[0])
+	}
+	ti := tf.(func() types.TypeImpl)()
+	if ti == nil {
+		return nil, fmt.Errorf("type %v is not implemented", typeStrings[0])
+	}
+	switch len(typeStrings) {
+	case 1:
+		return ti.SupportedVersions(), nil
+	case 2:
+		return []string{typeStrings[1]}, nil
+	}
+	return nil, errors.New("malformed type string")
+}

--- a/cmd/rekor-cli/app/pflags_test.go
+++ b/cmd/rekor-cli/app/pflags_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -762,7 +763,7 @@ func TestParseTypeFlag(t *testing.T) {
 		{
 			caseDesc:      "explicit intoto v0.0.1",
 			typeStr:       "intoto:0.0.1",
-			expectSuccess: false,
+			expectSuccess: true,
 		},
 		{
 			caseDesc:      "explicit intoto v0.0.2",
@@ -840,5 +841,34 @@ func TestParseTypeFlag(t *testing.T) {
 		if _, _, err := ParseTypeFlag(tc.typeStr); (err == nil) != tc.expectSuccess {
 			t.Fatalf("unexpected error parsing type flag in '%v': %v", tc.caseDesc, err)
 		}
+	}
+}
+
+func TestGetSupportedVersions(t *testing.T) {
+	tests := []struct {
+		description      string
+		typeStr          string
+		expectedVersions []string
+	}{
+		{
+			description:      "intoto specified with version",
+			typeStr:          "intoto:0.0.1",
+			expectedVersions: []string{"0.0.1"},
+		}, {
+			description:      "intoto no version specified",
+			typeStr:          "intoto",
+			expectedVersions: []string{"0.0.2", "0.0.1"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			got, err := GetSupportedVersions(test.typeStr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if d := cmp.Diff(test.expectedVersions, got); d != "" {
+				t.Fatalf("got unexpected versions: %s", d)
+			}
+		})
 	}
 }

--- a/cmd/rekor-cli/app/pflags_test.go
+++ b/cmd/rekor-cli/app/pflags_test.go
@@ -762,7 +762,7 @@ func TestParseTypeFlag(t *testing.T) {
 		{
 			caseDesc:      "explicit intoto v0.0.1",
 			typeStr:       "intoto:0.0.1",
-			expectSuccess: false,
+			expectSuccess: true,
 		},
 		{
 			caseDesc:      "explicit intoto v0.0.2",

--- a/pkg/types/entries.go
+++ b/pkg/types/entries.go
@@ -45,6 +45,14 @@ type EntryWithAttestationImpl interface {
 	AttestationKeyValue() (string, []byte) // returns the key to be used when storing the attestation as well as the attestation itself
 }
 
+// ProposedEntryIterator is an iterator over a list of proposed entries
+type ProposedEntryIterator interface {
+	models.ProposedEntry
+	HasNext() bool
+	Get() models.ProposedEntry
+	GetNext() models.ProposedEntry
+}
+
 // EntryFactory describes a factory function that can generate structs for a specific versioned type
 type EntryFactory func() EntryImpl
 

--- a/pkg/types/intoto/intoto.go
+++ b/pkg/types/intoto/intoto.go
@@ -78,7 +78,7 @@ func (it BaseIntotoType) DefaultVersion() string {
 // it deliberately omits 0.0.1 from the list of supported versions as that
 // version did not persist signatures inside the log entry
 func (it BaseIntotoType) SupportedVersions() []string {
-	return []string{"0.0.2"}
+	return []string{"0.0.2", "0.0.1"}
 }
 
 // IsSupportedVersion returns true if the version can be inserted into the log, and false if not

--- a/pkg/types/intoto/intoto.go
+++ b/pkg/types/intoto/intoto.go
@@ -82,12 +82,12 @@ func (it *BaseIntotoType) CreateProposedEntry(ctx context.Context, version strin
 			}
 			ei, err := it.VersionedUnmarshal(nil, v)
 			if err != nil {
-				log.Logger.Errorf("fetching Intoto version (%v) implementation: %w", v, err)
+				log.ContextLogger(ctx).Errorf("fetching Intoto version (%v) implementation: %w", v, err)
 				continue
 			}
 			versionedPE, err := ei.CreateFromArtifactProperties(ctx, props)
 			if err != nil {
-				log.Logger.Errorf("error creating Intoto entry of version (%v): %w", v, err)
+				log.ContextLogger(ctx).Errorf("error creating Intoto entry of version (%v): %w", v, err)
 				continue
 			}
 			next.next = &ProposedIntotoEntryIterator{versionedPE, nil}

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -33,19 +33,16 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"golang.org/x/sync/errgroup"
-	"sigs.k8s.io/release-utils/version"
 
 	"github.com/cyberphone/json-canonicalization/go/src/webpki.org/jsoncanonicalizer"
 	"github.com/go-openapi/strfmt"
@@ -524,10 +521,6 @@ func TestIntoto(t *testing.T) {
 	write(t, string(eb), attestationPath)
 	write(t, ecdsaPub, pubKeyPath)
 
-	// ensure that we can't upload a intoto v0.0.1 entry
-	v001out := runCliErr(t, "upload", "--artifact", attestationPath, "--type", "intoto:0.0.1", "--public-key", pubKeyPath)
-	outputContains(t, v001out, "type intoto does not support version 0.0.1")
-
 	// If we do it twice, it should already exist
 	out := runCli(t, "upload", "--artifact", attestationPath, "--type", "intoto", "--public-key", pubKeyPath)
 	outputContains(t, out, "Created entry at")
@@ -658,10 +651,6 @@ func TestIntotoMultiSig(t *testing.T) {
 	write(t, ecdsaPub, ecdsapubKeyPath)
 	write(t, pubKey, rsapubKeyPath)
 
-	// ensure that we can't upload a intoto v0.0.1 entry
-	v001out := runCliErr(t, "upload", "--artifact", attestationPath, "--type", "intoto:0.0.1", "--public-key", ecdsapubKeyPath, "--public-key", rsapubKeyPath)
-	outputContains(t, v001out, "type intoto does not support version 0.0.1")
-
 	// If we do it twice, it should already exist
 	out := runCli(t, "upload", "--artifact", attestationPath, "--type", "intoto", "--public-key", ecdsapubKeyPath, "--public-key", rsapubKeyPath)
 	outputContains(t, out, "Created entry at")
@@ -706,6 +695,7 @@ func TestIntotoMultiSig(t *testing.T) {
 
 }
 
+/*
 func TestIntotoBlockV001(t *testing.T) {
 	td := t.TempDir()
 	attestationPath := filepath.Join(td, "attestation.json")
@@ -802,6 +792,7 @@ func TestIntotoBlockV001(t *testing.T) {
 		t.Errorf("Expected error as intoto v0.0.1 should not be allowed to be entered into rekor")
 	}
 }
+*/
 
 func TestTimestampArtifact(t *testing.T) {
 	var out string

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -524,11 +524,6 @@ func TestIntoto(t *testing.T) {
 	write(t, string(eb), attestationPath)
 	write(t, ecdsaPub, pubKeyPath)
 
-	// ensure that we can't upload a intoto v0.0.1 entry
-	v001out := runCliErr(t, "upload", "--artifact", attestationPath, "--type", "intoto:0.0.1", "--public-key", pubKeyPath)
-	outputContains(t, v001out, "type intoto does not support version 0.0.1")
-
-	// If we do it twice, it should already exist
 	out := runCli(t, "upload", "--artifact", attestationPath, "--type", "intoto", "--public-key", pubKeyPath)
 	outputContains(t, out, "Created entry at")
 	uuid := getUUIDFromUploadOutput(t, out)
@@ -658,11 +653,6 @@ func TestIntotoMultiSig(t *testing.T) {
 	write(t, ecdsaPub, ecdsapubKeyPath)
 	write(t, pubKey, rsapubKeyPath)
 
-	// ensure that we can't upload a intoto v0.0.1 entry
-	v001out := runCliErr(t, "upload", "--artifact", attestationPath, "--type", "intoto:0.0.1", "--public-key", ecdsapubKeyPath, "--public-key", rsapubKeyPath)
-	outputContains(t, v001out, "type intoto does not support version 0.0.1")
-
-	// If we do it twice, it should already exist
 	out := runCli(t, "upload", "--artifact", attestationPath, "--type", "intoto", "--public-key", ecdsapubKeyPath, "--public-key", rsapubKeyPath)
 	outputContains(t, out, "Created entry at")
 	uuid := getUUIDFromUploadOutput(t, out)
@@ -795,11 +785,8 @@ func TestIntotoBlockV001(t *testing.T) {
 	params.SetProposedEntry(entry)
 
 	_, err = rekorClient.Entries.CreateLogEntry(params)
-	if err == nil {
-		t.Fatal("insertion of v0.0.1 entry should fail")
-	}
-	if !strings.Contains(err.Error(), "entry kind 'intoto' does not support inserting entries of version '0.0.1'") {
-		t.Errorf("Expected error as intoto v0.0.1 should not be allowed to be entered into rekor")
+	if err != nil {
+		t.Fatalf("failed inserting v0.0.1 entry: %v", err)
 	}
 }
 

--- a/tests/harness_test.go
+++ b/tests/harness_test.go
@@ -150,7 +150,7 @@ func TestHarnessAddIntoto(t *testing.T) {
 	write(t, ecdsaPub, pubKeyPath)
 
 	// If we do it twice, it should already exist
-	out := runCli(t, "upload", "--artifact", attestationPath, "--type", "intoto", "--public-key", pubKeyPath)
+	out := runCliStdout(t, "upload", "--artifact", attestationPath, "--type", "intoto", "--public-key", pubKeyPath)
 	outputContains(t, out, "Created entry at")
 	uuid := getUUIDFromUploadOutput(t, out)
 	logIndex := getLogIndexFromUploadOutput(t, out)

--- a/tests/rekor-harness.sh
+++ b/tests/rekor-harness.sh
@@ -87,10 +87,17 @@ function run_tests () {
     fi
 }
 
-# Get last 3 server versions
+# Get last 2 server versions
 git fetch origin
-NUM_VERSIONS_TO_TEST=3
+NUM_VERSIONS_TO_TEST=2
 VERSIONS=$(git tag --sort=-version:refname | head -n $NUM_VERSIONS_TO_TEST | tac)
+
+# Also add the commit @ HEAD
+HEAD=$(git log --pretty="%H" -n 1 )
+echo "Also testing at HEAD at commit $HEAD"
+
+VERSIONS="$VERSIONS $HEAD"
+
 echo $VERSIONS
 
 export REKOR_HARNESS_TMPDIR="$(mktemp -d -t rekor_test_harness.XXXXXX)"

--- a/tests/rekor-harness.sh
+++ b/tests/rekor-harness.sh
@@ -75,7 +75,7 @@ function run_tests () {
     trap "rm -rf $REKORTMPDIR" EXIT
 
     go clean -testcache
-    if ! REKORTMPDIR=$REKORTMPDIR go test -run TestHarness -v -tags=e2e ./tests/ ; then 
+    if ! REKORTMPDIR=$REKORTMPDIR SERVER_VERSION=$1 CLI_VERSION=$2 go test -run TestHarness -v -tags=e2e ./tests/ ; then 
         docker-compose logs --no-color > /tmp/docker-compose.log
         exit 1
     fi
@@ -112,17 +112,17 @@ do
         echo "Running tests with server version $server_version and CLI version $cli_version"
 
         build_cli $cli_version
-        run_tests
+        run_tests $server_version $cli_version
 
         echo "Tests passed successfully."
         echo "======================================================="
     done
 done
 
-# Since we add two entries to the log for every test, once all tests are run we should have 2*($NUM_VERSIONS_TO_TEST^2) entries
+# Since we add two entries to the log for every test, once all tests are run we should have 2*(($NUM_VERSIONS_TO_TEST+1)^2) entries
 make rekor-cli
 actual=$(./rekor-cli loginfo --rekor_server http://localhost:3000 --format json --store_tree_state=false | jq -r .ActiveTreeSize)
-expected=$((2*$NUM_VERSIONS_TO_TEST*$NUM_VERSIONS_TO_TEST))
+expected=$((2*(1+$NUM_VERSIONS_TO_TEST)*(1+$NUM_VERSIONS_TO_TEST)))
 if [[ ! "$expected" == "$actual" ]]; then
     echo "ERROR: Log had $actual entries instead of expected $expected"
     exit 1


### PR DESCRIPTION
also updates rekor-cli to iterate through all supported versions