### PR TITLE
Fetch all tags in harness tests

### DIFF
--- a/tests/rekor-harness.sh
+++ b/tests/rekor-harness.sh
@@ -88,7 +88,7 @@ function run_tests () {
 }
 
 # Get last 2 server versions
-git fetch --all
+git fetch --all --tags
 NUM_VERSIONS_TO_TEST=2
 VERSIONS=$(git tag --sort=-version:refname | head -n $NUM_VERSIONS_TO_TEST | tac)
 


### PR DESCRIPTION
Tests still are only fetching tags up until v0.8.0 on the tests @ main

Let's see if adding this flag forces the additional flags to be pulled in

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

