### PR TITLE
feat: Support publishing new log entries to Pub/Sub topics

### DIFF
--- a/Dockerfile.pubsub-emulator
+++ b/Dockerfile.pubsub-emulator
@@ -1,0 +1,3 @@
+# gcloud sdk for pubsub emulator with netcat added for the startup health check
+FROM google/cloud-sdk:437.0.0
+RUN apt-get install -y netcat

--- a/cmd/rekor-server/app/root.go
+++ b/cmd/rekor-server/app/root.go
@@ -93,6 +93,8 @@ func init() {
 Memory and file-based signers should only be used for testing.`)
 	rootCmd.PersistentFlags().String("rekor_server.signer-passwd", "", "Password to decrypt signer private key")
 
+	rootCmd.PersistentFlags().String("rekor_server.new_entry_publisher", "", "URL for pub/sub queue to send messages to when new entries are added to the log. Ignored if not set.")
+
 	rootCmd.PersistentFlags().Uint16("port", 3000, "Port to bind to")
 
 	rootCmd.PersistentFlags().Bool("enable_retrieve_api", true, "enables Redis-based index API endpoint")

--- a/cmd/rekor-server/app/serve.go
+++ b/cmd/rekor-server/app/serve.go
@@ -61,7 +61,6 @@ var serveCmd = &cobra.Command{
 	Short: "start http server with configured api",
 	Long:  `Starts a http server and serves the configured api`,
 	Run: func(cmd *cobra.Command, args []string) {
-
 		// Setup the logger to dev/prod
 		log.ConfigureLogger(viper.GetString("log_type"))
 
@@ -83,7 +82,6 @@ var serveCmd = &cobra.Command{
 				log.Logger.Error(err)
 			}
 		}()
-
 		//TODO: make this a config option for server to load via viper field
 		//TODO: add command line option to print versions supported in binary
 
@@ -101,7 +99,6 @@ var serveCmd = &cobra.Command{
 			hashedrekord.KIND: {hashedrekord_v001.APIVERSION},
 			dsse.KIND:         {dsse_v001.APIVERSION},
 		}
-
 		for k, v := range pluggableTypeMap {
 			log.Logger.Infof("Loading support for pluggable type '%v'", k)
 			log.Logger.Infof("Loading version '%v' for pluggable type '%v'", v, k)

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -19,6 +19,8 @@ services:
     build:
       context: .
       target: "test"
+    environment:
+      PUBSUB_EMULATOR_HOST: gcp-pubsub-emulator:8085
     command: [
       "rekor-server",
       "-test.coverprofile=rekor-server.cov",
@@ -32,7 +34,27 @@ services:
       "--enable_attestation_storage",
       "--attestation_storage_bucket=file:///var/run/attestations",
       "--max_request_body_size=32792576",
+      "--rekor_server.new_entry_publisher=gcppubsub://projects/fake-test-project/topics/new-entry",
       ]
     ports:
       - "3000:3000"
       - "2112:2112"
+    depends_on:
+      - gcp-pubsub-emulator
+  gcp-pubsub-emulator:
+    image: gcp-pubsub-emulator
+    ports:
+      - "8085:8085"
+    command:
+      - gcloud
+      - beta
+      - emulators
+      - pubsub
+      - start
+      - --project=fake-test-project
+    healthcheck:
+      test: ["CMD", "nc", "-zv", "localhost", "8085"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,4 +112,3 @@ services:
       timeout: 3s
       retries: 3
       start_period: 5s
-

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/sigstore/rekor
 
 go 1.19
 
+// TEMPORARY: DO NOT MERGE WITH THIS
+replace github.com/sigstore/protobuf-specs => ../../jalseth/protobuf-specs
+
 require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
 	github.com/blang/semver v3.5.1+incompatible
@@ -51,6 +54,7 @@ require (
 )
 
 require (
+	cloud.google.com/go/pubsub v1.31.0
 	github.com/AdamKorcz/go-fuzz-headers-1 v0.0.0-20230329111138-12e09aba5ebd
 	github.com/cyberphone/json-canonicalization v0.0.0-20220623050100-57a0ce2678a7
 	github.com/go-redis/redismock/v9 v9.0.3
@@ -180,7 +184,7 @@ require (
 	golang.org/x/term v0.9.0 // indirect
 	golang.org/x/text v0.10.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
-	google.golang.org/api v0.128.0 // indirect
+	google.golang.org/api v0.128.0
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -444,6 +444,7 @@ cloud.google.com/go/pubsub v1.26.0/go.mod h1:QgBH3U/jdJy/ftjPhTkyXNj543Tin1pRYcd
 cloud.google.com/go/pubsub v1.27.1/go.mod h1:hQN39ymbV9geqBnfQq6Xf63yNhUAhv9CZhzp5O6qsW0=
 cloud.google.com/go/pubsub v1.28.0/go.mod h1:vuXFpwaVoIPQMGXqRyUQigu/AX1S3IWugR9xznmcXX8=
 cloud.google.com/go/pubsub v1.30.0/go.mod h1:qWi1OPS0B+b5L+Sg6Gmc9zD1Y+HaM0MdUr7LsupY1P4=
+cloud.google.com/go/pubsub v1.31.0 h1:aXdyyJz90kA+bor9+6+xHAciMD5mj8v15WqFZ5E0sek=
 cloud.google.com/go/pubsub v1.31.0/go.mod h1:dYmJ3K97NCQ/e4OwZ20rD4Ym3Bu8Gu9m/aJdWQjdcks=
 cloud.google.com/go/pubsublite v1.5.0/go.mod h1:xapqNQ1CuLfGi23Yda/9l4bBCKz/wC3KIJ5gKcxveZg=
 cloud.google.com/go/pubsublite v1.6.0/go.mod h1:1eFCS0U11xlOuMFV/0iBqw3zP12kddMeCbj/F3FSj9k=
@@ -2122,8 +2123,6 @@ github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFR
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
-github.com/sigstore/protobuf-specs v0.1.0 h1:X0l/E2C2c79t/rI/lmSu8WAoKWsQtMqDzAMiDdEMGr8=
-github.com/sigstore/protobuf-specs v0.1.0/go.mod h1:5shUCxf82hGnjUEFVWiktcxwzdtn6EfeeJssxZ5Q5HE=
 github.com/sigstore/sigstore v1.7.1 h1:fCATemikcBK0cG4+NcM940MfoIgmioY1vC6E66hXxks=
 github.com/sigstore/sigstore v1.7.1/go.mod h1:0PmMzfJP2Y9+lugD0wer4e7TihR5tM7NcIs3bQNk5xg=
 github.com/sigstore/sigstore/pkg/signature/kms/aws v1.7.1 h1:rDHrG/63b3nBq3G9plg7iYnWN6lBhOfq/XultlCZgII=

--- a/pkg/pubsub/doc.go
+++ b/pkg/pubsub/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2023 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pubsub provides an interface and implementations for publishing
+// notifications for Rekor updates to a Pub/Sub system.
+package pubsub

--- a/pkg/pubsub/events.go
+++ b/pkg/pubsub/events.go
@@ -1,0 +1,111 @@
+// Copyright 2023 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pubsub
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sigstore/rekor/pkg/generated/models"
+	"github.com/sigstore/rekor/pkg/tle"
+	"golang.org/x/exp/slices"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	pb "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/events/v1"
+	tspb "google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// Event is any protobuf message that has getters for the required fields for
+// a CloudEvent.
+type Event interface {
+	protoreflect.ProtoMessage
+
+	GetSpecVersion() string
+	GetId() string
+	GetType() string
+	GetSource() string
+}
+
+// EventType is the unique name of an event type.
+type EventType string
+
+const (
+	// NewEntryEvent is an event that is published when a new entry is added to
+	// Rekor's transparency log.
+	NewEntryEvent EventType = "dev.sigstore.rekor.events.v1.NewEntry"
+)
+
+// BuildNewEntryEvent builds a new NewEntry event proto message. It takes the
+// unique entry ID, entry model, and slice of subjects that signed the entry
+// as arguments.
+func BuildNewEntryEvent(entryID string, entry models.LogEntryAnon, subjects []string) (*pb.NewEntry, error) {
+	if entryID == "" {
+		return nil, fmt.Errorf("entryID parameter must be set")
+	}
+	slices.Sort(subjects) // Must be sorted for consistency.
+
+	validated, err := tle.GenerateTransparencyLogEntry(entry)
+	if err != nil {
+		return nil, fmt.Errorf("validate entry: %w", err)
+	}
+	data, err := tle.MarshalTLEToJSON(validated)
+	if err != nil {
+		return nil, fmt.Errorf("marshal entry: %w", err)
+	}
+
+	return &pb.NewEntry{
+		Id:        entryID,
+		Type:      string(NewEntryEvent),
+		Data:      string(data),
+		DataType:  "application/json",
+		Source:    "/createLogEntry",
+		EntryKind: validated.GetKindVersion().GetKind(),
+		Subjects:  subjects,
+		Time:      &tspb.Timestamp{Seconds: validated.IntegratedTime},
+	}, nil
+}
+
+// EventAttributes returns the attributes for a given event. The key names
+// follow the CloudEvents specification. All Rekor-specific attributes have a
+// prefix of "rekor_".
+func EventAttributes(event Event) map[string]string {
+	// Standard CloudEvents attributes defined in the spec.
+	attrs := map[string]string{
+		"specversion": event.GetSpecVersion(),
+		"id":          event.GetId(),
+		"source":      event.GetSource(),
+		"type":        event.GetType(),
+	}
+
+	// Locate any Rekor-specific attributes.
+	fields := event.ProtoReflect().Descriptor().Fields()
+	for i := 0; i < fields.Len(); i++ {
+		fd := fields.Get(i)
+		if !strings.HasPrefix(fd.JSONName(), "rekor_") {
+			continue
+		}
+		val := event.ProtoReflect().Get(fd).Interface()
+		switch x := val.(type) {
+		case string:
+			attrs[fd.JSONName()] = x
+		case []string:
+			attrs[fd.JSONName()] = strings.Join(x, ",")
+		default:
+			attrs[fd.JSONName()] = fmt.Sprintf("%v", x)
+		}
+	}
+
+	return attrs
+}

--- a/pkg/pubsub/gcp/gcp.go
+++ b/pkg/pubsub/gcp/gcp.go
@@ -1,0 +1,110 @@
+// Copyright 2023 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package gcp implements the pubsub.Publisher with Google Cloud Pub/Sub.
+package gcp
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+
+	"cloud.google.com/go/pubsub"
+	sigpubsub "github.com/sigstore/rekor/pkg/pubsub"
+	"google.golang.org/api/option"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func init() {
+	sigpubsub.AddProvider(URIIdentifier, func(ctx context.Context, topicResourceID string) (sigpubsub.Publisher, error) {
+		return New(ctx, topicResourceID)
+	})
+}
+
+const URIIdentifier = "gcppubsub://"
+
+var (
+	// Copied from https://github.com/google/go-cloud/blob/master/pubsub/gcppubsub/gcppubsub.go
+	re = regexp.MustCompile(`^gcppubsub://projects/([^/]+)/topics/([^/]+)$`)
+	// Minimal set of permissions needed to check if the server can publish to the configured topic.
+	// https://cloud.google.com/pubsub/docs/access-control#required_permissions
+	requiredIAMPermissions = []string{
+		"pubsub.topics.get",
+		"pubsub.topics.publish",
+	}
+)
+
+type Publisher struct {
+	client *pubsub.Client
+	topic  string
+}
+
+func New(ctx context.Context, topicResourceID string, opts ...option.ClientOption) (*Publisher, error) {
+	projectID, topic, err := parseRef(topicResourceID)
+	if err != nil {
+		return nil, fmt.Errorf("parse ref: %w", err)
+	}
+	client, err := pubsub.NewClient(ctx, projectID, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("create pubsub client for project %q: %w", projectID, err)
+	}
+
+	// The PubSub emulator does not support IAM methods, and will block the
+	// server start up if they are called. If the environment variable is set,
+	// skip this check.
+	if os.Getenv("PUBSUB_EMULATOR_HOST") == "" {
+		if _, err := client.Topic(topic).IAM().TestPermissions(ctx, requiredIAMPermissions); err != nil {
+			return nil, fmt.Errorf("insufficient permissions for topic %q: %w", topic, err)
+		}
+	}
+
+	return &Publisher{
+		client: client,
+		topic:  topic,
+	}, nil
+}
+
+func (p *Publisher) Publish(ctx context.Context, event sigpubsub.Event) error {
+	data, err := protojson.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("marshal event: %w", err)
+	}
+	msg := &pubsub.Message{
+		Data:       data,
+		Attributes: sigpubsub.EventAttributes(event),
+	}
+	res := p.client.Topic(p.topic).Publish(ctx, msg)
+	// TODO: Consider making the timeout configurable.
+	withTimeout, cancel := context.WithTimeout(ctx, pubsub.DefaultPublishSettings.Timeout)
+	defer cancel()
+	if _, err := res.Get(withTimeout); err != nil {
+		return fmt.Errorf("publish event %q of type %q to topic %q: %w", event.GetId(), event.GetType(), p.topic, err)
+	}
+	return nil
+}
+
+func (p *Publisher) Close() error {
+	return p.client.Close()
+}
+
+func parseRef(ref string) (projectID, topic string, err error) {
+	v := re.FindStringSubmatch(ref)
+	if len(v) != 3 {
+		err = fmt.Errorf("invalid gcppubsub format %q", ref)
+		return
+	}
+	projectID, topic = v[1], v[2]
+	return
+}

--- a/pkg/pubsub/gcp/gcp_test.go
+++ b/pkg/pubsub/gcp/gcp_test.go
@@ -1,0 +1,72 @@
+// Copyright 2023 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcp
+
+import (
+	"testing"
+)
+
+func TestParseRef(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		desc string
+		ref  string
+
+		wantProject string
+		wantTopic   string
+		wantErr     bool
+	}{
+
+		{
+			desc:        "Valid example",
+			ref:         "gcppubsub://projects/project-foo/topics/topic-bar",
+			wantProject: "project-foo",
+			wantTopic:   "topic-bar",
+		},
+		{
+			desc:    "Empty ref",
+			wantErr: true,
+		},
+		{
+			desc:    "Missing topic",
+			ref:     "gcppubsub://projects/project-foo/topics/",
+			wantErr: true,
+		},
+		{
+			desc:    "Wrong scheme",
+			ref:     "foo://projects/project-foo/topics/topic-bar",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			project, topic, err := parseRef(tc.ref)
+			gotErr := err != nil
+			if gotErr != tc.wantErr {
+				t.Errorf("parseRef(%s) error = %v, wantErr %v", tc.ref, gotErr, tc.wantErr)
+				return
+			}
+			if project != tc.wantProject {
+				t.Errorf("parseRef(%s) project = %s, want %s", tc.ref, project, tc.wantProject)
+			}
+			if topic != tc.wantTopic {
+				t.Errorf("parseRef(%s) topic = %s, want %s", tc.ref, topic, tc.wantTopic)
+			}
+		})
+	}
+}

--- a/pkg/pubsub/publisher.go
+++ b/pkg/pubsub/publisher.go
@@ -1,0 +1,71 @@
+// Copyright 2023 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pubsub
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
+)
+
+// Publisher provides methods for publishing events to a Pub/Sub topic.
+type Publisher interface {
+	// Publish publishes an event to the configured Pub/Sub topic.
+	Publish(ctx context.Context, event Event) error
+	// Close safely closes any active connections.
+	Close() error
+}
+
+// ProviderNotFoundError indicates that no matching PubSub provider was found.
+type ProviderNotFoundError struct {
+	ref string
+}
+
+func (e *ProviderNotFoundError) Error() string {
+	return fmt.Sprintf("no pubsub provider found for key reference: %s", e.ref)
+}
+
+// ProviderInit is a function that initializes provider-specific Publisher.
+type ProviderInit func(ctx context.Context, topicResourceID string) (Publisher, error)
+
+// AddProvider adds the provider implementation into the local cache
+func AddProvider(uri string, init ProviderInit) {
+	providersMap[uri] = init
+}
+
+var providersMap = map[string]ProviderInit{}
+
+// Get returns a Publisher for the given resource string and hash function.
+// If no matching provider is found, Get returns a ProviderNotFoundError. It
+// also returns an error if initializing the Publisher fails. If no resource
+// is supplied, it returns a nil Publisher and no error.
+func Get(ctx context.Context, topicResourceID string) (Publisher, error) {
+	for ref, pi := range providersMap {
+		if strings.HasPrefix(topicResourceID, ref) {
+			return pi(ctx, topicResourceID)
+		}
+	}
+	return nil, &ProviderNotFoundError{ref: topicResourceID}
+}
+
+// SupportedProviders returns list of initialized providers
+func SupportedProviders() []string {
+	names := maps.Keys(providersMap)
+	slices.Sort(names)
+	return names
+}

--- a/pkg/tle/tle.go
+++ b/pkg/tle/tle.go
@@ -50,7 +50,17 @@ func GenerateTransparencyLogEntry(anon models.LogEntryAnon) (*rekor_pb.Transpare
 		inclusionProofHashes[i] = hashBytes
 	}
 
-	b, err := base64.StdEncoding.DecodeString(anon.Body.(string))
+	var body string
+	switch x := anon.Body.(type) {
+	case string:
+		body = x
+	case []byte:
+		body = string(x)
+	default:
+		return nil, fmt.Errorf("body is not string: (%T)%v", x, x)
+	}
+
+	b, err := base64.StdEncoding.DecodeString(body)
 	if err != nil {
 		return nil, fmt.Errorf("base64 decoding body: %w", err)
 	}


### PR DESCRIPTION
#### Summary

Adds initial support publishing new log entries to Pub/Sub topics. Interested parties can subscribe to the topic in order to receive notifications when new entries are added.

This relates to #191. 

#### Release Note

* New features: Added support publishing new log entries to Pub/Sub topics
* Config changes: Added the `rekor_server.new_entry_publisher` flag to configure the Pub/Sub topic to send notifications to when a new log entry is added. This flag is optional.

#### Documentation

This is a TODO still. I would like feedback on the PR before writing the docs.