### PR TITLE
Update checkpoint origin to match previous origin, make configurable

### DIFF
--- a/cmd/rekor-server/app/root.go
+++ b/cmd/rekor-server/app/root.go
@@ -78,6 +78,7 @@ func init() {
 		`Rekor signer to use. Valid options are: [gcpkms, memory, filename containing PEM encoded private key].
 		Memory and file-based signers should only be used for testing.`)
 	rootCmd.PersistentFlags().String("rekor_server.signer-passwd", "", "Password to decrypt signer private key")
+	rootCmd.PersistentFlags().String("rekor_server.checkpoint_origin", "Rekor", "Checkpoint (STH) Origin")
 
 	rootCmd.PersistentFlags().Uint16("port", 3000, "Port to bind to")
 

--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -93,7 +93,8 @@ func logEntryFromLeaf(ctx context.Context, signer signature.Signer, tc TrillianC
 		return nil, fmt.Errorf("signing entry error: %w", err)
 	}
 
-	scBytes, err := util.CreateAndSignCheckpoint(ctx, viper.GetString("rekor_server.hostname"), tc.logID, root, api.signer)
+	scBytes, err := util.CreateAndSignCheckpoint(ctx, viper.GetString("rekor_server.checkpoint_origin"),
+		viper.GetString("rekor_server.hostname"), tc.logID, root, api.signer)
 	if err != nil {
 		return nil, err
 	}
@@ -279,7 +280,8 @@ func createLogEntry(params entries.CreateLogEntryParams) (models.LogEntry, middl
 		hashes = append(hashes, hex.EncodeToString(hash))
 	}
 
-	scBytes, err := util.CreateAndSignCheckpoint(ctx, viper.GetString("rekor_server.hostname"), tc.logID, root, api.signer)
+	scBytes, err := util.CreateAndSignCheckpoint(ctx, viper.GetString("rekor_server.checkpoint_origin"),
+		viper.GetString("rekor_server.hostname"), tc.logID, root, api.signer)
 	if err != nil {
 		return nil, handleRekorAPIError(params, http.StatusInternalServerError, err, sthGenerateError)
 	}

--- a/pkg/api/tlog.go
+++ b/pkg/api/tlog.go
@@ -66,7 +66,7 @@ func GetLogInfoHandler(params tlog.GetLogInfoParams) middleware.Responder {
 	hashString := hex.EncodeToString(root.RootHash)
 	treeSize := int64(root.TreeSize)
 
-	scBytes, err := util.CreateAndSignCheckpoint(params.HTTPRequest.Context(),
+	scBytes, err := util.CreateAndSignCheckpoint(params.HTTPRequest.Context(), viper.GetString("rekor_server.checkpoint_origin"),
 		viper.GetString("rekor_server.hostname"), tc.ranges.ActiveTreeID(), root, api.signer)
 	if err != nil {
 		return handleRekorAPIError(params, http.StatusInternalServerError, err, sthGenerateError)
@@ -151,7 +151,8 @@ func inactiveShardLogInfo(ctx context.Context, tid int64) (*models.InactiveShard
 	hashString := hex.EncodeToString(root.RootHash)
 	treeSize := int64(root.TreeSize)
 
-	scBytes, err := util.CreateAndSignCheckpoint(ctx, viper.GetString("rekor_server.hostname"), tid, root, api.signer)
+	scBytes, err := util.CreateAndSignCheckpoint(ctx, viper.GetString("rekor_server.checkpoint_origin"),
+		viper.GetString("rekor_server.hostname"), tid, root, api.signer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/checkpoint.go
+++ b/pkg/util/checkpoint.go
@@ -168,9 +168,9 @@ func (r *SignedCheckpoint) GetTimestamp() uint64 {
 }
 
 // CreateAndSignCheckpoint creates a signed checkpoint as a commitment to the current root hash
-func CreateAndSignCheckpoint(ctx context.Context, hostname string, treeID int64, root *types.LogRootV1, signer signature.Signer) ([]byte, error) {
+func CreateAndSignCheckpoint(ctx context.Context, origin, hostname string, treeID int64, root *types.LogRootV1, signer signature.Signer) ([]byte, error) {
 	sth, err := CreateSignedCheckpoint(Checkpoint{
-		Origin: fmt.Sprintf("%s - %d", hostname, treeID),
+		Origin: origin,
 		Size:   root.TreeSize,
 		Hash:   root.RootHash,
 	})

--- a/pkg/util/checkpoint_test.go
+++ b/pkg/util/checkpoint_test.go
@@ -25,7 +25,6 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
-	"fmt"
 	"testing"
 	"time"
 
@@ -449,6 +448,7 @@ func TestUnmarshalSignedCheckpoint(t *testing.T) {
 }
 
 func TestSignCheckpoint(t *testing.T) {
+	origin := "Rekor"
 	hostname := "rekor.localhost"
 	treeID := int64(123)
 	rootHash := sha256.Sum256([]byte{1, 2, 3})
@@ -458,7 +458,7 @@ func TestSignCheckpoint(t *testing.T) {
 		t.Fatalf("error generating signer: %v", err)
 	}
 	ctx := context.Background()
-	scBytes, err := CreateAndSignCheckpoint(ctx, hostname, treeID, &types.LogRootV1{TreeSize: treeSize, RootHash: rootHash[:]}, signer)
+	scBytes, err := CreateAndSignCheckpoint(ctx, origin, hostname, treeID, &types.LogRootV1{TreeSize: treeSize, RootHash: rootHash[:]}, signer)
 	if err != nil {
 		t.Fatalf("error creating signed checkpoint: %v", err)
 	}
@@ -470,9 +470,8 @@ func TestSignCheckpoint(t *testing.T) {
 	if !sth.Verify(signer) {
 		t.Fatalf("checkpoint signature invalid")
 	}
-	expectedOrigin := fmt.Sprintf("%s - %d", hostname, treeID)
-	if sth.Origin != fmt.Sprintf("%s - %d", hostname, treeID) {
-		t.Fatalf("unexpected origin: got %s, expected %s", expectedOrigin, sth.Origin)
+	if sth.Origin != origin {
+		t.Fatalf("unexpected origin: got %s, expected %s", origin, sth.Origin)
 	}
 	if !bytes.Equal(sth.Hash, rootHash[:]) {
 		t.Fatalf("unexpected mismatch of root hash")


### PR DESCRIPTION
Changing the origin breaks witnessing, so I've reverted this change, but made it configurable so we can change the value in staging.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->