### PR TITLE
backport fix from pr 1309 to release-branch

### DIFF
--- a/pkg/generated/models/intoto_v001_schema.go
+++ b/pkg/generated/models/intoto_v001_schema.go
@@ -282,7 +282,7 @@ func (m *IntotoV001SchemaContent) UnmarshalBinary(b []byte) error {
 	return nil
 }
 
-// IntotoV001SchemaContentHash Specifies the hash algorithm and value encompassing the entire signed envelope
+// IntotoV001SchemaContentHash Specifies the hash algorithm and value encompassing the entire signed envelope; this is computed by the rekor server, client-provided values are ignored
 //
 // swagger:model IntotoV001SchemaContentHash
 type IntotoV001SchemaContentHash struct {
@@ -392,7 +392,7 @@ func (m *IntotoV001SchemaContentHash) UnmarshalBinary(b []byte) error {
 	return nil
 }
 
-// IntotoV001SchemaContentPayloadHash Specifies the hash algorithm and value covering the payload within the DSSE envelope
+// IntotoV001SchemaContentPayloadHash Specifies the hash algorithm and value covering the payload within the DSSE envelope; this is computed by the rekor server, client-provided values are ignored
 //
 // swagger:model IntotoV001SchemaContentPayloadHash
 type IntotoV001SchemaContentPayloadHash struct {

--- a/pkg/generated/restapi/embedded_spec.go
+++ b/pkg/generated/restapi/embedded_spec.go
@@ -1834,7 +1834,7 @@ func init() {
           "writeOnly": true
         },
         "hash": {
-          "description": "Specifies the hash algorithm and value encompassing the entire signed envelope",
+          "description": "Specifies the hash algorithm and value encompassing the entire signed envelope; this is computed by the rekor server, client-provided values are ignored",
           "type": "object",
           "required": [
             "algorithm",
@@ -1856,7 +1856,7 @@ func init() {
           "readOnly": true
         },
         "payloadHash": {
-          "description": "Specifies the hash algorithm and value covering the payload within the DSSE envelope",
+          "description": "Specifies the hash algorithm and value covering the payload within the DSSE envelope; this is computed by the rekor server, client-provided values are ignored",
           "type": "object",
           "required": [
             "algorithm",
@@ -1880,7 +1880,7 @@ func init() {
       }
     },
     "IntotoV001SchemaContentHash": {
-      "description": "Specifies the hash algorithm and value encompassing the entire signed envelope",
+      "description": "Specifies the hash algorithm and value encompassing the entire signed envelope; this is computed by the rekor server, client-provided values are ignored",
       "type": "object",
       "required": [
         "algorithm",
@@ -1902,7 +1902,7 @@ func init() {
       "readOnly": true
     },
     "IntotoV001SchemaContentPayloadHash": {
-      "description": "Specifies the hash algorithm and value covering the payload within the DSSE envelope",
+      "description": "Specifies the hash algorithm and value covering the payload within the DSSE envelope; this is computed by the rekor server, client-provided values are ignored",
       "type": "object",
       "required": [
         "algorithm",
@@ -3212,7 +3212,7 @@ func init() {
               "writeOnly": true
             },
             "hash": {
-              "description": "Specifies the hash algorithm and value encompassing the entire signed envelope",
+              "description": "Specifies the hash algorithm and value encompassing the entire signed envelope; this is computed by the rekor server, client-provided values are ignored",
               "type": "object",
               "required": [
                 "algorithm",
@@ -3234,7 +3234,7 @@ func init() {
               "readOnly": true
             },
             "payloadHash": {
-              "description": "Specifies the hash algorithm and value covering the payload within the DSSE envelope",
+              "description": "Specifies the hash algorithm and value covering the payload within the DSSE envelope; this is computed by the rekor server, client-provided values are ignored",
               "type": "object",
               "required": [
                 "algorithm",

--- a/pkg/types/intoto/v0.0.1/entry.go
+++ b/pkg/types/intoto/v0.0.1/entry.go
@@ -185,7 +185,16 @@ func (v *V001Entry) Unmarshal(pe models.ProposedEntry) error {
 
 func (v *V001Entry) Canonicalize(ctx context.Context) ([]byte, error) {
 	if v.keyObj == nil {
-		return nil, errors.New("cannot canonicalze empty key")
+		return nil, errors.New("cannot canonicalize empty key")
+	}
+	if v.IntotoObj.Content == nil {
+		return nil, errors.New("missing content")
+	}
+	if v.IntotoObj.Content.Hash == nil {
+		return nil, errors.New("missing envelope hash")
+	}
+	if v.IntotoObj.Content.PayloadHash == nil {
+		return nil, errors.New("missing payload hash")
 	}
 	pk, err := v.keyObj.CanonicalValue()
 	if err != nil {
@@ -219,10 +228,24 @@ func (v *V001Entry) validate() error {
 	// TODO handle multiple
 	pk := v.keyObj.(*x509.PublicKey)
 
-	// This also gets called in the CLI, where we won't have this data
+	// one of two cases must be true:
+	// - ProposedEntry: client gives an envelope; (client provided hash/payloadhash are ignored as they are computed server-side) OR
+	// - CommittedEntry: NO envelope and hash/payloadHash must be present
 	if v.IntotoObj.Content.Envelope == "" {
+		if v.IntotoObj.Content.Hash == nil {
+			return fmt.Errorf("missing hash value for envelope")
+		} else if err := v.IntotoObj.Content.Hash.Validate(strfmt.Default); err != nil {
+			return fmt.Errorf("validation error on envelope hash: %w", err)
+		}
+		if v.IntotoObj.Content.PayloadHash == nil {
+			return fmt.Errorf("missing hash value for payload")
+		} else if err := v.IntotoObj.Content.PayloadHash.Validate(strfmt.Default); err != nil {
+			return fmt.Errorf("validation error on payload hash: %w", err)
+		}
+		// if there is no envelope, and hash/payloadHash are valid, then there's nothing else to do here
 		return nil
 	}
+
 	vfr, err := signature.LoadVerifier(pk.CryptoPubKey(), crypto.SHA256)
 	if err != nil {
 		return err

--- a/pkg/types/intoto/v0.0.1/entry_test.go
+++ b/pkg/types/intoto/v0.0.1/entry_test.go
@@ -162,7 +162,7 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 					Envelope: envelope(t, key, validPayload, "application/vnd.in-toto+json"),
 				},
 			},
-			wantErr:         false,
+			wantErr: false,
 		},
 		{
 			name: "valid intoto but hash specified by client (should be ignored)",
@@ -176,7 +176,7 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 					},
 				},
 			},
-			wantErr:         false,
+			wantErr: false,
 		},
 		{
 			name: "valid intoto but payloadhash specified by client (should be ignored)",
@@ -190,7 +190,7 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 					},
 				},
 			},
-			wantErr:         false,
+			wantErr: false,
 		},
 		{
 			name: "valid intoto but envelope and payloadhash specified by client (hash values should be ignored)",

--- a/pkg/types/intoto/v0.0.1/entry_test.go
+++ b/pkg/types/intoto/v0.0.1/entry_test.go
@@ -163,7 +163,6 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 				},
 			},
 			wantErr:         false,
-			wantVerifierErr: false,
 		},
 		{
 			name: "valid intoto but hash specified by client (should be ignored)",
@@ -178,7 +177,6 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 				},
 			},
 			wantErr:         false,
-			wantVerifierErr: false,
 		},
 		{
 			name: "valid intoto but payloadhash specified by client (should be ignored)",
@@ -193,7 +191,6 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 				},
 			},
 			wantErr:         false,
-			wantVerifierErr: false,
 		},
 		{
 			name: "valid intoto but envelope and payloadhash specified by client (hash values should be ignored)",

--- a/pkg/types/intoto/v0.0.1/entry_test.go
+++ b/pkg/types/intoto/v0.0.1/entry_test.go
@@ -148,7 +148,7 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "missing envelope",
+			name: "invalid key",
 			it: &models.IntotoV001Schema{
 				PublicKey: p([]byte("hello")),
 			},
@@ -160,8 +160,54 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 				PublicKey: p(pub),
 				Content: &models.IntotoV001SchemaContent{
 					Envelope: envelope(t, key, validPayload, "application/vnd.in-toto+json"),
+				},
+			},
+			wantErr:         false,
+			wantVerifierErr: false,
+		},
+		{
+			name: "valid intoto but hash specified by client (should be ignored)",
+			it: &models.IntotoV001Schema{
+				PublicKey: p(pub),
+				Content: &models.IntotoV001SchemaContent{
+					Envelope: envelope(t, key, validPayload, "application/vnd.in-toto+json"),
 					Hash: &models.IntotoV001SchemaContentHash{
 						Algorithm: swag.String(models.IntotoV001SchemaContentHashAlgorithmSha256),
+						Value:     swag.String("1a1707bb54e5fb4deddd19f07adcb4f1e022ca7879e3c8348da8d4fa496ae8e2"),
+					},
+				},
+			},
+			wantErr:         false,
+			wantVerifierErr: false,
+		},
+		{
+			name: "valid intoto but payloadhash specified by client (should be ignored)",
+			it: &models.IntotoV001Schema{
+				PublicKey: p(pub),
+				Content: &models.IntotoV001SchemaContent{
+					Envelope: envelope(t, key, validPayload, "application/vnd.in-toto+json"),
+					PayloadHash: &models.IntotoV001SchemaContentPayloadHash{
+						Algorithm: swag.String(models.IntotoV001SchemaContentPayloadHashAlgorithmSha256),
+						Value:     swag.String("1a1707bb54e5fb4deddd19f07adcb4f1e022ca7879e3c8348da8d4fa496ae8e2"),
+					},
+				},
+			},
+			wantErr:         false,
+			wantVerifierErr: false,
+		},
+		{
+			name: "valid intoto but envelope and payloadhash specified by client (hash values should be ignored)",
+			it: &models.IntotoV001Schema{
+				PublicKey: p(pub),
+				Content: &models.IntotoV001SchemaContent{
+					Envelope: envelope(t, key, validPayload, "application/vnd.in-toto+json"),
+					Hash: &models.IntotoV001SchemaContentHash{
+						Algorithm: swag.String(models.IntotoV001SchemaContentHashAlgorithmSha256),
+						Value:     swag.String("1a1707bb54e5fb4deddd19f07adcb4f1e022ca7879e3c8348da8d4fa496ae8e2"),
+					},
+					PayloadHash: &models.IntotoV001SchemaContentPayloadHash{
+						Algorithm: swag.String(models.IntotoV001SchemaContentPayloadHashAlgorithmSha256),
+						Value:     swag.String("1a1707bb54e5fb4deddd19f07adcb4f1e022ca7879e3c8348da8d4fa496ae8e2"),
 					},
 				},
 			},
@@ -173,9 +219,6 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 				PublicKey: p(pub),
 				Content: &models.IntotoV001SchemaContent{
 					Envelope: envelope(t, key, validPayload, "text"),
-					Hash: &models.IntotoV001SchemaContentHash{
-						Algorithm: swag.String(models.IntotoV001SchemaContentHashAlgorithmSha256),
-					},
 				},
 			},
 			wantErr: false,
@@ -186,9 +229,6 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 				PublicKey: p([]byte(pemBytes)),
 				Content: &models.IntotoV001SchemaContent{
 					Envelope: envelope(t, priv, validPayload, "text"),
-					Hash: &models.IntotoV001SchemaContentHash{
-						Algorithm: swag.String(models.IntotoV001SchemaContentHashAlgorithmSha256),
-					},
 				},
 			},
 			additionalIndexKeys: []string{"joe@schmoe.com"},
@@ -200,9 +240,6 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 				PublicKey: p(pub),
 				Content: &models.IntotoV001SchemaContent{
 					Envelope: string(invalid),
-					Hash: &models.IntotoV001SchemaContentHash{
-						Algorithm: swag.String(models.IntotoV001SchemaContentHashAlgorithmSha256),
-					},
 				},
 			},
 			wantErr: true,
@@ -213,9 +250,6 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 				PublicKey: p([]byte("notavalidkey")),
 				Content: &models.IntotoV001SchemaContent{
 					Envelope: envelope(t, key, validPayload, "text"),
-					Hash: &models.IntotoV001SchemaContentHash{
-						Algorithm: swag.String(models.IntotoV001SchemaContentHashAlgorithmSha256),
-					},
 				},
 			},
 			wantErr: true,
@@ -224,11 +258,6 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			v := &V001Entry{}
-			if tt.it.Content != nil {
-				h := sha256.Sum256([]byte(tt.it.Content.Envelope))
-				tt.it.Content.Hash.Algorithm = swag.String(models.IntotoV001SchemaContentHashAlgorithmSha256)
-				tt.it.Content.Hash.Value = swag.String(hex.EncodeToString(h[:]))
-			}
 
 			it := &models.Intoto{
 				Spec: tt.it,
@@ -236,9 +265,6 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 
 			var uv = func() error {
 				if err := v.Unmarshal(it); err != nil {
-					return err
-				}
-				if err := v.validate(); err != nil {
 					return err
 				}
 				if v.IntotoObj.Content.Hash == nil || v.IntotoObj.Content.Hash.Algorithm != tt.it.Content.Hash.Algorithm || v.IntotoObj.Content.Hash.Value != tt.it.Content.Hash.Value {

--- a/pkg/types/intoto/v0.0.1/intoto_v0_0_1_schema.json
+++ b/pkg/types/intoto/v0.0.1/intoto_v0_0_1_schema.json
@@ -14,7 +14,7 @@
                     "writeOnly": true
                 },
                 "hash": {
-                    "description": "Specifies the hash algorithm and value encompassing the entire signed envelope",
+                    "description": "Specifies the hash algorithm and value encompassing the entire signed envelope; this is computed by the rekor server, client-provided values are ignored",
                     "type": "object",
                     "properties": {
                         "algorithm": {
@@ -36,7 +36,7 @@
                     "readOnly": true
                 },
                 "payloadHash": {
-                    "description": "Specifies the hash algorithm and value covering the payload within the DSSE envelope",
+                    "description": "Specifies the hash algorithm and value covering the payload within the DSSE envelope; this is computed by the rekor server, client-provided values are ignored",
                     "type": "object",
                     "properties": {
                         "algorithm": {


### PR DESCRIPTION
#### Release Note

Ensures that validation logic for `intoto v0.0.1` types match intent expressed in JSON schema
