### PR TITLE
fix: correctly handle invalid or missing pki format (backport)

### DIFF
--- a/pkg/types/rekord/v0.0.1/entry.go
+++ b/pkg/types/rekord/v0.0.1/entry.go
@@ -340,7 +340,7 @@ func (v V001Entry) CreateFromArtifactProperties(ctx context.Context, props types
 
 	var err error
 	artifactBytes := props.ArtifactBytes
-	if artifactBytes == nil {
+	if len(artifactBytes) == 0 {
 		var artifactReader io.ReadCloser
 		if props.ArtifactPath == nil {
 			return nil, errors.New("path to artifact file must be specified")
@@ -373,9 +373,11 @@ func (v V001Entry) CreateFromArtifactProperties(ctx context.Context, props types
 		re.RekordObj.Signature.Format = swag.String(models.RekordV001SchemaSignatureFormatX509)
 	case "ssh":
 		re.RekordObj.Signature.Format = swag.String(models.RekordV001SchemaSignatureFormatSSH)
+	default:
+		return nil, fmt.Errorf("unexpected format of public key: %s", props.PKIFormat)
 	}
 	sigBytes := props.SignatureBytes
-	if sigBytes == nil {
+	if len(sigBytes) == 0 {
 		if props.SignaturePath == nil {
 			return nil, errors.New("a detached signature must be provided")
 		}

--- a/pkg/types/rekord/v0.0.1/entry_test.go
+++ b/pkg/types/rekord/v0.0.1/entry_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/rekor/pkg/types"
+	"github.com/sigstore/rekor/pkg/types/rekord"
 )
 
 func TestMain(m *testing.M) {
@@ -237,5 +238,23 @@ func TestCrossFieldValidation(t *testing.T) {
 				t.Errorf("unexpected err from type-specific unmarshalling for '%v': %v", tc.caseDesc, err)
 			}
 		}
+	}
+}
+
+func TestUnspecifiedPKIFormat(t *testing.T) {
+	props := types.ArtifactProperties{
+		ArtifactBytes:  []byte("something"),
+		SignatureBytes: []byte("signature"),
+		PublicKeyBytes: [][]byte{[]byte("public_key")},
+		// PKIFormat is deliberately unspecified
+	}
+	rek := rekord.New()
+	if _, err := rek.CreateProposedEntry(context.Background(), APIVERSION, props); err == nil {
+		t.Errorf("no signature, public key or format should not create a valid entry")
+	}
+
+	props.PKIFormat = "invalid_format"
+	if _, err := rek.CreateProposedEntry(context.Background(), APIVERSION, props); err == nil {
+		t.Errorf("invalid pki format should not create a valid entry")
 	}
 }


### PR DESCRIPTION
cherry-pick of #1281 into release-1.0 branch

Signed-off-by: Bob Callaway <bcallaway@google.com>