### PR TITLE
fix goroutine leak in client; add insecure TLS option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20221103172237-443f56ff4ba8
+	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-retryablehttp v0.7.1
 	golang.org/x/exp v0.0.0-20220823124025-807a23277127
 )
@@ -65,7 +66,6 @@ require (
 	github.com/cyphar/filepath-securejoin v0.2.3 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	go.opentelemetry.io/otel v1.11.1 // indirect
 	go.opentelemetry.io/otel/trace v1.11.1 // indirect
 )

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -24,9 +24,10 @@ import (
 type Option func(*options)
 
 type options struct {
-	UserAgent  string
-	RetryCount uint
-	Logger     interface{}
+	UserAgent   string
+	RetryCount  uint
+	InsecureTLS bool
+	Logger      interface{}
 }
 
 const (
@@ -68,6 +69,12 @@ func WithLogger(logger interface{}) Option {
 		case retryablehttp.Logger, retryablehttp.LeveledLogger:
 			o.Logger = logger
 		}
+	}
+}
+
+func WithInsecureTLS(enabled bool) Option {
+	return func(o *options) {
+		o.InsecureTLS = enabled
 	}
 }
 

--- a/pkg/client/options_test.go
+++ b/pkg/client/options_test.go
@@ -50,6 +50,14 @@ func TestMakeOptions(t *testing.T) {
 		desc: "WithLoggerNil",
 		opts: []Option{WithLogger(nil)},
 		want: &options{UserAgent: "", RetryCount: DefaultRetryCount},
+	}, {
+		desc: "WithInsecureTLSEnabled",
+		opts: []Option{WithInsecureTLS(true)},
+		want: &options{UserAgent: "", RetryCount: DefaultRetryCount, InsecureTLS: true},
+	}, {
+		desc: "WithInsecureTLSDisabled",
+		opts: []Option{WithInsecureTLS(false)},
+		want: &options{UserAgent: "", RetryCount: DefaultRetryCount, InsecureTLS: false},
 	}}
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/pkg/client/rekor_client.go
+++ b/pkg/client/rekor_client.go
@@ -38,6 +38,7 @@ func GetRekorClient(rekorServerURL string, opts ...Option) (*client.Rekor, error
 	retryableClient := retryablehttp.NewClient()
 	defaultTransport := cleanhttp.DefaultTransport()
 	if o.InsecureTLS {
+		/* #nosec G402 */
 		defaultTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 	retryableClient.HTTPClient = &http.Client{

--- a/pkg/client/rekor_client.go
+++ b/pkg/client/rekor_client.go
@@ -15,11 +15,14 @@
 package client
 
 import (
+	"crypto/tls"
+	"net/http"
 	"net/url"
 
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/hashicorp/go-cleanhttp"
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
 	"github.com/sigstore/rekor/pkg/generated/client"
 	"github.com/sigstore/rekor/pkg/util"
@@ -33,6 +36,13 @@ func GetRekorClient(rekorServerURL string, opts ...Option) (*client.Rekor, error
 	o := makeOptions(opts...)
 
 	retryableClient := retryablehttp.NewClient()
+	defaultTransport := cleanhttp.DefaultTransport()
+	if o.InsecureTLS {
+		defaultTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+	retryableClient.HTTPClient = &http.Client{
+		Transport: defaultTransport,
+	}
 	retryableClient.RetryMax = int(o.RetryCount)
 	retryableClient.Logger = o.Logger
 


### PR DESCRIPTION
This fixes a leaking goroutine (which comes from the underlying connection pool as noted at https://github.com/hashicorp/go-cleanhttp/blob/a0807dd79fc1680a7b1f2d5a2081d92567aab97d/cleanhttp.go#L19). In order to test this, we need to be able to use `httptest` with TLS enabled, which required enabling a client option for InsecureTLS connections. 

Fixes: #1094 

Signed-off-by: Bob Callaway <bcallaway@google.com>
