### PR TITLE
logging tweaks to improve usability

### DIFF
--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -133,14 +133,14 @@ func logEntryFromLeaf(ctx context.Context, signer signature.Signer, tc TrillianC
 			if attKey != "" {
 				att, fetchErr = storageClient.FetchAttestation(ctx, attKey)
 				if fetchErr != nil {
-					log.ContextLogger(ctx).Errorf("error fetching attestation by key, trying by UUID: %s %w", attKey, fetchErr)
+					log.ContextLogger(ctx).Debugf("error fetching attestation by key, trying by UUID: %s %v", attKey, fetchErr)
 				}
 			}
 			// if looking up by key failed or we weren't able to generate a key, try looking up by uuid
 			if attKey == "" || fetchErr != nil {
 				att, fetchErr = storageClient.FetchAttestation(ctx, entryIDstruct.UUID)
 				if fetchErr != nil {
-					log.ContextLogger(ctx).Errorf("error fetching attestation by uuid: %s %v", entryIDstruct.UUID, fetchErr)
+					log.ContextLogger(ctx).Debugf("error fetching attestation by uuid: %s %v", entryIDstruct.UUID, fetchErr)
 				}
 			}
 			if fetchErr == nil {
@@ -237,12 +237,12 @@ func createLogEntry(params entries.CreateLogEntryParams) (models.LogEntry, middl
 		go func() {
 			keys, err := entry.IndexKeys()
 			if err != nil {
-				log.ContextLogger(ctx).Error(err)
+				log.ContextLogger(ctx).Errorf("getting entry index keys: %v", err)
 				return
 			}
 			for _, key := range keys {
 				if err := addToIndex(context.Background(), key, entryID); err != nil {
-					log.ContextLogger(ctx).Error(err)
+					log.ContextLogger(ctx).Errorf("adding keys to index: %v", err)
 				}
 			}
 		}()

--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -69,7 +69,12 @@ func handleRekorAPIError(params interface{}, code int, err error, message string
 
 	logMsg := func(r *http.Request) {
 		ctx := r.Context()
-		log.ContextLogger(ctx).Errorw("error processing request", append([]interface{}{"handler", handler, "statusCode", code, "clientMessage", message, "error", err}, fields...)...)
+		fields := append([]interface{}{"handler", handler, "statusCode", code, "clientMessage", message}, fields...)
+		if code >= 500 {
+			log.ContextLogger(ctx).Errorw(err.Error(), fields)
+		} else {
+			log.ContextLogger(ctx).Warnw(err.Error(), fields)
+		}
 		paramsFields := map[string]interface{}{}
 		if err := mapstructure.Decode(params, &paramsFields); err == nil {
 			log.ContextLogger(ctx).Debug(paramsFields)

--- a/pkg/api/public_key.go
+++ b/pkg/api/public_key.go
@@ -23,7 +23,6 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/rekor/pkg/generated/restapi/operations/pubkey"
-	"github.com/sigstore/rekor/pkg/log"
 )
 
 func GetPublicKeyHandler(params pubkey.GetPublicKeyParams) middleware.Responder {
@@ -34,7 +33,6 @@ func GetPublicKeyHandler(params pubkey.GetPublicKeyParams) middleware.Responder 
 	if err != nil {
 		return handleRekorAPIError(params, http.StatusBadRequest, err, "")
 	}
-	log.ContextLogger(ctx).Info("returning public key")
 	return pubkey.NewGetPublicKeyOK().WithPayload(pk)
 }
 

--- a/pkg/generated/restapi/configure_rekor_server.go
+++ b/pkg/generated/restapi/configure_rekor_server.go
@@ -180,7 +180,7 @@ func setupMiddlewares(handler http.Handler) http.Handler {
 
 type httpRequestFields struct {
 	requestMethod string
-	requestUrl    string
+	requestURL    string
 	requestSize   string
 	status        int
 	responseSize  string
@@ -192,7 +192,7 @@ type httpRequestFields struct {
 
 func (h httpRequestFields) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddString("requestMethod", h.requestMethod)
-	enc.AddString("requestUrl", h.requestUrl)
+	enc.AddString("requestUrl", h.requestURL)
 	enc.AddString("requestSize", h.requestSize)
 	enc.AddInt("status", h.status)
 	enc.AddString("responseSize", h.responseSize)
@@ -219,7 +219,7 @@ func (z *zapLogEntry) Write(status, bytes int, header http.Header, elapsed time.
 	}
 	httpRequestObj := httpRequestFields{
 		requestMethod: z.r.Method,
-		requestUrl:    fmt.Sprintf("%s://%s%s", scheme, z.r.Host, z.r.RequestURI),
+		requestURL:    fmt.Sprintf("%s://%s%s", scheme, z.r.Host, z.r.RequestURI),
 		requestSize:   fmt.Sprintf("%d", z.r.ContentLength),
 		status:        status,
 		responseSize:  fmt.Sprintf("%d", bytes),

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -37,6 +37,11 @@ func ConfigureLogger(logType string) {
 		cfg = zap.NewProductionConfig()
 		cfg.EncoderConfig.LevelKey = "severity"
 		cfg.EncoderConfig.MessageKey = "message"
+		cfg.EncoderConfig.TimeKey = "time"
+		cfg.EncoderConfig.EncodeLevel = encodeLevel()
+		cfg.EncoderConfig.EncodeTime = zapcore.RFC3339TimeEncoder
+		cfg.EncoderConfig.EncodeDuration = zapcore.SecondsDurationEncoder
+		cfg.EncoderConfig.EncodeCaller = zapcore.FullCallerEncoder
 	} else {
 		cfg = zap.NewDevelopmentConfig()
 		cfg.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
@@ -46,6 +51,27 @@ func ConfigureLogger(logType string) {
 		log.Fatalln("createLogger", err)
 	}
 	Logger = logger.Sugar()
+}
+
+func encodeLevel() zapcore.LevelEncoder {
+	return func(l zapcore.Level, enc zapcore.PrimitiveArrayEncoder) {
+		switch l {
+		case zapcore.DebugLevel:
+			enc.AppendString("DEBUG")
+		case zapcore.InfoLevel:
+			enc.AppendString("INFO")
+		case zapcore.WarnLevel:
+			enc.AppendString("WARNING")
+		case zapcore.ErrorLevel:
+			enc.AppendString("ERROR")
+		case zapcore.DPanicLevel:
+			enc.AppendString("CRITICAL")
+		case zapcore.PanicLevel:
+			enc.AppendString("ALERT")
+		case zapcore.FatalLevel:
+			enc.AppendString("EMERGENCY")
+		}
+	}
 }
 
 var CliLogger = createCliLogger()
@@ -68,11 +94,21 @@ func WithRequestID(ctx context.Context, id string) context.Context {
 	return context.WithValue(ctx, middleware.RequestIDKey, id)
 }
 
+type operation struct {
+	id string
+}
+
+func (o operation) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddString("id", o.id)
+	return nil
+}
+
 func ContextLogger(ctx context.Context) *zap.SugaredLogger {
 	proposedLogger := Logger
 	if ctx != nil {
 		if ctxRequestID, ok := ctx.Value(middleware.RequestIDKey).(string); ok {
-			proposedLogger = proposedLogger.With(zap.String("requestID", ctxRequestID))
+			requestID := operation{ctxRequestID}
+			proposedLogger = proposedLogger.With(zap.Object("operation", requestID))
 		}
 	}
 	return proposedLogger


### PR DESCRIPTION
- Changes HTTP Responses with codes >= 500 as Errors, any response < 500 as Warn
- Removes / edits some rather noisy log statements
- More aggressively use zap structured logging aligned with GCP logging norms
- reimplements panic recovery so that log messages have correlated request ID for aided debugging

Signed-off-by: Bob Callaway <bcallaway@google.com>