### PR TITLE
chore: bump golangci-lint version to v1.53.x

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -59,4 +59,4 @@ jobs:
         uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # v3.6.0
         timeout-minutes: 5
         with:
-          version: v1.52
+          version: v1.53


### PR DESCRIPTION

#### Summary
- bump golangci-lint version to v1.53.x