### PR TITLE
stop inserting envelope hash for intoto:0.0.2 types into index

### DIFF
--- a/pkg/types/intoto/v0.0.2/entry.go
+++ b/pkg/types/intoto/v0.0.2/entry.go
@@ -96,8 +96,10 @@ func (v V002Entry) IndexKeys() ([]string, error) {
 	payloadKey := strings.ToLower(fmt.Sprintf("%s:%s", *v.IntotoObj.Content.PayloadHash.Algorithm, *v.IntotoObj.Content.PayloadHash.Value))
 	result = append(result, payloadKey)
 
-	hashkey := strings.ToLower(fmt.Sprintf("%s:%s", *v.IntotoObj.Content.Hash.Algorithm, *v.IntotoObj.Content.Hash.Value))
-	result = append(result, hashkey)
+	// since we can't deterministically calculate this server-side (due to public keys being added inline, and also canonicalization being potentially different),
+	// we'll just skip adding this index key
+	// hashkey := strings.ToLower(fmt.Sprintf("%s:%s", *v.IntotoObj.Content.Hash.Algorithm, *v.IntotoObj.Content.Hash.Value))
+	// result = append(result, hashkey)
 
 	switch *v.IntotoObj.Content.Envelope.PayloadType {
 	case in_toto.PayloadType:

--- a/pkg/types/intoto/v0.0.2/entry_test.go
+++ b/pkg/types/intoto/v0.0.2/entry_test.go
@@ -32,7 +32,6 @@ import (
 	"math/big"
 	"reflect"
 	"sort"
-	"strings"
 	"testing"
 
 	"github.com/go-openapi/runtime"
@@ -294,8 +293,6 @@ func TestV002Entry_Unmarshal(t *testing.T) {
 					t.Errorf("V002Entry.AttestationKey() = %v, want %v", v.AttestationKey(), "sha256:"+hex.EncodeToString(h[:]))
 				}
 
-				hashkey := strings.ToLower(fmt.Sprintf("%s:%s", *tt.it.Content.Hash.Algorithm, *tt.it.Content.Hash.Value))
-				want = append(want, hashkey)
 				got, _ := v.IndexKeys()
 				sort.Strings(got)
 				sort.Strings(want)
@@ -456,8 +453,6 @@ func TestV002Entry_IndexKeys(t *testing.T) {
 
 			want = append(want, "sha256:"+hex.EncodeToString(payloadHash[:]))
 
-			hashkey := strings.ToLower("sha256:" + *v.IntotoObj.Content.Hash.Value)
-			want = append(want, hashkey)
 			want = append(want, tt.want...)
 			got, _ := v.IndexKeys()
 			sort.Strings(got)


### PR DESCRIPTION
Fixes: #1164 

Signed-off-by: Bob Callaway <bcallaway@google.com>