### PR TITLE
types: refactor multiple fuzzers

### DIFF
--- a/pkg/fuzz/fuzz_utils.go
+++ b/pkg/fuzz/fuzz_utils.go
@@ -1,0 +1,74 @@
+//
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fuzz
+
+import (
+	"net/url"
+	"os"
+	"path/filepath"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+
+	"github.com/sigstore/rekor/pkg/log"
+	"github.com/sigstore/rekor/pkg/types"
+)
+
+func CreateProps(ff *fuzz.ConsumeFuzzer) (types.ArtifactProperties, func(), error) {
+	props := types.ArtifactProperties{}
+	ff.GenerateStruct(&props) //nolint:all
+
+	if props.ArtifactBytes == nil {
+		artifactBytes, err := ff.GetBytes()
+		if err != nil {
+			return props, nil, err
+		}
+		artifactFile, err := os.Create("ArtifactFile")
+		if err != nil {
+			return props, nil, err
+		}
+		defer artifactFile.Close()
+
+		artifactPath, err := filepath.Abs("ArtifactFile")
+		if err != nil {
+			return props, nil, err
+		}
+		artifactURL, err := url.Parse(artifactPath)
+		if err != nil {
+			return props, nil, err
+		}
+		props.ArtifactPath = artifactURL
+
+		_, err = artifactFile.Write(artifactBytes)
+		return props, func() {
+			os.Remove("ArtifactFile")
+		}, err
+
+	}
+	return props, func() {}, nil
+}
+
+func SetFuzzLogger() {
+	config := zap.NewProductionConfig()
+	config.Level = zap.NewAtomicLevelAt(zapcore.FatalLevel)
+	logger, err := config.Build()
+	if err != nil {
+		panic(err)
+	}
+	log.Logger = logger.Named("rekor-fuzz-logger").Sugar()
+}

--- a/pkg/types/intoto/v0.0.1/fuzz_test.go
+++ b/pkg/types/intoto/v0.0.1/fuzz_test.go
@@ -13,23 +13,36 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tuf
+package intoto
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
 
-	"github.com/sigstore/rekor/pkg/types"
+	fuzzUtils "github.com/sigstore/rekor/pkg/fuzz"
+	"github.com/sigstore/rekor/pkg/types/intoto"
 )
 
-func FuzzTufCreateProposedEntry(f *testing.F) {
-	f.Fuzz(func(t *testing.T, version string, propsData []byte) {
+var initter sync.Once
+
+func FuzzIntotoCreateProposedEntry(f *testing.F) {
+	f.Fuzz(func(t *testing.T, propsData []byte) {
+		initter.Do(fuzzUtils.SetFuzzLogger)
+
+		version := "0.0.1"
+
 		ff := fuzz.NewConsumer(propsData)
-		props := types.ArtifactProperties{}
-		ff.GenerateStruct(&props)
-		it := New()
+
+		props, cleanup, err := fuzzUtils.CreateProps(ff)
+		if err != nil {
+			t.Skip()
+		}
+		defer cleanup()
+
+		it := intoto.New()
 		entry, err := it.CreateProposedEntry(context.Background(), version, props)
 		if err != nil {
 			t.Skip()

--- a/pkg/types/intoto/v0.0.2/fuzz_test.go
+++ b/pkg/types/intoto/v0.0.2/fuzz_test.go
@@ -13,23 +13,36 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package rpm
+package intoto
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
 
-	"github.com/sigstore/rekor/pkg/types"
+	fuzzUtils "github.com/sigstore/rekor/pkg/fuzz"
+	"github.com/sigstore/rekor/pkg/types/intoto"
 )
 
-func FuzzRpmCreateProposedEntry(f *testing.F) {
-	f.Fuzz(func(t *testing.T, version string, propsData []byte) {
+var initter sync.Once
+
+func FuzzIntotoCreateProposedEntry(f *testing.F) {
+	f.Fuzz(func(t *testing.T, propsData []byte) {
+		initter.Do(fuzzUtils.SetFuzzLogger)
+
+		version := "0.0.2"
+
 		ff := fuzz.NewConsumer(propsData)
-		props := types.ArtifactProperties{}
-		ff.GenerateStruct(&props)
-		it := New()
+
+		props, cleanup, err := fuzzUtils.CreateProps(ff)
+		if err != nil {
+			t.Skip()
+		}
+		defer cleanup()
+
+		it := intoto.New()
 		entry, err := it.CreateProposedEntry(context.Background(), version, props)
 		if err != nil {
 			t.Skip()

--- a/pkg/types/rekord/v0.0.1/fuzz_test.go
+++ b/pkg/types/rekord/v0.0.1/fuzz_test.go
@@ -17,19 +17,32 @@ package rekord
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
 
-	"github.com/sigstore/rekor/pkg/types"
+	fuzzUtils "github.com/sigstore/rekor/pkg/fuzz"
+	"github.com/sigstore/rekor/pkg/types/rekord"
 )
 
+var initter sync.Once
+
 func FuzzRekordCreateProposedEntry(f *testing.F) {
-	f.Fuzz(func(t *testing.T, version string, propsData []byte) {
+	f.Fuzz(func(t *testing.T, propsData []byte) {
+		initter.Do(fuzzUtils.SetFuzzLogger)
+
+		version := "0.0.1"
+
 		ff := fuzz.NewConsumer(propsData)
-		props := types.ArtifactProperties{}
-		ff.GenerateStruct(&props)
-		it := New()
+
+		props, cleanup, err := fuzzUtils.CreateProps(ff)
+		if err != nil {
+			t.Skip()
+		}
+		defer cleanup()
+
+		it := rekord.New()
 		entry, err := it.CreateProposedEntry(context.Background(), version, props)
 		if err != nil {
 			t.Skip()

--- a/pkg/types/tuf/v0.0.1/fuzz_test.go
+++ b/pkg/types/tuf/v0.0.1/fuzz_test.go
@@ -13,23 +13,36 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package rfc3161
+package tuf
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	fuzz "github.com/AdaLogics/go-fuzz-headers"
 
-	"github.com/sigstore/rekor/pkg/types"
+	fuzzUtils "github.com/sigstore/rekor/pkg/fuzz"
+	"github.com/sigstore/rekor/pkg/types/tuf"
 )
 
-func FuzzRfc3161CreateProposedEntry(f *testing.F) {
-	f.Fuzz(func(t *testing.T, version string, propsData []byte) {
+var initter sync.Once
+
+func FuzzTufCreateProposedEntry(f *testing.F) {
+	f.Fuzz(func(t *testing.T, propsData []byte) {
+		initter.Do(fuzzUtils.SetFuzzLogger)
+
+		version := "0.0.1"
+
 		ff := fuzz.NewConsumer(propsData)
-		props := types.ArtifactProperties{}
-		ff.GenerateStruct(&props)
-		it := New()
+
+		props, cleanup, err := fuzzUtils.CreateProps(ff)
+		if err != nil {
+			t.Skip()
+		}
+		defer cleanup()
+
+		it := tuf.New()
 		entry, err := it.CreateProposedEntry(context.Background(), version, props)
 		if err != nil {
 			t.Skip()

--- a/tests/oss_fuzz.sh
+++ b/tests/oss_fuzz.sh
@@ -38,10 +38,11 @@ compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/cose FuzzCreateProp
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/alpine FuzzPackageUnmarshal FuzzPackageUnmarshal
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/jar FuzzJarUnmarshal FuzzJarUnmarshal
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/hashedrekord FuzzHashedRekord FuzzHashedRekord
-compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/intoto FuzzIntotoCreateProposedEntry FuzzIntotoCreateProposedEntry
-compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/tuf FuzzTufCreateProposedEntry FuzzTufCreateProposedEntry
-compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/rfc3161 FuzzRfc3161CreateProposedEntry FuzzRfc3161CreateProposedEntry
-compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/rpm FuzzRpmCreateProposedEntry FuzzRpmCreateProposedEntry
-compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/helm FuzzHelmCreateProposedEntry FuzzHelmCreateProposedEntry
+compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/intoto/v0.0.1 FuzzIntotoCreateProposedEntry FuzzIntotoCreateProposedEntry_v001
+compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/intoto/v0.0.2 FuzzIntotoCreateProposedEntry FuzzIntotoCreateProposedEntry_v002
+compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/tuf/v0.0.1 FuzzTufCreateProposedEntry FuzzTufCreateProposedEntry
+compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/rfc3161/v0.0.1 FuzzRfc3161CreateProposedEntry FuzzRfc3161CreateProposedEntry
+compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/rpm/v0.0.1 FuzzRpmCreateProposedEntry FuzzRpmCreateProposedEntry
+compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/helm/v0.0.1 FuzzHelmCreateProposedEntry FuzzHelmCreateProposedEntry
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/helm FuzzHelmProvenanceUnmarshal FuzzHelmProvenanceUnmarshal
-compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/rekord FuzzRekordCreateProposedEntry FuzzRekordCreateProposedEntry
+compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/rekord/v0.0.1 FuzzRekordCreateProposedEntry FuzzRekordCreateProposedEntry


### PR DESCRIPTION
Signed-off-by: AdamKorcz <adam@adalogics.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Adds a fuzzer for intoto v0.0.2

Does the following changes to multiple types fuzzers:

1. Silences the logger.
2. Creates the artifact file if the artifact bytes are `nil` for the properties.
3. Hardcodes the version to avoid unnecessary time in the semver dependency.
4. Moves the fuzzers to their v0.0.1 directory to initiate the relevant entry in the VersionMap. For example here:
https://github.com/sigstore/rekor/blob/26f44cd4ba51119da6b9557edcadabe3a97ae2af/pkg/types/helm/v0.0.1/entry.go#L46-L50


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->