### PR TITLE
Add Rekor OID info.

### DIFF
--- a/oid-info.md
+++ b/oid-info.md
@@ -9,20 +9,21 @@ Rekor reserves the `1.3.6.1.4.1.57264.3` OID root for all of its values.
 
 ## Directory
 
-| OID                       | Name                   | Description                                                                                                   |
-| ------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------- |
-| 1.3.6.1.4.1.57264.3.1     | Integrated Time        | When the data was added to the log.                                                                           |
-| 1.3.6.1.4.1.57264.3.2     | Log ID                 | This is a SHA256 hash of the DER-encoded public key for the log at the time the entry was included in the log |
-| 1.3.6.1.4.1.57264.3.3     | Log Index              | The index of the entry in the transparency log.                                                               |
-| 1.3.6.1.4.1.57264.3.4     | Verification           | Log Entry Verification data.                                                                                  |
-| 1.3.6.1.4.1.57264.3.4.1   | Inclusion Proof        | Proof of inclusion on the transparency log.                                                                   |
-| 1.3.6.1.4.1.57264.3.4.1.1 | Checkpoint             | The checkpoint (signed tree head) that the inclusion proof is based on.                                       |
-| 1.3.6.1.4.1.57264.3.4.1.2 | Hashes                 | A list of hashes required to compute the inclusion proof, sorted in order from leaf to root.                  |
-| 1.3.6.1.4.1.57264.3.4.1.3 | Root Hash              | The hash value stored at the root of the merkle tree at the time the proof was generated.                     |
-| 1.3.6.1.4.1.57264.3.4.1.4 | Tree Size              | The size of the merkle tree at the time the inclusion proof was generated.                                    |
-| 1.3.6.1.4.1.57264.3.4.2   | Signed Entry Timestamp | Base64 encoded signature of the Inclusion Proof                                                               |
+| OID                       | Name                   | Tag Type               | Description                                                                                                   |
+| ------------------------- | ---------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------- |
+| 1.3.6.1.4.1.57264.3.1     | Integrated Time        | INTEGER                | When the data was added to the log.                                                                           |
+| 1.3.6.1.4.1.57264.3.2     | Log ID                 | UTF8STRING             | This is a SHA256 hash of the DER-encoded public key for the log at the time the entry was included in the log |
+| 1.3.6.1.4.1.57264.3.3     | Log Index              | INTEGER                | The index of the entry in the transparency log.                                                               |
+| 1.3.6.1.4.1.57264.3.4     | Verification           |                        | Log Entry Verification data.                                                                                  |
+| 1.3.6.1.4.1.57264.3.4.1   | Inclusion Proof        |                        | Proof of inclusion on the transparency log.                                                                   |
+| 1.3.6.1.4.1.57264.3.4.1.1 | Checkpoint             | UTF8STRING             | The checkpoint (signed tree head) that the inclusion proof is based on.                                       |
+| 1.3.6.1.4.1.57264.3.4.1.2 | Hashes                 | SEQUENCE OF UTF8STRING | A list of hashes required to compute the inclusion proof, sorted in order from leaf to root.                  |
+| 1.3.6.1.4.1.57264.3.4.1.3 | Root Hash              | UTF8STRING             | The hash value stored at the root of the merkle tree at the time the proof was generated.                     |
+| 1.3.6.1.4.1.57264.3.4.1.4 | Tree Size              | INTEGER                | The size of the merkle tree at the time the inclusion proof was generated.                                    |
+| 1.3.6.1.4.1.57264.3.4.2   | Signed Entry Timestamp | UTF8STRING             | Base64 encoded signature of the promise of inclusion.                                                         |
 
 ### Notes:
 
 - This is not an exhaustive list of values included in a LogEntry.
-- Log Index not included in Inclusion Proof since it's already defined in `1.3.6.1.4.1.57264.3.3`.
+- Log Index not included in Inclusion Proof since it's already defined in
+  `1.3.6.1.4.1.57264.3.3`.

--- a/oid-info.md
+++ b/oid-info.md
@@ -9,21 +9,6 @@ Rekor reserves the `1.3.6.1.4.1.57264.3` OID root for all of its values.
 
 ## Directory
 
-| OID                       | Name                   | Tag Type               | Description                                                                                                   |
-| ------------------------- | ---------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------- |
-| 1.3.6.1.4.1.57264.3.1     | Integrated Time        | INTEGER                | When the data was added to the log.                                                                           |
-| 1.3.6.1.4.1.57264.3.2     | Log ID                 | UTF8STRING             | This is a SHA256 hash of the DER-encoded public key for the log at the time the entry was included in the log |
-| 1.3.6.1.4.1.57264.3.3     | Log Index              | INTEGER                | The index of the entry in the transparency log.                                                               |
-| 1.3.6.1.4.1.57264.3.4     | Verification           |                        | Log Entry Verification data.                                                                                  |
-| 1.3.6.1.4.1.57264.3.4.1   | Inclusion Proof        |                        | Proof of inclusion on the transparency log.                                                                   |
-| 1.3.6.1.4.1.57264.3.4.1.1 | Checkpoint             | UTF8STRING             | The checkpoint (signed tree head) that the inclusion proof is based on.                                       |
-| 1.3.6.1.4.1.57264.3.4.1.2 | Hashes                 | SEQUENCE OF UTF8STRING | A list of hashes required to compute the inclusion proof, sorted in order from leaf to root.                  |
-| 1.3.6.1.4.1.57264.3.4.1.3 | Root Hash              | UTF8STRING             | The hash value stored at the root of the merkle tree at the time the proof was generated.                     |
-| 1.3.6.1.4.1.57264.3.4.1.4 | Tree Size              | INTEGER                | The size of the merkle tree at the time the inclusion proof was generated.                                    |
-| 1.3.6.1.4.1.57264.3.4.2   | Signed Entry Timestamp | UTF8STRING             | Base64 encoded signature of the promise of inclusion.                                                         |
-
-### Notes:
-
-- This is not an exhaustive list of values included in a LogEntry.
-- Log Index not included in Inclusion Proof since it's already defined in
-  `1.3.6.1.4.1.57264.3.3`.
+| OID                   | Name                 | Tag Type     | Description                                                                                                                                                        |
+| --------------------- | -------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1.3.6.1.4.1.57264.3.1 | TransparencyLogEntry | `BIT STRING` | Proto serialized [TransparencyLogEntry](https://github.com/sigstore/protobuf-specs/blob/4dbf10bc287d76f1bfa68c05a78f3f5add5f56fe/protos/sigstore_rekor.proto#L89). |

--- a/oid-info.md
+++ b/oid-info.md
@@ -1,0 +1,28 @@
+# Rekor OID Information
+
+## Description
+
+This document defines Rekor
+[OID values](https://github.com/sigstore/sigstore/blob/main/docs/oid-info.md).
+
+Rekor reserves the `1.3.6.1.4.1.57264.3` OID root for all of its values.
+
+## Directory
+
+| OID                       | Name                   | Description                                                                                                   |
+| ------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------- |
+| 1.3.6.1.4.1.57264.3.1     | Integrated Time        | When the data was added to the log.                                                                           |
+| 1.3.6.1.4.1.57264.3.2     | Log ID                 | This is a SHA256 hash of the DER-encoded public key for the log at the time the entry was included in the log |
+| 1.3.6.1.4.1.57264.3.3     | Log Index              | The index of the entry in the transparency log.                                                               |
+| 1.3.6.1.4.1.57264.3.4     | Verification           | Log Entry Verification data.                                                                                  |
+| 1.3.6.1.4.1.57264.3.4.1   | Inclusion Proof        | Proof of inclusion on the transparency log.                                                                   |
+| 1.3.6.1.4.1.57264.3.4.1.1 | Checkpoint             | The checkpoint (signed tree head) that the inclusion proof is based on.                                       |
+| 1.3.6.1.4.1.57264.3.4.1.2 | Hashes                 | A list of hashes required to compute the inclusion proof, sorted in order from leaf to root.                  |
+| 1.3.6.1.4.1.57264.3.4.1.3 | Root Hash              | The hash value stored at the root of the merkle tree at the time the proof was generated.                     |
+| 1.3.6.1.4.1.57264.3.4.1.4 | Tree Size              | The size of the merkle tree at the time the inclusion proof was generated.                                    |
+| 1.3.6.1.4.1.57264.3.4.2   | Signed Entry Timestamp | Base64 encoded signature of the Inclusion Proof                                                               |
+
+### Notes:
+
+- This is not an exhaustive list of values included in a LogEntry.
+- Log Index not included in Inclusion Proof since it's already defined in `1.3.6.1.4.1.57264.3.3`.

--- a/oid-info.md
+++ b/oid-info.md
@@ -11,4 +11,4 @@ Rekor reserves the `1.3.6.1.4.1.57264.3` OID root for all of its values.
 
 | OID                   | Name                 | Tag Type     | Description                                                                                                                                                        |
 | --------------------- | -------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 1.3.6.1.4.1.57264.3.1 | TransparencyLogEntry | `BIT STRING` | Proto serialized [TransparencyLogEntry](https://github.com/sigstore/protobuf-specs/blob/4dbf10bc287d76f1bfa68c05a78f3f5add5f56fe/protos/sigstore_rekor.proto#L89). |
+| 1.3.6.1.4.1.57264.3.1 | TransparencyLogEntry | `UTF8STRING` | Proto serialized [TransparencyLogEntry](https://github.com/sigstore/protobuf-specs/blob/4dbf10bc287d76f1bfa68c05a78f3f5add5f56fe/protos/sigstore_rekor.proto#L89). |


### PR DESCRIPTION
@haydentherapper Finally circling back to this 🙏 

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This defines OIDs for most log entry fields (though not all). This is primarily intended to be used by clients that want to represent Rekor data in different formats and/or cannot use bundles.

For example, gitsign cannot use the verification bundle since it uses PKCS7 signatures to keep compatibility with existing Git clients / signature formats. Since PKCS7 already defines a structure for payload hashes, it implements offline verification by deconstructing bundles into distinct OIDs then reconstructs them for verification. See https://github.com/sigstore/gitsign/pull/220 for more details.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Adds OID definitions for LogEntry fields.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

✅ 