### PR TITLE
install gocovmerge in hack/tools

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           go-version: ${{ env.GOVERSION }}
       - name: install gocovmerge
-        run: go install github.com/wadey/gocovmerge@b5bfa59ec0adc420475f97f89b58045c721d761c
+        run: make gocovmerge
 
       - name: CLI
         run: ./tests/e2e-test.sh

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-.PHONY: all test clean clean-gen lint gosec ko ko-local sign-container cross-cli
+.PHONY: all test clean clean-gen lint gosec ko ko-local sign-container cross-cli gocovmerge
 
 all: rekor-cli rekor-server
 
@@ -52,6 +52,7 @@ GOBIN ?= $(shell go env GOPATH)/bin
 # Binaries
 SWAGGER := $(TOOLS_BIN_DIR)/swagger
 GO-FUZZ-BUILD := $(TOOLS_BIN_DIR)/go-fuzz-build
+GOCOVMERGE := $(TOOLS_BIN_DIR)/gocovmerge
 
 REKOR_LDFLAGS=-X sigs.k8s.io/release-utils/version.gitVersion=$(GIT_VERSION) \
               -X sigs.k8s.io/release-utils/version.gitCommit=$(GIT_HASH) \
@@ -82,6 +83,8 @@ rekor-server: $(SRCS)
 
 test:
 	go test ./...
+
+gocovmerge: $(GOCOVMERGE)
 
 # there is no fuzzing currently
 fuzz: ;
@@ -165,10 +168,13 @@ ko-trillian:
 ## --------------------------------------
 
 $(GO-FUZZ-BUILD): $(TOOLS_DIR)/go.mod
-	cd $(TOOLS_DIR);go build -trimpath -tags=tools -o $(TOOLS_BIN_DIR)/go-fuzz-build github.com/dvyukov/go-fuzz/go-fuzz-build
+	cd $(TOOLS_DIR); go build -trimpath -tags=tools -o $(TOOLS_BIN_DIR)/go-fuzz-build github.com/dvyukov/go-fuzz/go-fuzz-build
 
 $(SWAGGER): $(TOOLS_DIR)/go.mod
 	cd $(TOOLS_DIR); go build -trimpath -tags=tools -o $(TOOLS_BIN_DIR)/swagger github.com/go-swagger/go-swagger/cmd/swagger
+
+$(GOCOVMERGE): $(TOOLS_DIR)/go.mod
+	cd $(TOOLS_DIR); go build -trimpath -tags=tools -o $(TOOLS_BIN_DIR)/gocovmerge github.com/wadey/gocovmerge
 
 ##################
 # help

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -92,6 +92,7 @@ require (
 	github.com/subosito/gotenv v1.3.0 // indirect
 	github.com/toqueteos/webbrowser v1.2.0 // indirect
 	github.com/transparency-dev/merkle v0.0.1 // indirect
+	github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad // indirect
 	go.etcd.io/etcd/api/v3 v3.5.4 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.4 // indirect
 	go.etcd.io/etcd/client/v3 v3.5.4 // indirect

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -539,6 +539,8 @@ github.com/toqueteos/webbrowser v1.2.0 h1:tVP/gpK69Fx+qMJKsLE7TD8LuGWPnEV71wBN9r
 github.com/toqueteos/webbrowser v1.2.0/go.mod h1:XWoZq4cyp9WeUeak7w7LXRUQf1F1ATJMir8RTqb4ayM=
 github.com/transparency-dev/merkle v0.0.1 h1:T9/9gYB8uZl7VOJIhdwjALeRWlxUxSfDEysjfmx+L9E=
 github.com/transparency-dev/merkle v0.0.1/go.mod h1:B8FIw5LTq6DaULoHsVFRzYIUDkl8yuSwCdZnOZGKL/A=
+github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad h1:W0LEBv82YCGEtcmPA3uNZBI33/qF//HAAs3MawDjRa0=
+github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad/go.mod h1:Hy8o65+MXnS6EwGElrSRjUzQDLXreJlzYLlWiHtt8hM=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.0.2/go.mod h1:1WAq6h33pAW+iRreB34OORO2Nf7qel3VV3fjBj+hCSs=
 github.com/xdg-go/scram v1.1.1/go.mod h1:RaEWvsqvNKKvBPvcKeFjrG2cJqOkHTiyTpzz23ni57g=

--- a/hack/tools/tools.go
+++ b/hack/tools/tools.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/dvyukov/go-fuzz/go-fuzz-build"
 	_ "github.com/dvyukov/go-fuzz/go-fuzz-dep"
 	_ "github.com/go-swagger/go-swagger/cmd/swagger"
+	_ "github.com/wadey/gocovmerge"
 
 	// These are so we can build these two binaries into containers with ko
 	_ "github.com/google/trillian/cmd/trillian_log_server"

--- a/tests/e2e-test.sh
+++ b/tests/e2e-test.sh
@@ -19,6 +19,9 @@ testdir=$(dirname "$0")
 
 rm -f /tmp/rekor-*.cov
 
+echo "installing gocovmerge"
+make gocovmerge
+
 echo "starting services"
 docker-compose -f docker-compose.yml -f docker-compose.test.yml up -d --force-recreate --build
 
@@ -69,5 +72,5 @@ if ! docker cp $(docker ps -aqf "name=rekor_rekor-server"):go/rekor-server.cov /
 fi
 
 # merging coverage reports and filtering out /pkg/generated from final report
-gocovmerge /tmp/rekor-*.cov | grep -v "/pkg/generated/" > /tmp/rekor-merged.cov
+hack/tools/bin/gocovmerge /tmp/rekor-*.cov | grep -v "/pkg/generated/" > /tmp/rekor-merged.cov
 echo "code coverage $(go tool cover -func=/tmp/rekor-merged.cov | grep -E '^total\:' | sed -E 's/\s+/ /g')"


### PR DESCRIPTION
Adding this as a managed "tool" in hack/tools so we can ensure it is on any system where we run e2e tests.

Signed-off-by: Bob Callaway <bcallaway@google.com>