### PR TITLE
Adds new rekor metrics for latency and QPS.

### DIFF
--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -16,6 +16,8 @@
 package api
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -35,4 +37,18 @@ var (
 		Name: "rekor_api_latency_summary",
 		Help: "Api Latency on calls",
 	}, []string{"path", "code"})
+
+	MetricRequestLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "rekor_latency_by_api",
+		Help: "Api Latency (in ns) by path and method",
+		Buckets: prometheus.ExponentialBucketsRange(
+			float64(time.Millisecond),
+			float64(4*time.Second),
+			10),
+	}, []string{"path", "method"})
+
+	MetricRequestCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "rekor_qps_by_api",
+		Help: "Api QPS by path, method, and response code",
+	}, []string{"path", "method", "code"})
 )

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -19,6 +19,7 @@
 package e2e
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"crypto"
@@ -37,6 +38,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -1345,5 +1347,77 @@ func TestSearchValidateTreeID(t *testing.T) {
 	// Not Found because currently we don't detect that an unused random tree ID is invalid.
 	if resp.StatusCode != 404 {
 		t.Fatalf("expected 404 status code but got %d", resp.StatusCode)
+	}
+}
+
+func getRekorMetricCount(metricLine string, t *testing.T) (int, error) {
+	re, err := regexp.Compile(fmt.Sprintf("^%s.*([0-9]+)$", regexp.QuoteMeta(metricLine)))
+	if err != nil {
+		return 0, err
+	}
+
+	resp, err := http.Get("http://localhost:2112/metrics")
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		match := re.FindStringSubmatch(scanner.Text())
+		if len(match) != 2 {
+			continue
+		}
+
+		result, err := strconv.Atoi(match[1])
+		if err != nil {
+			return 0, nil
+		}
+		t.Log("Matched metric line: " + scanner.Text())
+		return result, nil
+	}
+	return 0, nil
+}
+
+// Smoke test to ensure we're publishing and recording metrics when an API is
+// called.
+// TODO: use a more robust test approach here e.g. prometheus client-based?
+// TODO: cover all endpoints to make sure none are dropped.
+func TestMetricsCounts(t *testing.T) {
+	latencyMetric := "rekor_latency_by_api_count{method=\"GET\",path=\"/api/v1/log\"}"
+	qpsMetric := "rekor_qps_by_api{code=\"200\",method=\"GET\",path=\"/api/v1/log\"}"
+
+	latencyCount, err := getRekorMetricCount(latencyMetric, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	qpsCount, err := getRekorMetricCount(qpsMetric, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := http.Get("http://localhost:3000/api/v1/log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	latencyCount2, err := getRekorMetricCount(latencyMetric, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	qpsCount2, err := getRekorMetricCount(qpsMetric, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if latencyCount2-latencyCount != 1 {
+		t.Error("rekor_latency_by_api_count did not increment")
+	}
+
+	if qpsCount2-qpsCount != 1 {
+		t.Error("rekor_qps_by_api did not increment")
 	}
 }


### PR DESCRIPTION
The current server metrics have two problems:
1. They don't capture method so we can't differentiate POST vs GET/write vs read.
2. They use the path as passed by the caller for the path field. This prevents us from aggregating correctly ("api/v1/log" is a different time series than "api/v1/log/") and can be a scale risk as it lets end users create new time series arbitrarily.

The two new metrics track latency by endpoint/method,  and qps by endpoint/method/status code for error budget. The old metrics will be removed once monitoring has been updated to use the new metrics.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->