### PR TITLE
helm: add fuzzer for provenance unmarshalling

### DIFF
--- a/pkg/types/helm/fuzz_test.go
+++ b/pkg/types/helm/fuzz_test.go
@@ -16,6 +16,7 @@
 package helm
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -38,5 +39,13 @@ func FuzzHelmCreateProposedEntry(f *testing.F) {
 		if err != nil {
 			t.Skip()
 		}
+	})
+}
+
+func FuzzHelmProvenanceUnmarshal(f *testing.F) {
+	f.Fuzz(func(t *testing.T, provenanceData []byte) {
+		p := &Provenance{}
+		r := bytes.NewReader(provenanceData)
+		p.Unmarshal(r)
 	})
 }

--- a/tests/oss_fuzz.sh
+++ b/tests/oss_fuzz.sh
@@ -43,4 +43,5 @@ compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/tuf FuzzTufCreatePr
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/rfc3161 FuzzRfc3161CreateProposedEntry FuzzRfc3161CreateProposedEntry
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/rpm FuzzRpmCreateProposedEntry FuzzRpmCreateProposedEntry
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/helm FuzzHelmCreateProposedEntry FuzzHelmCreateProposedEntry
+compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/helm FuzzHelmProvenanceUnmarshal FuzzHelmProvenanceUnmarshal
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/rekord FuzzRekordCreateProposedEntry FuzzRekordCreateProposedEntry


### PR DESCRIPTION
Signed-off-by: AdamKorcz <adam@adalogics.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
Adds a fuzzer for the helm type provenance unmarshalling. Adds it to the OSS-Fuzz build script.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->