### PR TITLE
update swagger API version to 1.0.0

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17,7 +17,7 @@ swagger: "2.0"
 info:
   title: Rekor
   description: Rekor is a cryptographically secure, immutable transparency log for signed software releases.
-  version: 0.0.1
+  version: 1.0.0
 
 host: rekor.sigstore.dev
 schemes:

--- a/pkg/generated/restapi/doc.go
+++ b/pkg/generated/restapi/doc.go
@@ -22,7 +22,7 @@
 //	  http
 //	Host: rekor.sigstore.dev
 //	BasePath: /
-//	Version: 0.0.1
+//	Version: 1.0.0
 //
 //	Consumes:
 //	  - application/json

--- a/pkg/generated/restapi/embedded_spec.go
+++ b/pkg/generated/restapi/embedded_spec.go
@@ -47,7 +47,7 @@ func init() {
   "info": {
     "description": "Rekor is a cryptographically secure, immutable transparency log for signed software releases.",
     "title": "Rekor",
-    "version": "0.0.1"
+    "version": "1.0.0"
   },
   "host": "rekor.sigstore.dev",
   "paths": {
@@ -951,7 +951,7 @@ func init() {
   "info": {
     "description": "Rekor is a cryptographically secure, immutable transparency log for signed software releases.",
     "title": "Rekor",
-    "version": "0.0.1"
+    "version": "1.0.0"
   },
   "host": "rekor.sigstore.dev",
   "paths": {


### PR DESCRIPTION
@priyawadhwa this should ideally get included before we cut 1.0; it will just make sure the doc reflects the correct major version.

Signed-off-by: Bob Callaway <bcallaway@google.com>