### PR TITLE
omit informational message if machine-parseable output has been requested

### DIFF
--- a/cmd/rekor-cli/app/search.go
+++ b/cmd/rekor-cli/app/search.go
@@ -201,7 +201,9 @@ var searchCmd = &cobra.Command{
 			return nil, fmt.Errorf("no matching entries found")
 		}
 
-		fmt.Fprintln(os.Stderr, "Found matching entries (listed by UUID):")
+		if viper.GetString("format") != "json" {
+			fmt.Fprintln(os.Stderr, "Found matching entries (listed by UUID):")
+		}
 
 		return &searchCmdOutput{
 			UUIDs: resp.GetPayload(),


### PR DESCRIPTION
Fixes: #1395 