### PR TITLE
use t.Skip() in fuzzers instead of t.Errorf

### DIFF
--- a/pkg/types/alpine/v0.0.1/fuzz_test.go
+++ b/pkg/types/alpine/v0.0.1/fuzz_test.go
@@ -91,7 +91,7 @@ func FuzzAlpineUnmarshalAndCanonicalize(f *testing.F) {
 		}
 
 		if _, err := types.CanonicalizeEntry(context.Background(), ei); err != nil {
-			t.Errorf("error canonicalizing unmarshalled entry: %v", err)
+			t.Skip()
 		}
 	})
 }

--- a/pkg/types/helm/v0.0.1/fuzz_test.go
+++ b/pkg/types/helm/v0.0.1/fuzz_test.go
@@ -91,7 +91,7 @@ func FuzzHelmUnmarshalAndCanonicalize(f *testing.F) {
 		}
 
 		if _, err := types.CanonicalizeEntry(context.Background(), ei); err != nil {
-			t.Errorf("error canonicalizing unmarshalled entry: %v", err)
+			t.Skip()
 		}
 	})
 }

--- a/pkg/types/jar/v0.0.1/fuzz_test.go
+++ b/pkg/types/jar/v0.0.1/fuzz_test.go
@@ -94,7 +94,7 @@ func FuzzJarUnmarshalAndCanonicalize(f *testing.F) {
 		}
 
 		if _, err := types.CanonicalizeEntry(context.Background(), ei); err != nil {
-			t.Errorf("error canonicalizing unmarshalled entry: %v", err)
+			t.Skip()
 		}
 	})
 }

--- a/pkg/types/rekord/v0.0.1/fuzz_test.go
+++ b/pkg/types/rekord/v0.0.1/fuzz_test.go
@@ -90,7 +90,7 @@ func FuzzRekordUnmarshalAndCanonicalize(f *testing.F) {
 		}
 
 		if _, err := types.CanonicalizeEntry(context.Background(), ei); err != nil {
-			t.Errorf("error canonicalizing unmarshalled entry: %v", err)
+			t.Skip()
 		}
 	})
 }

--- a/pkg/types/rpm/v0.0.1/fuzz_test.go
+++ b/pkg/types/rpm/v0.0.1/fuzz_test.go
@@ -90,7 +90,7 @@ func FuzzRpmUnmarshalAndCanonicalize(f *testing.F) {
 		}
 
 		if _, err := types.CanonicalizeEntry(context.Background(), ei); err != nil {
-			t.Errorf("error canonicalizing unmarshalled entry: %v", err)
+			t.Skip()
 		}
 	})
 }

--- a/pkg/types/tuf/v0.0.1/fuzz_test.go
+++ b/pkg/types/tuf/v0.0.1/fuzz_test.go
@@ -90,7 +90,7 @@ func FuzzTufUnmarshalAndCanonicalize(f *testing.F) {
 		}
 
 		if _, err := types.CanonicalizeEntry(context.Background(), ei); err != nil {
-			t.Errorf("error canonicalizing unmarshalled entry: %v", err)
+			t.Skip()
 		}
 	})
 }


### PR DESCRIPTION
use t.Skip() in fuzzers where full input validation does not happen until the call to Canonicalize due to the fetchExternalEntities pattern.