### PR TITLE
pki: clean up fuzzer

### DIFF
--- a/pkg/pki/fuzz_test.go
+++ b/pkg/pki/fuzz_test.go
@@ -20,8 +20,6 @@ import (
 	"io"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-
 	"github.com/sigstore/rekor/pkg/pki/minisign"
 	"github.com/sigstore/rekor/pkg/pki/pgp"
 	"github.com/sigstore/rekor/pkg/pki/pkcs7"
@@ -31,14 +29,6 @@ import (
 )
 
 var (
-	cmpOpts = []cmp.Option{cmp.AllowUnexported(minisign.PublicKey{},
-		pgp.PublicKey{},
-		ssh.PublicKey{},
-		x509.PublicKey{},
-		pkcs7.PublicKey{},
-		tuf.PublicKey{},
-	)}
-
 	fuzzArtifactFactoryMap = map[uint]pkiImpl{
 		0: {
 			newPubKey: func(r io.Reader) (PublicKey, error) {
@@ -93,23 +83,6 @@ var (
 
 func FuzzKeys(f *testing.F) {
 	f.Fuzz(func(t *testing.T, keyType uint, origSignatureData, verSignatureData, keyData []byte) {
-
-		// test public key
-		pub1, err := fuzzArtifactFactoryMap[keyType%6].newPubKey(bytes.NewReader(keyData))
-		if err == nil && pub1 != nil {
-			b, err := pub1.CanonicalValue()
-			if err == nil {
-				pub2, err := fuzzArtifactFactoryMap[keyType%6].newPubKey(bytes.NewReader(b))
-				if err != nil {
-					t.Fatal("Could not create a key from valid key data")
-				}
-				if !cmp.Equal(pub1, pub2, cmpOpts...) {
-					t.Fatal("The two public keys should be equal but are not")
-				}
-			}
-		}
-
-		// test signature
 		s, err := fuzzArtifactFactoryMap[keyType%6].newSignature(bytes.NewReader(origSignatureData))
 		if err == nil && s != nil {
 			b, err := s.CanonicalValue()


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Removes a check that is not correct.

For example, `NewPublicKey` in the ssh package parses the input data into the key and the comment: 

https://github.com/sigstore/rekor/blob/7359299098785225d6334b0384cb861b08cdb5de/pkg/pki/ssh/ssh.go#L82-L99

but canonicalizes only the `key` value:
https://github.com/sigstore/rekor/blob/7359299098785225d6334b0384cb861b08cdb5de/pkg/pki/ssh/ssh.go#L102-L107

and when then fuzzer then creates another key with the canonical value, the two public keys will differ and the comparison statement:
```golang
	if !cmp.Equal(pub1, pub2, cmpOpts...) {
	        t.Fatal("The two public keys should be equal but are not")
	}
```

... will fail.

Each PKI does something different, so I am removing this check in the fuzzer to let it run without interruption.



#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
