### PR TITLE
export rekor build/version information

### DIFF
--- a/cmd/rekor-server/app/root.go
+++ b/cmd/rekor-server/app/root.go
@@ -76,7 +76,7 @@ func init() {
 
 	rootCmd.PersistentFlags().String("rekor_server.signer", "memory",
 		`Rekor signer to use. Valid options are: [gcpkms, memory, filename containing PEM encoded private key].
-		Memory and file-based signers should only be used for testing.`)
+Memory and file-based signers should only be used for testing.`)
 	rootCmd.PersistentFlags().String("rekor_server.signer-passwd", "", "Password to decrypt signer private key")
 
 	rootCmd.PersistentFlags().Uint16("port", 3000, "Port to bind to")

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"sigs.k8s.io/release-utils/version"
 )
 
 var (
@@ -51,4 +52,19 @@ var (
 		Name: "rekor_qps_by_api",
 		Help: "Api QPS by path, method, and response code",
 	}, []string{"path", "method", "code"})
+
+	_ = promauto.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Namespace: "rekor",
+			Name:      "build_info",
+			Help:      "A metric with a constant '1' value labeled by version, revision, branch, and goversion from which rekor was built.",
+			ConstLabels: prometheus.Labels{
+				"version":    version.GetVersionInfo().GitVersion,
+				"revision":   version.GetVersionInfo().GitCommit,
+				"build_date": version.GetVersionInfo().BuildDate,
+				"goversion":  version.GetVersionInfo().GoVersion,
+			},
+		},
+		func() float64 { return 1 },
+	)
 )


### PR DESCRIPTION
#### Summary
- export rekor build/version information

with this, we can add a dashboard to see what version we have deployed and also can be used to compare between environments which I saw a issue around but was not able to find it

also fixes partially: https://github.com/sigstore/public-good-instance/issues/714

```
# HELP rekor_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which rekor was built.
# TYPE rekor_build_info gauge
rekor_build_info{build_date="2022-09-23T12:41:18Z",goversion="go1.19.1",revision="7652a619d8389632b01e489f6ebd076d46cdbded",version="v0.12.1-5-g7652a61-dirty"} 1
```


