### PR TITLE
alpine: add v001 fuzzer

### DIFF
--- a/pkg/types/alpine/v0.0.1/fuzz_test.go
+++ b/pkg/types/alpine/v0.0.1/fuzz_test.go
@@ -1,0 +1,56 @@
+//
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alpine
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+
+	fuzzUtils "github.com/sigstore/rekor/pkg/fuzz"
+	"github.com/sigstore/rekor/pkg/types/alpine"
+)
+
+var initter sync.Once
+
+func FuzzAlpineCreateProposedEntry(f *testing.F) {
+	f.Fuzz(func(t *testing.T, propsData []byte) {
+		initter.Do(fuzzUtils.SetFuzzLogger)
+
+		version := "0.0.1"
+
+		ff := fuzz.NewConsumer(propsData)
+
+		props, cleanup, err := fuzzUtils.CreateProps(ff)
+		if err != nil {
+			t.Skip()
+		}
+		defer cleanup()
+
+		it := alpine.New()
+		entry, err := it.CreateProposedEntry(context.Background(), version, props)
+		if err != nil {
+			t.Skip()
+		}
+		c, err := it.UnmarshalEntry(entry)
+		if err != nil {
+			t.Skip()
+		}
+		_, _ = c.IndexKeys()
+	})
+}

--- a/tests/oss_fuzz.sh
+++ b/tests/oss_fuzz.sh
@@ -46,6 +46,7 @@ compile_native_go_fuzzer github.com/sigstore/rekor/pkg/sharding FuzzValidateEntr
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/signer FuzzNewFile FuzzNewFile
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/cose/v0.0.1 FuzzCoseCreateProposedEntry FuzzCoseCreateProposedEntry
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/alpine FuzzPackageUnmarshal FuzzPackageUnmarshal
+compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/alpine/v0.0.1 FuzzAlpineCreateProposedEntry FuzzAlpineCreateProposedEntry
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/jar FuzzJarUnmarshal FuzzJarUnmarshal
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/hashedrekord FuzzHashedRekord FuzzHashedRekord
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/intoto/v0.0.1 FuzzIntotoCreateProposedEntry FuzzIntotoCreateProposedEntry_v001


### PR DESCRIPTION
Signed-off-by: AdamKorcz <adam@adalogics.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
Adds a fuzzer for the alpine type that creates an entry, unmarshals it, and invokes the entrys `IndexKeys()` method. 
Also adds the fuzzer to the OSS-Fuzz build script.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->