### PR TITLE
remove double encoding of payload and signature fields for intoto v0.0.2

### DIFF
--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -237,12 +237,12 @@ func createLogEntry(params entries.CreateLogEntryParams) (models.LogEntry, middl
 		go func() {
 			keys, err := entry.IndexKeys()
 			if err != nil {
-				log.ContextLogger(ctx).Error(err)
+				log.ContextLogger(ctx).Error(fmt.Errorf("error generating index keys: %w", err))
 				return
 			}
 			for _, key := range keys {
 				if err := addToIndex(context.Background(), key, entryID); err != nil {
-					log.ContextLogger(ctx).Error(err)
+					log.ContextLogger(ctx).Error(fmt.Errorf("error inserting key/value pairs into index: %w", err))
 				}
 			}
 		}()

--- a/pkg/generated/models/intoto_v002_schema.go
+++ b/pkg/generated/models/intoto_v002_schema.go
@@ -313,9 +313,9 @@ func (m *IntotoV002SchemaContent) UnmarshalBinary(b []byte) error {
 // swagger:model IntotoV002SchemaContentEnvelope
 type IntotoV002SchemaContentEnvelope struct {
 
-	// payload of the envelope
-	// Format: byte
-	Payload strfmt.Base64 `json:"payload,omitempty"`
+	// base64 encoded payload of the envelope
+	// Pattern: ^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{4})$
+	Payload string `json:"payload,omitempty"`
 
 	// type describing the payload
 	// Required: true
@@ -331,6 +331,10 @@ type IntotoV002SchemaContentEnvelope struct {
 func (m *IntotoV002SchemaContentEnvelope) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validatePayload(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validatePayloadType(formats); err != nil {
 		res = append(res, err)
 	}
@@ -342,6 +346,18 @@ func (m *IntotoV002SchemaContentEnvelope) Validate(formats strfmt.Registry) erro
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *IntotoV002SchemaContentEnvelope) validatePayload(formats strfmt.Registry) error {
+	if swag.IsZero(m.Payload) { // not required
+		return nil
+	}
+
+	if err := validate.Pattern("content"+"."+"envelope"+"."+"payload", "body", m.Payload, `^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{4})$`); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -452,13 +468,34 @@ type IntotoV002SchemaContentEnvelopeSignaturesItems0 struct {
 	// Format: byte
 	PublicKey strfmt.Base64 `json:"publicKey,omitempty"`
 
-	// signature of the payload
-	// Format: byte
-	Sig strfmt.Base64 `json:"sig,omitempty"`
+	// base64 encoded signature of the payload
+	// Pattern: ^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{4})$
+	Sig string `json:"sig,omitempty"`
 }
 
 // Validate validates this intoto v002 schema content envelope signatures items0
 func (m *IntotoV002SchemaContentEnvelopeSignaturesItems0) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.validateSig(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (m *IntotoV002SchemaContentEnvelopeSignaturesItems0) validateSig(formats strfmt.Registry) error {
+	if swag.IsZero(m.Sig) { // not required
+		return nil
+	}
+
+	if err := validate.Pattern("sig", "body", m.Sig, `^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{4})$`); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/generated/restapi/embedded_spec.go
+++ b/pkg/generated/restapi/embedded_spec.go
@@ -1935,9 +1935,9 @@ func init() {
           ],
           "properties": {
             "payload": {
-              "description": "payload of the envelope",
+              "description": "base64 encoded payload of the envelope",
               "type": "string",
-              "format": "byte",
+              "pattern": "^(?:[A-Za-z0-9+\\/]{4})*(?:[A-Za-z0-9+\\/]{2}==|[A-Za-z0-9+\\/]{3}=|[A-Za-z0-9+\\/]{4})$",
               "writeOnly": true
             },
             "payloadType": {
@@ -2009,9 +2009,9 @@ func init() {
       ],
       "properties": {
         "payload": {
-          "description": "payload of the envelope",
+          "description": "base64 encoded payload of the envelope",
           "type": "string",
-          "format": "byte",
+          "pattern": "^(?:[A-Za-z0-9+\\/]{4})*(?:[A-Za-z0-9+\\/]{2}==|[A-Za-z0-9+\\/]{3}=|[A-Za-z0-9+\\/]{4})$",
           "writeOnly": true
         },
         "payloadType": {
@@ -2043,9 +2043,9 @@ func init() {
           "readOnly": true
         },
         "sig": {
-          "description": "signature of the payload",
+          "description": "base64 encoded signature of the payload",
           "type": "string",
-          "format": "byte"
+          "pattern": "^(?:[A-Za-z0-9+\\/]{4})*(?:[A-Za-z0-9+\\/]{2}==|[A-Za-z0-9+\\/]{3}=|[A-Za-z0-9+\\/]{4})$"
         }
       }
     },
@@ -3286,9 +3286,9 @@ func init() {
               ],
               "properties": {
                 "payload": {
-                  "description": "payload of the envelope",
+                  "description": "base64 encoded payload of the envelope",
                   "type": "string",
-                  "format": "byte",
+                  "pattern": "^(?:[A-Za-z0-9+\\/]{4})*(?:[A-Za-z0-9+\\/]{2}==|[A-Za-z0-9+\\/]{3}=|[A-Za-z0-9+\\/]{4})$",
                   "writeOnly": true
                 },
                 "payloadType": {

--- a/pkg/types/intoto/v0.0.2/intoto_v0_0_2_schema.json
+++ b/pkg/types/intoto/v0.0.2/intoto_v0_0_2_schema.json
@@ -13,9 +13,9 @@
                     "type": "object",
                     "properties": {
                         "payload": {
-                            "description": "payload of the envelope",
+                            "description": "base64 encoded payload of the envelope",
                             "type": "string",
-                            "format": "byte",
+                            "pattern": "^(?:[A-Za-z0-9+\\/]{4})*(?:[A-Za-z0-9+\\/]{2}==|[A-Za-z0-9+\\/]{3}=|[A-Za-z0-9+\\/]{4})$",
                             "writeOnly": true
                         },
                         "payloadType": {
@@ -35,9 +35,9 @@
                                         "type": "string"
                                     },
                                     "sig": {
-                                        "description": "signature of the payload",
+                                        "description": "base64 encoded signature of the payload",
                                         "type": "string",
-                                        "format": "byte"
+                                        "pattern": "^(?:[A-Za-z0-9+\\/]{4})*(?:[A-Za-z0-9+\\/]{2}==|[A-Za-z0-9+\\/]{3}=|[A-Za-z0-9+\\/]{4})$"
                                     },
                                     "publicKey": {
                                         "description": "public key that corresponds to this signature",


### PR DESCRIPTION
The intoto v0.0.2 type was defined with a hint to the code generation tool used in `rekor-cli` & `rekor-server` that indicated that these strings were base64 encoded (this caused the code generated to handle encoding and decoding to/from `[]byte` slices). However, `CreateArtifactFromProps` unnecessarily double encoded uploads to Rekor (that originated from `rekor-cli` or any caller of `CreateArtifactFromProps`).

This patch removes that hint to the code generation tool, leaving the field to be handled internally as a `string` rather than `strfmt.Base64`, while still supporting either single or double encoded entries to provide backwards compatibility for released clients. 

Fixes: #1139 

Signed-off-by: Bob Callaway <bcallaway@google.com>