### PR TITLE
fix: do not persist local log state if log is empty

### DIFF
--- a/cmd/rekor-cli/app/state/state.go
+++ b/cmd/rekor-cli/app/state/state.go
@@ -17,6 +17,7 @@ package state
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 
@@ -27,6 +28,9 @@ import (
 type persistedState map[string]*util.SignedCheckpoint
 
 func Dump(key string, sth *util.SignedCheckpoint) error {
+	if sth.Size == 0 {
+		return errors.New("do not persist state for empty logs")
+	}
 	rekorDir, err := getRekorDir()
 	if err != nil {
 		return err

--- a/pkg/verify/verify.go
+++ b/pkg/verify/verify.go
@@ -41,6 +41,8 @@ func ProveConsistency(ctx context.Context, rClient *client.Rekor,
 	oldSTH *util.SignedCheckpoint, newSTH *util.SignedCheckpoint, treeID string) error {
 	oldTreeSize := int64(oldSTH.Size)
 	switch {
+	case oldTreeSize == 0:
+		return errors.New("consistency proofs can not be computed starting from an empty log")
 	case oldTreeSize == int64(newSTH.Size):
 		if !bytes.Equal(oldSTH.Hash, newSTH.Hash) {
 			return errors.New("old root hash does not match STH hash")

--- a/pkg/verify/verify_test.go
+++ b/pkg/verify/verify_test.go
@@ -60,6 +60,7 @@ func TestConsistency(t *testing.T) {
 	root2String := "5be1758dd2228acfaf2546b4b6ce8aa40c82a3748f3dcb550e0d67ba34f02a45"
 	root2, _ := hex.DecodeString(root2String)
 	root1, _ := hex.DecodeString("59a575f157274702c38de3ab1e1784226f391fb79500ebf9f02b4439fb77574c")
+	root0, _ := hex.DecodeString("1a341bc342ff4e567387de9789ab14000b147124317841489172419874198147")
 	hashes := []string{"d3be742c8d73e2dd3c5635843e987ad3dfb3837616f412a07bf730c3ad73f5cb"}
 	for _, test := range []struct {
 		name    string
@@ -134,6 +135,20 @@ func TestConsistency(t *testing.T) {
 			newC: util.Checkpoint{
 				Origin: "test",
 				Size:   uint64(1),
+				Hash:   root2,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid consistency - empty log",
+			oldC: util.Checkpoint{
+				Origin: "test",
+				Size:   uint64(0),
+				Hash:   root0,
+			},
+			newC: util.Checkpoint{
+				Origin: "test",
+				Size:   uint64(2),
 				Hash:   root2,
 			},
 			wantErr: true,


### PR DESCRIPTION
Since consistency of a log can only be proven for non-zero sizes, we should not persist the root hash for an empty log in a local state file.

Fixes: #1234 

Signed-off-by: Bob Callaway <bcallaway@google.com>
