### PR TITLE
fix validation for proposed vs committed log entries for intoto v0.0.1

### DIFF
--- a/pkg/generated/models/intoto_v001_schema.go
+++ b/pkg/generated/models/intoto_v001_schema.go
@@ -282,7 +282,7 @@ func (m *IntotoV001SchemaContent) UnmarshalBinary(b []byte) error {
 	return nil
 }
 
-// IntotoV001SchemaContentHash Specifies the hash algorithm and value encompassing the entire signed envelope
+// IntotoV001SchemaContentHash Specifies the hash algorithm and value encompassing the entire signed envelope; this is computed by the rekor server, client-provided values are ignored
 //
 // swagger:model IntotoV001SchemaContentHash
 type IntotoV001SchemaContentHash struct {
@@ -392,7 +392,7 @@ func (m *IntotoV001SchemaContentHash) UnmarshalBinary(b []byte) error {
 	return nil
 }
 
-// IntotoV001SchemaContentPayloadHash Specifies the hash algorithm and value covering the payload within the DSSE envelope
+// IntotoV001SchemaContentPayloadHash Specifies the hash algorithm and value covering the payload within the DSSE envelope; this is computed by the rekor server, client-provided values are ignored
 //
 // swagger:model IntotoV001SchemaContentPayloadHash
 type IntotoV001SchemaContentPayloadHash struct {

--- a/pkg/generated/restapi/embedded_spec.go
+++ b/pkg/generated/restapi/embedded_spec.go
@@ -1834,7 +1834,7 @@ func init() {
           "writeOnly": true
         },
         "hash": {
-          "description": "Specifies the hash algorithm and value encompassing the entire signed envelope",
+          "description": "Specifies the hash algorithm and value encompassing the entire signed envelope; this is computed by the rekor server, client-provided values are ignored",
           "type": "object",
           "required": [
             "algorithm",
@@ -1856,7 +1856,7 @@ func init() {
           "readOnly": true
         },
         "payloadHash": {
-          "description": "Specifies the hash algorithm and value covering the payload within the DSSE envelope",
+          "description": "Specifies the hash algorithm and value covering the payload within the DSSE envelope; this is computed by the rekor server, client-provided values are ignored",
           "type": "object",
           "required": [
             "algorithm",
@@ -1880,7 +1880,7 @@ func init() {
       }
     },
     "IntotoV001SchemaContentHash": {
-      "description": "Specifies the hash algorithm and value encompassing the entire signed envelope",
+      "description": "Specifies the hash algorithm and value encompassing the entire signed envelope; this is computed by the rekor server, client-provided values are ignored",
       "type": "object",
       "required": [
         "algorithm",
@@ -1902,7 +1902,7 @@ func init() {
       "readOnly": true
     },
     "IntotoV001SchemaContentPayloadHash": {
-      "description": "Specifies the hash algorithm and value covering the payload within the DSSE envelope",
+      "description": "Specifies the hash algorithm and value covering the payload within the DSSE envelope; this is computed by the rekor server, client-provided values are ignored",
       "type": "object",
       "required": [
         "algorithm",
@@ -3212,7 +3212,7 @@ func init() {
               "writeOnly": true
             },
             "hash": {
-              "description": "Specifies the hash algorithm and value encompassing the entire signed envelope",
+              "description": "Specifies the hash algorithm and value encompassing the entire signed envelope; this is computed by the rekor server, client-provided values are ignored",
               "type": "object",
               "required": [
                 "algorithm",
@@ -3234,7 +3234,7 @@ func init() {
               "readOnly": true
             },
             "payloadHash": {
-              "description": "Specifies the hash algorithm and value covering the payload within the DSSE envelope",
+              "description": "Specifies the hash algorithm and value covering the payload within the DSSE envelope; this is computed by the rekor server, client-provided values are ignored",
               "type": "object",
               "required": [
                 "algorithm",

--- a/pkg/types/intoto/v0.0.1/entry.go
+++ b/pkg/types/intoto/v0.0.1/entry.go
@@ -244,8 +244,6 @@ func (v *V001Entry) validate() error {
 		}
 		// if there is no envelope, and hash/payloadHash are valid, then there's nothing else to do here
 		return nil
-	} else if v.IntotoObj.Content.Hash != nil || v.IntotoObj.Content.PayloadHash != nil {
-		return fmt.Errorf("hash values for payload and envelope are read-only fields")
 	}
 
 	vfr, err := signature.LoadVerifier(pk.CryptoPubKey(), crypto.SHA256)

--- a/pkg/types/intoto/v0.0.1/entry.go
+++ b/pkg/types/intoto/v0.0.1/entry.go
@@ -229,7 +229,7 @@ func (v *V001Entry) validate() error {
 	pk := v.keyObj.(*x509.PublicKey)
 
 	// one of two cases must be true:
-	// - ProposedEntry: client gives an envelope and NOT hash/payloadhash (to be computed server-side) OR
+	// - ProposedEntry: client gives an envelope; (client provided hash/payloadhash are ignored as they are computed server-side) OR
 	// - CommittedEntry: NO envelope and hash/payloadHash must be present
 	if v.IntotoObj.Content.Envelope == "" {
 		if v.IntotoObj.Content.Hash == nil {

--- a/pkg/types/intoto/v0.0.1/entry_test.go
+++ b/pkg/types/intoto/v0.0.1/entry_test.go
@@ -170,7 +170,7 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 			wantVerifierErr: false,
 		},
 		{
-			name: "valid intoto but hash specified by client",
+			name: "valid intoto but hash specified by client (should be ignored)",
 			it: &models.IntotoV001Schema{
 				PublicKey: p(pub),
 				Content: &models.IntotoV001SchemaContent{
@@ -181,11 +181,11 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 					},
 				},
 			},
-			wantErr:         true,
+			wantErr:         false,
 			wantVerifierErr: false,
 		},
 		{
-			name: "valid intoto but payloadhash specified by client",
+			name: "valid intoto but payloadhash specified by client (should be ignored)",
 			it: &models.IntotoV001Schema{
 				PublicKey: p(pub),
 				Content: &models.IntotoV001SchemaContent{
@@ -196,11 +196,11 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 					},
 				},
 			},
-			wantErr:         true,
+			wantErr:         false,
 			wantVerifierErr: false,
 		},
 		{
-			name: "valid intoto but envelope and payloadhash specified by client",
+			name: "valid intoto but envelope and payloadhash specified by client (hash values should be ignored)",
 			it: &models.IntotoV001Schema{
 				PublicKey: p(pub),
 				Content: &models.IntotoV001SchemaContent{
@@ -215,7 +215,7 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 					},
 				},
 			},
-			wantErr:         true,
+			wantErr:         false,
 			wantVerifierErr: false,
 		},
 		{

--- a/pkg/types/intoto/v0.0.1/entry_test.go
+++ b/pkg/types/intoto/v0.0.1/entry_test.go
@@ -151,7 +151,7 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 			wantVerifierErr: false,
 		},
 		{
-			name: "missing envelope",
+			name: "invalid key",
 			it: &models.IntotoV001Schema{
 				PublicKey: p([]byte("hello")),
 			},
@@ -164,12 +164,58 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 				PublicKey: p(pub),
 				Content: &models.IntotoV001SchemaContent{
 					Envelope: envelope(t, key, validPayload, "application/vnd.in-toto+json"),
-					Hash: &models.IntotoV001SchemaContentHash{
-						Algorithm: swag.String(models.IntotoV001SchemaContentHashAlgorithmSha256),
-					},
 				},
 			},
 			wantErr:         false,
+			wantVerifierErr: false,
+		},
+		{
+			name: "valid intoto but hash specified by client",
+			it: &models.IntotoV001Schema{
+				PublicKey: p(pub),
+				Content: &models.IntotoV001SchemaContent{
+					Envelope: envelope(t, key, validPayload, "application/vnd.in-toto+json"),
+					Hash: &models.IntotoV001SchemaContentHash{
+						Algorithm: swag.String(models.IntotoV001SchemaContentHashAlgorithmSha256),
+						Value:     swag.String("1a1707bb54e5fb4deddd19f07adcb4f1e022ca7879e3c8348da8d4fa496ae8e2"),
+					},
+				},
+			},
+			wantErr:         true,
+			wantVerifierErr: false,
+		},
+		{
+			name: "valid intoto but payloadhash specified by client",
+			it: &models.IntotoV001Schema{
+				PublicKey: p(pub),
+				Content: &models.IntotoV001SchemaContent{
+					Envelope: envelope(t, key, validPayload, "application/vnd.in-toto+json"),
+					PayloadHash: &models.IntotoV001SchemaContentPayloadHash{
+						Algorithm: swag.String(models.IntotoV001SchemaContentPayloadHashAlgorithmSha256),
+						Value:     swag.String("1a1707bb54e5fb4deddd19f07adcb4f1e022ca7879e3c8348da8d4fa496ae8e2"),
+					},
+				},
+			},
+			wantErr:         true,
+			wantVerifierErr: false,
+		},
+		{
+			name: "valid intoto but envelope and payloadhash specified by client",
+			it: &models.IntotoV001Schema{
+				PublicKey: p(pub),
+				Content: &models.IntotoV001SchemaContent{
+					Envelope: envelope(t, key, validPayload, "application/vnd.in-toto+json"),
+					Hash: &models.IntotoV001SchemaContentHash{
+						Algorithm: swag.String(models.IntotoV001SchemaContentHashAlgorithmSha256),
+						Value:     swag.String("1a1707bb54e5fb4deddd19f07adcb4f1e022ca7879e3c8348da8d4fa496ae8e2"),
+					},
+					PayloadHash: &models.IntotoV001SchemaContentPayloadHash{
+						Algorithm: swag.String(models.IntotoV001SchemaContentPayloadHashAlgorithmSha256),
+						Value:     swag.String("1a1707bb54e5fb4deddd19f07adcb4f1e022ca7879e3c8348da8d4fa496ae8e2"),
+					},
+				},
+			},
+			wantErr:         true,
 			wantVerifierErr: false,
 		},
 		{
@@ -178,9 +224,6 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 				PublicKey: p(pub),
 				Content: &models.IntotoV001SchemaContent{
 					Envelope: envelope(t, key, validPayload, "text"),
-					Hash: &models.IntotoV001SchemaContentHash{
-						Algorithm: swag.String(models.IntotoV001SchemaContentHashAlgorithmSha256),
-					},
 				},
 			},
 			wantErr:         false,
@@ -192,9 +235,6 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 				PublicKey: p([]byte(pemBytes)),
 				Content: &models.IntotoV001SchemaContent{
 					Envelope: envelope(t, priv, validPayload, "text"),
-					Hash: &models.IntotoV001SchemaContentHash{
-						Algorithm: swag.String(models.IntotoV001SchemaContentHashAlgorithmSha256),
-					},
 				},
 			},
 			additionalIndexKeys: []string{"joe@schmoe.com"},
@@ -207,9 +247,6 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 				PublicKey: p(pub),
 				Content: &models.IntotoV001SchemaContent{
 					Envelope: string(invalid),
-					Hash: &models.IntotoV001SchemaContentHash{
-						Algorithm: swag.String(models.IntotoV001SchemaContentHashAlgorithmSha256),
-					},
 				},
 			},
 			wantErr:         true,
@@ -221,9 +258,6 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 				PublicKey: p([]byte("notavalidkey")),
 				Content: &models.IntotoV001SchemaContent{
 					Envelope: envelope(t, key, validPayload, "text"),
-					Hash: &models.IntotoV001SchemaContentHash{
-						Algorithm: swag.String(models.IntotoV001SchemaContentHashAlgorithmSha256),
-					},
 				},
 			},
 			wantErr:         true,
@@ -233,11 +267,6 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			v := &V001Entry{}
-			if tt.it.Content != nil {
-				h := sha256.Sum256([]byte(tt.it.Content.Envelope))
-				tt.it.Content.Hash.Algorithm = swag.String(models.IntotoV001SchemaContentHashAlgorithmSha256)
-				tt.it.Content.Hash.Value = swag.String(hex.EncodeToString(h[:]))
-			}
 
 			it := &models.Intoto{
 				Spec: tt.it,
@@ -245,9 +274,6 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 
 			var uv = func() error {
 				if err := v.Unmarshal(it); err != nil {
-					return err
-				}
-				if err := v.validate(); err != nil {
 					return err
 				}
 				if v.IntotoObj.Content.Hash == nil || v.IntotoObj.Content.Hash.Algorithm != tt.it.Content.Hash.Algorithm || v.IntotoObj.Content.Hash.Value != tt.it.Content.Hash.Value {

--- a/pkg/types/intoto/v0.0.1/intoto_v0_0_1_schema.json
+++ b/pkg/types/intoto/v0.0.1/intoto_v0_0_1_schema.json
@@ -14,7 +14,7 @@
                     "writeOnly": true
                 },
                 "hash": {
-                    "description": "Specifies the hash algorithm and value encompassing the entire signed envelope",
+                    "description": "Specifies the hash algorithm and value encompassing the entire signed envelope; this is computed by the rekor server, client-provided values are ignored",
                     "type": "object",
                     "properties": {
                         "algorithm": {
@@ -36,7 +36,7 @@
                     "readOnly": true
                 },
                 "payloadHash": {
-                    "description": "Specifies the hash algorithm and value covering the payload within the DSSE envelope",
+                    "description": "Specifies the hash algorithm and value covering the payload within the DSSE envelope; this is computed by the rekor server, client-provided values are ignored",
                     "type": "object",
                     "properties": {
                         "algorithm": {


### PR DESCRIPTION
PTAL; I prefer this fix over https://github.com/sigstore/rekor/pull/1294 because it more explicitly expresses the validation logic that was originally intended in the JSON schema.

I'd also like to handle any fixes for other intoto versions in separate PRs where possible.

Signed-off-by: Bob Callaway <bcallaway@google.com>