### PR TITLE
swap killswitch for 'docker-compose restart'

### DIFF
--- a/cmd/rekor-server/app/root.go
+++ b/cmd/rekor-server/app/root.go
@@ -72,8 +72,6 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.rekor-server.yaml)")
 	rootCmd.PersistentFlags().StringVar(&logType, "log_type", "dev", "logger type to use (dev/prod)")
 	rootCmd.PersistentFlags().BoolVar(&enablePprof, "enable_pprof", false, "enable pprof for profiling on port 6060")
-	rootCmd.PersistentFlags().Bool("enable_killswitch", false, "enable killswitch for TESTING ONLY on port 2345")
-	_ = rootCmd.PersistentFlags().MarkHidden("enable_killswitch")
 
 	rootCmd.PersistentFlags().String("trillian_log_server.address", "127.0.0.1", "Trillian log server address")
 	rootCmd.PersistentFlags().Uint16("trillian_log_server.port", 8090, "Trillian log server port")

--- a/cmd/rekor-server/app/serve.go
+++ b/cmd/rekor-server/app/serve.go
@@ -126,27 +126,6 @@ var serveCmd = &cobra.Command{
 			_ = srv.ListenAndServe()
 		}()
 
-		if viper.GetBool("enable_killswitch") {
-			go func() {
-				mux := http.NewServeMux()
-				mux.Handle("/kill", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					if err := server.Shutdown(); err != nil {
-						log.Logger.Error(err)
-					}
-					w.WriteHeader(http.StatusOK)
-				}))
-
-				srv := &http.Server{
-					Addr:         ":2345",
-					ReadTimeout:  10 * time.Second,
-					WriteTimeout: 10 * time.Second,
-					Handler:      mux,
-				}
-
-				_ = srv.ListenAndServe()
-			}()
-		}
-
 		if err := server.Serve(); err != nil {
 			log.Logger.Fatal(err)
 		}

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -31,10 +31,8 @@ services:
       "--rekor_server.signer=memory",
       "--enable_attestation_storage",
       "--attestation_storage_bucket=file:///var/run/attestations",
-      "--enable_killswitch",
       "--max_request_body_size=32792576",
       ]
     ports:
       - "3000:3000"
       - "2112:2112"
-      - "2345:2345"

--- a/e2e-test.sh
+++ b/e2e-test.sh
@@ -62,8 +62,7 @@ if docker-compose logs --no-color | grep -q "panic: runtime error:" ; then
 fi
 
 echo "generating code coverage"
-curl -X GET 0.0.0.0:2345/kill
-sleep 5
+docker-compose restart rekor-server
 
 if ! docker cp $(docker ps -aqf "name=rekor_rekor-server"):go/rekor-server.cov /tmp/pkg-rekor-server.cov ; then
    # failed to copy code coverage report from server

--- a/tests/e2e-test.sh
+++ b/tests/e2e-test.sh
@@ -65,8 +65,7 @@ if docker-compose logs --no-color | grep -q "panic: runtime error:" ; then
 fi
 
 echo "generating code coverage"
-curl -X GET 0.0.0.0:2345/kill
-sleep 5
+docker-compose restart rekor-server
 
 if ! docker cp $(docker ps -aqf "name=rekor_rekor-server"):go/rekor-server.cov /tmp/rekor-server.cov ; then
    # failed to copy code coverage report from server


### PR DESCRIPTION
#### Summary
This removes the killswitch endpoint and simply calls `docker-compose restart` instead. 