### PR TITLE
fuzzing: add call to IndexKeys in multiple fuzzers

### DIFF
--- a/pkg/types/helm/v0.0.1/fuzz_test.go
+++ b/pkg/types/helm/v0.0.1/fuzz_test.go
@@ -48,10 +48,11 @@ func FuzzHelmCreateProposedEntry(f *testing.F) {
 		if err != nil {
 			t.Skip()
 		}
-		_, err = it.UnmarshalEntry(entry)
+		c, err := it.UnmarshalEntry(entry)
 		if err != nil {
 			t.Skip()
 		}
+		_, _ = c.IndexKeys()
 	})
 }
 

--- a/pkg/types/intoto/v0.0.1/fuzz_test.go
+++ b/pkg/types/intoto/v0.0.1/fuzz_test.go
@@ -47,9 +47,10 @@ func FuzzIntotoCreateProposedEntry(f *testing.F) {
 		if err != nil {
 			t.Skip()
 		}
-		_, err = it.UnmarshalEntry(entry)
+		c, err := it.UnmarshalEntry(entry)
 		if err != nil {
 			t.Skip()
 		}
+		_, _ = c.IndexKeys()
 	})
 }

--- a/pkg/types/intoto/v0.0.2/fuzz_test.go
+++ b/pkg/types/intoto/v0.0.2/fuzz_test.go
@@ -47,9 +47,10 @@ func FuzzIntotoCreateProposedEntry(f *testing.F) {
 		if err != nil {
 			t.Skip()
 		}
-		_, err = it.UnmarshalEntry(entry)
+		c, err := it.UnmarshalEntry(entry)
 		if err != nil {
 			t.Skip()
 		}
+		_, _ = c.IndexKeys()
 	})
 }

--- a/pkg/types/rekord/v0.0.1/fuzz_test.go
+++ b/pkg/types/rekord/v0.0.1/fuzz_test.go
@@ -47,9 +47,10 @@ func FuzzRekordCreateProposedEntry(f *testing.F) {
 		if err != nil {
 			t.Skip()
 		}
-		_, err = it.UnmarshalEntry(entry)
+		c, err := it.UnmarshalEntry(entry)
 		if err != nil {
 			t.Skip()
 		}
+		_, _ = c.IndexKeys()
 	})
 }

--- a/pkg/types/rfc3161/v0.0.1/fuzz_test.go
+++ b/pkg/types/rfc3161/v0.0.1/fuzz_test.go
@@ -47,9 +47,10 @@ func FuzzRfc3161CreateProposedEntry(f *testing.F) {
 		if err != nil {
 			t.Skip()
 		}
-		_, err = it.UnmarshalEntry(entry)
+		c, err := it.UnmarshalEntry(entry)
 		if err != nil {
 			t.Skip()
 		}
+		_, _ = c.IndexKeys()
 	})
 }

--- a/pkg/types/rpm/v0.0.1/fuzz_test.go
+++ b/pkg/types/rpm/v0.0.1/fuzz_test.go
@@ -47,9 +47,10 @@ func FuzzRpmCreateProposedEntry(f *testing.F) {
 		if err != nil {
 			t.Skip()
 		}
-		_, err = it.UnmarshalEntry(entry)
+		c, err := it.UnmarshalEntry(entry)
 		if err != nil {
 			t.Skip()
 		}
+		_, _ = c.IndexKeys()
 	})
 }

--- a/pkg/types/tuf/v0.0.1/fuzz_test.go
+++ b/pkg/types/tuf/v0.0.1/fuzz_test.go
@@ -47,9 +47,10 @@ func FuzzTufCreateProposedEntry(f *testing.F) {
 		if err != nil {
 			t.Skip()
 		}
-		_, err = it.UnmarshalEntry(entry)
+		c, err := it.UnmarshalEntry(entry)
 		if err != nil {
 			t.Skip()
 		}
+		_, _ = c.IndexKeys()
 	})
 }


### PR DESCRIPTION
Signed-off-by: AdamKorcz <adam@adalogics.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Adds a call to `IndexKeys()` for the created entry in multiple fuzzers.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->