### PR TITLE
alpine: add max metadata size to fuzzer

### DIFF
--- a/pkg/types/alpine/apk_test.go
+++ b/pkg/types/alpine/apk_test.go
@@ -53,8 +53,7 @@ func TestAlpinePackage(t *testing.T) {
 }
 
 func TestAlpineMetadataSize(t *testing.T) {
-	os.Setenv("MAX_APK_METADATA_SIZE", "10")
-	viper.AutomaticEnv()
+	viper.Set("max_apk_metadata_size", 10)
 
 	inputArchive, err := os.Open("tests/test_alpine.apk")
 	if err != nil {

--- a/pkg/types/alpine/fuzz_test.go
+++ b/pkg/types/alpine/fuzz_test.go
@@ -17,11 +17,21 @@ package alpine
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
+
+	"github.com/spf13/viper"
 
 	fuzz "github.com/AdamKorcz/go-fuzz-headers-1"
 	utils "github.com/sigstore/rekor/pkg/fuzz"
 )
+
+func init() {
+	viper.Set("max_apk_metadata_size", 60000)
+	if viper.GetUint64("max_apk_metadata_size") != 60000 {
+		panic(fmt.Sprintf("max metadata size is not defined: %d", viper.GetUint64("max_apk_metadata_size")))
+	}
+}
 
 // FuzzPackageUnmarshal implements the fuzz test
 func FuzzPackageUnmarshal(f *testing.F) {


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Adds the metadata size check to the fuzzing of the alpine package. 

Changes the viper API for setting the value in the unit test, since its otherwise breaks with the changes to the fuzzer.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
