### PR TITLE
Handle possibly nil values gracefully

### DIFF
--- a/pkg/types/intoto/v0.0.1/entry.go
+++ b/pkg/types/intoto/v0.0.1/entry.go
@@ -193,6 +193,16 @@ func (v *V001Entry) Canonicalize(ctx context.Context) ([]byte, error) {
 	}
 	pkb := strfmt.Base64(pk)
 
+	// hash and payloadHash can be nil when providing an entry for /api/v1/log/retrieve
+	// that is not canonicalized or complete
+	// these fields are not required by the API since they are set during validation
+	if v.IntotoObj.Content.Hash == nil {
+		return nil, errors.New("hash must be set for intoto v0.0.1")
+	}
+	if v.IntotoObj.Content.PayloadHash == nil {
+		return nil, errors.New("payloadHash must be set for intoto v0.0.1")
+	}
+
 	canonicalEntry := models.IntotoV001Schema{
 		PublicKey: &pkb,
 		Content: &models.IntotoV001SchemaContent{

--- a/pkg/types/intoto/v0.0.2/entry.go
+++ b/pkg/types/intoto/v0.0.2/entry.go
@@ -212,6 +212,12 @@ func (v *V002Entry) Unmarshal(pe models.ProposedEntry) error {
 }
 
 func (v *V002Entry) Canonicalize(ctx context.Context) ([]byte, error) {
+	// envelope can be nil when providing an entry for /api/v1/log/retrieve
+	// that is not canonicalized or complete
+	// this field is not required by the API since it is set during validation
+	if v.IntotoObj.Content.Envelope == nil {
+		return nil, errors.New("envelope must be set for intoto v0.0.2")
+	}
 
 	canonicalEntry := models.IntotoV002Schema{
 		Content: &models.IntotoV002SchemaContent{
@@ -223,6 +229,7 @@ func (v *V002Entry) Canonicalize(ctx context.Context) ([]byte, error) {
 			PayloadHash: v.IntotoObj.Content.PayloadHash,
 		},
 	}
+
 	itObj := models.Intoto{}
 	itObj.APIVersion = swag.String(APIVERSION)
 	itObj.Spec = &canonicalEntry


### PR DESCRIPTION
When searching by entry, you could construct an entry without a required field, causing canonicalization to fail.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->