### PR TITLE
pki: add fuzzer

### DIFF
--- a/pkg/pki/fuzz_test.go
+++ b/pkg/pki/fuzz_test.go
@@ -1,0 +1,129 @@
+//
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pki
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/sigstore/rekor/pkg/pki/minisign"
+	"github.com/sigstore/rekor/pkg/pki/pgp"
+	"github.com/sigstore/rekor/pkg/pki/pkcs7"
+	"github.com/sigstore/rekor/pkg/pki/ssh"
+	"github.com/sigstore/rekor/pkg/pki/tuf"
+	"github.com/sigstore/rekor/pkg/pki/x509"
+)
+
+var (
+	cmpOpts = []cmp.Option{cmp.AllowUnexported(minisign.PublicKey{},
+		pgp.PublicKey{},
+		ssh.PublicKey{},
+		x509.PublicKey{},
+		pkcs7.PublicKey{},
+		tuf.PublicKey{},
+	)}
+
+	fuzzArtifactFactoryMap = map[uint]pkiImpl{
+		0: {
+			newPubKey: func(r io.Reader) (PublicKey, error) {
+				return pgp.NewPublicKey(r)
+			},
+			newSignature: func(r io.Reader) (Signature, error) {
+				return pgp.NewSignature(r)
+			},
+		},
+		1: {
+			newPubKey: func(r io.Reader) (PublicKey, error) {
+				return minisign.NewPublicKey(r)
+			},
+			newSignature: func(r io.Reader) (Signature, error) {
+				return minisign.NewSignature(r)
+			},
+		},
+		2: {
+			newPubKey: func(r io.Reader) (PublicKey, error) {
+				return ssh.NewPublicKey(r)
+			},
+			newSignature: func(r io.Reader) (Signature, error) {
+				return ssh.NewSignature(r)
+			},
+		},
+		3: {
+			newPubKey: func(r io.Reader) (PublicKey, error) {
+				return x509.NewPublicKey(r)
+			},
+			newSignature: func(r io.Reader) (Signature, error) {
+				return x509.NewSignature(r)
+			},
+		},
+		4: {
+			newPubKey: func(r io.Reader) (PublicKey, error) {
+				return pkcs7.NewPublicKey(r)
+			},
+			newSignature: func(r io.Reader) (Signature, error) {
+				return pkcs7.NewSignature(r)
+			},
+		},
+		5: {
+			newPubKey: func(r io.Reader) (PublicKey, error) {
+				return tuf.NewPublicKey(r)
+			},
+			newSignature: func(r io.Reader) (Signature, error) {
+				return tuf.NewSignature(r)
+			},
+		},
+	}
+)
+
+func FuzzKeys(f *testing.F) {
+	f.Fuzz(func(t *testing.T, keyType uint, origSignatureData, verSignatureData, keyData []byte) {
+
+		// test public key
+		pub1, err := fuzzArtifactFactoryMap[keyType%6].newPubKey(bytes.NewReader(keyData))
+		if err == nil && pub1 != nil {
+			b, err := pub1.CanonicalValue()
+			if err == nil {
+				pub2, err := fuzzArtifactFactoryMap[keyType%6].newPubKey(bytes.NewReader(b))
+				if err != nil {
+					t.Fatal("Could not create a key from valid key data")
+				}
+				if !cmp.Equal(pub1, pub2, cmpOpts...) {
+					t.Fatal("The two public keys should be equal but are not")
+				}
+			}
+		}
+
+		// test signature
+		s, err := fuzzArtifactFactoryMap[keyType%6].newSignature(bytes.NewReader(origSignatureData))
+		if err == nil && s != nil {
+			b, err := s.CanonicalValue()
+			if err == nil {
+				_, err = fuzzArtifactFactoryMap[keyType%6].newSignature(bytes.NewReader(b))
+				if err != nil {
+					t.Fatal("Could not create a signature from valid key data")
+				}
+			}
+			pub, err := fuzzArtifactFactoryMap[keyType%6].newPubKey(bytes.NewReader(keyData))
+			if err != nil {
+				t.Skip()
+			}
+			s.Verify(bytes.NewReader(verSignatureData), pub)
+		}
+	})
+}

--- a/tests/oss_fuzz.sh
+++ b/tests/oss_fuzz.sh
@@ -16,6 +16,7 @@
 
 go get github.com/AdamKorcz/go-118-fuzz-build/testing
 
+compile_native_go_fuzzer github.com/sigstore/rekor/pkg/pki FuzzKeys FuzzKeys
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/sharding FuzzCreateEntryIDFromParts FuzzCreateEntryIDFromParts
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/sharding FuzzGetUUIDFromIDString FuzzGetUUIDFromIDString
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/sharding FuzzGetTreeIDFromIDString FuzzGetTreeIDFromIDString


### PR DESCRIPTION
Signed-off-by: AdamKorcz <adam@adalogics.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
Adds a fuzzer that tests the public key APIs and the signature APIs.

With the public key APIs it:
1. Creates a public key
2. Gets the canonical value
3. Creates another public key with the canonical value

With the signature APIs it:

1. Creates a signature
2. Gets the canonical value
3. Creates another signature with the canonical value
4. Verifies some test data.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->