### PR TITLE
Refactor Verifiers to return multiple keys

### DIFF
--- a/pkg/types/alpine/alpine_test.go
+++ b/pkg/types/alpine/alpine_test.go
@@ -43,7 +43,7 @@ func (u UnmarshalFailsTester) Unmarshal(_ models.ProposedEntry) error {
 	return errors.New("error")
 }
 
-func (u UnmarshalFailsTester) Verifier() (pki.PublicKey, error) {
+func (u UnmarshalFailsTester) Verifiers() ([]pki.PublicKey, error) {
 	return nil, nil
 }
 

--- a/pkg/types/alpine/v0.0.1/entry.go
+++ b/pkg/types/alpine/v0.0.1/entry.go
@@ -351,11 +351,15 @@ func (v V001Entry) CreateFromArtifactProperties(ctx context.Context, props types
 	return &returnVal, nil
 }
 
-func (v V001Entry) Verifier() (pki.PublicKey, error) {
+func (v V001Entry) Verifiers() ([]pki.PublicKey, error) {
 	if v.AlpineModel.PublicKey == nil || v.AlpineModel.PublicKey.Content == nil {
 		return nil, errors.New("alpine v0.0.1 entry not initialized")
 	}
-	return x509.NewPublicKey(bytes.NewReader(*v.AlpineModel.PublicKey.Content))
+	key, err := x509.NewPublicKey(bytes.NewReader(*v.AlpineModel.PublicKey.Content))
+	if err != nil {
+		return nil, err
+	}
+	return []pki.PublicKey{key}, nil
 }
 
 func (v V001Entry) Insertable() (bool, error) {

--- a/pkg/types/alpine/v0.0.1/entry_test.go
+++ b/pkg/types/alpine/v0.0.1/entry_test.go
@@ -179,19 +179,19 @@ func TestCrossFieldValidation(t *testing.T) {
 			}
 		}
 
-		verifier, err := v.Verifier()
+		verifiers, err := v.Verifiers()
 		if tc.expectedVerifierSuccess {
 			if err != nil {
 				t.Errorf("%v: unexpected error, got %v", tc.caseDesc, err)
 			} else {
-				pub, _ := verifier.CanonicalValue()
+				pub, _ := verifiers[0].CanonicalValue()
 				if !reflect.DeepEqual(pub, keyBytes) {
 					t.Errorf("%v: verifier and public keys do not match: %v, %v", tc.caseDesc, string(pub), string(keyBytes))
 				}
 			}
 		} else {
 			if err == nil {
-				s, _ := verifier.CanonicalValue()
+				s, _ := verifiers[0].CanonicalValue()
 				t.Errorf("%v: expected error for %v, got %v", tc.caseDesc, string(s), err)
 			}
 		}

--- a/pkg/types/cose/cose_test.go
+++ b/pkg/types/cose/cose_test.go
@@ -44,7 +44,7 @@ func (u UnmarshalFailsTester) Unmarshal(_ models.ProposedEntry) error {
 	return errors.New("error")
 }
 
-func (u UnmarshalFailsTester) Verifier() (pki.PublicKey, error) {
+func (u UnmarshalFailsTester) Verifiers() ([]pki.PublicKey, error) {
 	return nil, nil
 }
 

--- a/pkg/types/cose/v0.0.1/entry.go
+++ b/pkg/types/cose/v0.0.1/entry.go
@@ -348,11 +348,15 @@ func (v V001Entry) CreateFromArtifactProperties(_ context.Context, props types.A
 	return &returnVal, nil
 }
 
-func (v V001Entry) Verifier() (pki.PublicKey, error) {
+func (v V001Entry) Verifiers() ([]pki.PublicKey, error) {
 	if v.CoseObj.PublicKey == nil {
 		return nil, errors.New("cose v0.0.1 entry not initialized")
 	}
-	return x509.NewPublicKey(bytes.NewReader(*v.CoseObj.PublicKey))
+	key, err := x509.NewPublicKey(bytes.NewReader(*v.CoseObj.PublicKey))
+	if err != nil {
+		return nil, err
+	}
+	return []pki.PublicKey{key}, nil
 }
 
 func (v V001Entry) Insertable() (bool, error) {

--- a/pkg/types/cose/v0.0.1/entry_test.go
+++ b/pkg/types/cose/v0.0.1/entry_test.go
@@ -278,10 +278,10 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 				}
 			}
 
-			verifier, err := v.Verifier()
+			verifiers, err := v.Verifiers()
 			if !tt.wantVerifierErr {
 				if err != nil {
-					s, _ := verifier.CanonicalValue()
+					s, _ := verifiers[0].CanonicalValue()
 					t.Errorf("%v: unexpected error for %v, got %v", tt.name, string(s), err)
 				}
 
@@ -305,12 +305,12 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 					}
 				}
 
-				pubV, _ := verifier.CanonicalValue()
+				pubV, _ := verifiers[0].CanonicalValue()
 				if !reflect.DeepEqual(pubV, pub) && !reflect.DeepEqual(pubV, pemBytes) {
 					t.Errorf("verifier and public keys do not match: %v, %v", string(pubV), string(pub))
 				}
 			} else if err == nil {
-				s, _ := verifier.CanonicalValue()
+				s, _ := verifiers[0].CanonicalValue()
 				t.Errorf("%v: expected error for %v, got %v", tt.name, string(s), err)
 			}
 		})

--- a/pkg/types/dsse/dsse_test.go
+++ b/pkg/types/dsse/dsse_test.go
@@ -44,7 +44,7 @@ func (u UnmarshalFailsTester) Unmarshal(_ models.ProposedEntry) error {
 	return errors.New("error")
 }
 
-func (u UnmarshalFailsTester) Verifier() (pki.PublicKey, error) {
+func (u UnmarshalFailsTester) Verifiers() ([]pki.PublicKey, error) {
 	return nil, nil
 }
 

--- a/pkg/types/dsse/v0.0.1/entry.go
+++ b/pkg/types/dsse/v0.0.1/entry.go
@@ -403,13 +403,20 @@ func verifyEnvelope(allPubKeyBytes [][]byte, env *dsse.Envelope) (map[string]*x5
 	return verifierBySig, nil
 }
 
-func (v V001Entry) Verifier() (pki.PublicKey, error) {
+func (v V001Entry) Verifiers() ([]pki.PublicKey, error) {
 	if len(v.DSSEObj.Signatures) == 0 {
 		return nil, errors.New("dsse v0.0.1 entry not initialized")
 	}
 
-	//TODO: return multiple pki.PublicKeys; sigstore/rekor issue #1278
-	return x509.NewPublicKey(bytes.NewReader(*v.DSSEObj.Signatures[0].Verifier))
+	var keys []pki.PublicKey
+	for _, s := range v.DSSEObj.Signatures {
+		key, err := x509.NewPublicKey(bytes.NewReader(*s.Verifier))
+		if err != nil {
+			return nil, err
+		}
+		keys = append(keys, key)
+	}
+	return keys, nil
 }
 
 func (v V001Entry) Insertable() (bool, error) {

--- a/pkg/types/entries.go
+++ b/pkg/types/entries.go
@@ -37,7 +37,7 @@ type EntryImpl interface {
 	Canonicalize(ctx context.Context) ([]byte, error) // marshal the canonical entry to be put into the tlog
 	Unmarshal(e models.ProposedEntry) error           // unmarshal the abstract entry into the specific struct for this versioned type
 	CreateFromArtifactProperties(context.Context, ArtifactProperties) (models.ProposedEntry, error)
-	Verifier() (pki.PublicKey, error)
+	Verifiers() ([]pki.PublicKey, error)
 	Insertable() (bool, error) // denotes whether the entry that was unmarshalled has the writeOnly fields required to validate and insert into the log
 }
 

--- a/pkg/types/hashedrekord/hashedrekord_test.go
+++ b/pkg/types/hashedrekord/hashedrekord_test.go
@@ -43,7 +43,7 @@ func (u UnmarshalFailsTester) Unmarshal(_ models.ProposedEntry) error {
 	return errors.New("error")
 }
 
-func (u UnmarshalFailsTester) Verifier() (pki.PublicKey, error) {
+func (u UnmarshalFailsTester) Verifiers() ([]pki.PublicKey, error) {
 	return nil, nil
 }
 

--- a/pkg/types/hashedrekord/v0.0.1/entry.go
+++ b/pkg/types/hashedrekord/v0.0.1/entry.go
@@ -246,11 +246,15 @@ func (v V001Entry) CreateFromArtifactProperties(_ context.Context, props types.A
 	return &returnVal, nil
 }
 
-func (v V001Entry) Verifier() (pki.PublicKey, error) {
+func (v V001Entry) Verifiers() ([]pki.PublicKey, error) {
 	if v.HashedRekordObj.Signature == nil || v.HashedRekordObj.Signature.PublicKey == nil || v.HashedRekordObj.Signature.PublicKey.Content == nil {
 		return nil, errors.New("hashedrekord v0.0.1 entry not initialized")
 	}
-	return x509.NewPublicKey(bytes.NewReader(v.HashedRekordObj.Signature.PublicKey.Content))
+	key, err := x509.NewPublicKey(bytes.NewReader(v.HashedRekordObj.Signature.PublicKey.Content))
+	if err != nil {
+		return nil, err
+	}
+	return []pki.PublicKey{key}, nil
 }
 
 func (v V001Entry) Insertable() (bool, error) {

--- a/pkg/types/hashedrekord/v0.0.1/entry_test.go
+++ b/pkg/types/hashedrekord/v0.0.1/entry_test.go
@@ -315,12 +315,12 @@ func TestCrossFieldValidation(t *testing.T) {
 			}
 		}
 
-		verifier, err := v.Verifier()
+		verifiers, err := v.Verifiers()
 		if tc.expectedVerifierSuccess {
 			if err != nil {
 				t.Errorf("%v: unexpected error, got %v", tc.caseDesc, err)
 			} else {
-				pub, _ := verifier.CanonicalValue()
+				pub, _ := verifiers[0].CanonicalValue()
 				// invalidKeyBytes is a valid ed25519 key
 				if !reflect.DeepEqual(pub, keyBytes) && !reflect.DeepEqual(pub, invalidKeyBytes) {
 					t.Errorf("verifier and public keys do not match: %v, %v", string(pub), string(keyBytes))
@@ -328,7 +328,7 @@ func TestCrossFieldValidation(t *testing.T) {
 			}
 		} else {
 			if err == nil {
-				s, _ := verifier.CanonicalValue()
+				s, _ := verifiers[0].CanonicalValue()
 				t.Errorf("%v: expected error for %v, got %v", tc.caseDesc, string(s), err)
 			}
 		}

--- a/pkg/types/helm/helm_test.go
+++ b/pkg/types/helm/helm_test.go
@@ -43,7 +43,7 @@ func (u UnmarshalFailsTester) Unmarshal(_ models.ProposedEntry) error {
 	return errors.New("error")
 }
 
-func (u UnmarshalFailsTester) Verifier() (pki.PublicKey, error) {
+func (u UnmarshalFailsTester) Verifiers() ([]pki.PublicKey, error) {
 	return nil, nil
 }
 

--- a/pkg/types/helm/v0.0.1/entry.go
+++ b/pkg/types/helm/v0.0.1/entry.go
@@ -349,11 +349,15 @@ func (v V001Entry) CreateFromArtifactProperties(ctx context.Context, props types
 	return &returnVal, nil
 }
 
-func (v V001Entry) Verifier() (pki.PublicKey, error) {
+func (v V001Entry) Verifiers() ([]pki.PublicKey, error) {
 	if v.HelmObj.PublicKey == nil || v.HelmObj.PublicKey.Content == nil {
 		return nil, errors.New("helm v0.0.1 entry not initialized")
 	}
-	return pgp.NewPublicKey(bytes.NewReader(*v.HelmObj.PublicKey.Content))
+	key, err := pgp.NewPublicKey(bytes.NewReader(*v.HelmObj.PublicKey.Content))
+	if err != nil {
+		return nil, err
+	}
+	return []pki.PublicKey{key}, nil
 }
 
 func (v V001Entry) Insertable() (bool, error) {

--- a/pkg/types/helm/v0.0.1/entry_test.go
+++ b/pkg/types/helm/v0.0.1/entry_test.go
@@ -211,20 +211,20 @@ func TestCrossFieldValidation(t *testing.T) {
 				}
 			}
 
-			verifier, err := v.Verifier()
+			verifiers, err := v.Verifiers()
 			if tc.expectedVerifierSuccess {
 				if err != nil {
 					t.Errorf("%v: unexpected error, got %v", tc.caseDesc, err)
 				} else {
 					// TODO: Improve this test once CanonicalValue returns same result as input for PGP keys
-					_, err := verifier.CanonicalValue()
+					_, err := verifiers[0].CanonicalValue()
 					if err != nil {
 						t.Errorf("%v: unexpected error getting canonical value, got %v", tc.caseDesc, err)
 					}
 				}
 			} else {
 				if err == nil {
-					s, _ := verifier.CanonicalValue()
+					s, _ := verifiers[0].CanonicalValue()
 					t.Errorf("%v: expected error for %v, got %v", tc.caseDesc, string(s), err)
 				}
 			}

--- a/pkg/types/intoto/intoto_test.go
+++ b/pkg/types/intoto/intoto_test.go
@@ -43,7 +43,7 @@ func (u UnmarshalFailsTester) Unmarshal(_ models.ProposedEntry) error {
 	return errors.New("error")
 }
 
-func (u UnmarshalFailsTester) Verifier() (pki.PublicKey, error) {
+func (u UnmarshalFailsTester) Verifiers() ([]pki.PublicKey, error) {
 	return nil, nil
 }
 

--- a/pkg/types/intoto/v0.0.1/entry.go
+++ b/pkg/types/intoto/v0.0.1/entry.go
@@ -353,11 +353,15 @@ func (v V001Entry) CreateFromArtifactProperties(_ context.Context, props types.A
 	return &returnVal, nil
 }
 
-func (v V001Entry) Verifier() (pki.PublicKey, error) {
+func (v V001Entry) Verifiers() ([]pki.PublicKey, error) {
 	if v.IntotoObj.PublicKey == nil {
 		return nil, errors.New("intoto v0.0.1 entry not initialized")
 	}
-	return x509.NewPublicKey(bytes.NewReader(*v.IntotoObj.PublicKey))
+	key, err := x509.NewPublicKey(bytes.NewReader(*v.IntotoObj.PublicKey))
+	if err != nil {
+		return nil, err
+	}
+	return []pki.PublicKey{key}, nil
 }
 
 func (v V001Entry) Insertable() (bool, error) {

--- a/pkg/types/intoto/v0.0.1/entry_test.go
+++ b/pkg/types/intoto/v0.0.1/entry_test.go
@@ -336,19 +336,19 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 					t.Errorf("index keys from hydrated object do not match those generated from canonicalized (and re-hydrated) object: %v %v", got, canonicalIndexKeys)
 				}
 
-				verifier, err := v.Verifier()
+				verifiers, err := v.Verifiers()
 				if !tt.wantVerifierErr {
 					if err != nil {
 						t.Errorf("%v: unexpected error, got %v", tt.name, err)
 					} else {
-						pubV, _ := verifier.CanonicalValue()
+						pubV, _ := verifiers[0].CanonicalValue()
 						if !reflect.DeepEqual(pubV, pub) && !reflect.DeepEqual(pubV, pemBytes) {
 							t.Errorf("verifier and public keys do not match: %v, %v", string(pubV), string(pub))
 						}
 					}
 				} else {
 					if err == nil {
-						s, _ := verifier.CanonicalValue()
+						s, _ := verifiers[0].CanonicalValue()
 						t.Errorf("%v: expected error for %v, got %v", tt.name, string(s), err)
 					}
 				}

--- a/pkg/types/intoto/v0.0.2/entry.go
+++ b/pkg/types/intoto/v0.0.2/entry.go
@@ -457,7 +457,7 @@ func verifyEnvelope(allPubKeyBytes [][]byte, env *dsse.Envelope) (map[string]*x5
 	return verifierBySig, nil
 }
 
-func (v V002Entry) Verifier() (pki.PublicKey, error) {
+func (v V002Entry) Verifiers() ([]pki.PublicKey, error) {
 	if v.IntotoObj.Content == nil || v.IntotoObj.Content.Envelope == nil {
 		return nil, errors.New("intoto v0.0.2 entry not initialized")
 	}
@@ -467,7 +467,15 @@ func (v V002Entry) Verifier() (pki.PublicKey, error) {
 		return nil, errors.New("no signatures found on intoto entry")
 	}
 
-	return x509.NewPublicKey(bytes.NewReader(*v.IntotoObj.Content.Envelope.Signatures[0].PublicKey))
+	var keys []pki.PublicKey
+	for _, s := range v.IntotoObj.Content.Envelope.Signatures {
+		key, err := x509.NewPublicKey(bytes.NewReader(*s.PublicKey))
+		if err != nil {
+			return nil, err
+		}
+		keys = append(keys, key)
+	}
+	return keys, nil
 }
 
 func (v V002Entry) Insertable() (bool, error) {

--- a/pkg/types/intoto/v0.0.2/entry_test.go
+++ b/pkg/types/intoto/v0.0.2/entry_test.go
@@ -377,19 +377,19 @@ func TestV002Entry_Unmarshal(t *testing.T) {
 					t.Errorf("index keys from hydrated object do not match those generated from canonicalized (and re-hydrated) object: %v %v", got, canonicalIndexKeys)
 				}
 
-				verifier, err := v.Verifier()
+				verifiers, err := v.Verifiers()
 				if !tt.wantVerifierErr {
 					if err != nil {
 						t.Errorf("%v: unexpected error, got %v", tt.name, err)
 					} else {
-						pubV, _ := verifier.CanonicalValue()
+						pubV, _ := verifiers[0].CanonicalValue()
 						if !reflect.DeepEqual(pubV, pub) && !reflect.DeepEqual(pubV, pemBytes) {
 							t.Errorf("verifier and public keys do not match: %v, %v", string(pubV), string(pub))
 						}
 					}
 				} else {
 					if err == nil {
-						s, _ := verifier.CanonicalValue()
+						s, _ := verifiers[0].CanonicalValue()
 						t.Errorf("%v: expected error for %v, got %v", tt.name, string(s), err)
 					}
 				}

--- a/pkg/types/jar/jar_test.go
+++ b/pkg/types/jar/jar_test.go
@@ -42,7 +42,7 @@ func (u UnmarshalFailsTester) Unmarshal(_ models.ProposedEntry) error {
 	return errors.New("error")
 }
 
-func (u UnmarshalFailsTester) Verifier() (pki.PublicKey, error) {
+func (u UnmarshalFailsTester) Verifiers() ([]pki.PublicKey, error) {
 	return nil, nil
 }
 

--- a/pkg/types/jar/v0.0.1/entry.go
+++ b/pkg/types/jar/v0.0.1/entry.go
@@ -338,11 +338,15 @@ func (v *V001Entry) CreateFromArtifactProperties(ctx context.Context, props type
 	return &returnVal, nil
 }
 
-func (v V001Entry) Verifier() (pki.PublicKey, error) {
+func (v V001Entry) Verifiers() ([]pki.PublicKey, error) {
 	if v.JARModel.Signature == nil || v.JARModel.Signature.PublicKey == nil || v.JARModel.Signature.PublicKey.Content == nil {
 		return nil, errors.New("jar v0.0.1 entry not initialized")
 	}
-	return x509.NewPublicKey(bytes.NewReader(*v.JARModel.Signature.PublicKey.Content))
+	key, err := x509.NewPublicKey(bytes.NewReader(*v.JARModel.Signature.PublicKey.Content))
+	if err != nil {
+		return nil, err
+	}
+	return []pki.PublicKey{key}, nil
 }
 
 func (v V001Entry) Insertable() (bool, error) {

--- a/pkg/types/jar/v0.0.1/entry_test.go
+++ b/pkg/types/jar/v0.0.1/entry_test.go
@@ -142,19 +142,19 @@ Hr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ==
 			}
 		}
 
-		verifier, err := v.Verifier()
+		verifiers, err := v.Verifiers()
 		if tc.expectedVerifierSuccess {
 			if err != nil {
 				t.Errorf("%v: unexpected error, got %v", tc.caseDesc, err)
 			} else {
-				pub, _ := verifier.CanonicalValue()
+				pub, _ := verifiers[0].CanonicalValue()
 				if !reflect.DeepEqual(pub, []byte(certificate)) {
 					t.Errorf("verifier and public keys do not match: %v, %v", string(pub), certificate)
 				}
 			}
 		} else {
 			if err == nil {
-				s, _ := verifier.CanonicalValue()
+				s, _ := verifiers[0].CanonicalValue()
 				t.Errorf("%v: expected error for %v, got %v", tc.caseDesc, string(s), err)
 			}
 		}

--- a/pkg/types/rekord/rekord_test.go
+++ b/pkg/types/rekord/rekord_test.go
@@ -43,7 +43,7 @@ func (u UnmarshalFailsTester) Unmarshal(_ models.ProposedEntry) error {
 	return errors.New("error")
 }
 
-func (u UnmarshalFailsTester) Verifier() (pki.PublicKey, error) {
+func (u UnmarshalFailsTester) Verifiers() ([]pki.PublicKey, error) {
 	return nil, nil
 }
 

--- a/pkg/types/rekord/v0.0.1/entry_test.go
+++ b/pkg/types/rekord/v0.0.1/entry_test.go
@@ -258,13 +258,13 @@ func TestCrossFieldValidation(t *testing.T) {
 			}
 		}
 
-		verifier, err := v.Verifier()
+		verifiers, err := v.Verifiers()
 		if tc.expectedVerifierSuccess {
 			if err != nil {
 				t.Errorf("%v: unexpected error, got %v", tc.caseDesc, err)
 			} else {
 				// TODO: Improve this test once CanonicalValue returns same result as input for PGP keys
-				_, err := verifier.CanonicalValue()
+				_, err := verifiers[0].CanonicalValue()
 				if err != nil {
 					t.Errorf("%v: unexpected error getting canonical value, got %v", tc.caseDesc, err)
 				}
@@ -272,7 +272,7 @@ func TestCrossFieldValidation(t *testing.T) {
 
 		} else {
 			if err == nil {
-				s, _ := verifier.CanonicalValue()
+				s, _ := verifiers[0].CanonicalValue()
 				t.Errorf("%v: expected error for %v, got %v", tc.caseDesc, string(s), err)
 			}
 		}

--- a/pkg/types/rfc3161/rfc3161_test.go
+++ b/pkg/types/rfc3161/rfc3161_test.go
@@ -43,7 +43,7 @@ func (u UnmarshalFailsTester) Unmarshal(_ models.ProposedEntry) error {
 	return errors.New("error")
 }
 
-func (u UnmarshalFailsTester) Verifier() (pki.PublicKey, error) {
+func (u UnmarshalFailsTester) Verifiers() ([]pki.PublicKey, error) {
 	return nil, nil
 }
 

--- a/pkg/types/rfc3161/v0.0.1/entry.go
+++ b/pkg/types/rfc3161/v0.0.1/entry.go
@@ -207,8 +207,8 @@ func (v V001Entry) CreateFromArtifactProperties(_ context.Context, props types.A
 	return &returnVal, nil
 }
 
-func (v V001Entry) Verifier() (pki.PublicKey, error) {
-	return nil, errors.New("Verifier() does not support rfc3161 entry type")
+func (v V001Entry) Verifiers() ([]pki.PublicKey, error) {
+	return nil, errors.New("Verifiers() does not support rfc3161 entry type")
 }
 
 func (v V001Entry) Insertable() (bool, error) {

--- a/pkg/types/rpm/rpm_test.go
+++ b/pkg/types/rpm/rpm_test.go
@@ -43,7 +43,7 @@ func (u UnmarshalFailsTester) Unmarshal(_ models.ProposedEntry) error {
 	return errors.New("error")
 }
 
-func (u UnmarshalFailsTester) Verifier() (pki.PublicKey, error) {
+func (u UnmarshalFailsTester) Verifiers() ([]pki.PublicKey, error) {
 	return nil, nil
 }
 

--- a/pkg/types/rpm/v0.0.1/entry.go
+++ b/pkg/types/rpm/v0.0.1/entry.go
@@ -371,11 +371,15 @@ func (v V001Entry) CreateFromArtifactProperties(ctx context.Context, props types
 	return &returnVal, nil
 }
 
-func (v V001Entry) Verifier() (pki.PublicKey, error) {
+func (v V001Entry) Verifiers() ([]pki.PublicKey, error) {
 	if v.RPMModel.PublicKey == nil || v.RPMModel.PublicKey.Content == nil {
 		return nil, errors.New("rpm v0.0.1 entry not initialized")
 	}
-	return pgp.NewPublicKey(bytes.NewReader(*v.RPMModel.PublicKey.Content))
+	key, err := pgp.NewPublicKey(bytes.NewReader(*v.RPMModel.PublicKey.Content))
+	if err != nil {
+		return nil, err
+	}
+	return []pki.PublicKey{key}, nil
 }
 
 func (v V001Entry) Insertable() (bool, error) {

--- a/pkg/types/rpm/v0.0.1/entry_test.go
+++ b/pkg/types/rpm/v0.0.1/entry_test.go
@@ -196,20 +196,20 @@ func TestCrossFieldValidation(t *testing.T) {
 			}
 		}
 
-		verifier, err := v.Verifier()
+		verifiers, err := v.Verifiers()
 		if tc.expectVerifierSuccess {
 			if err != nil {
 				t.Errorf("%v: unexpected error, got %v", tc.caseDesc, err)
 			} else {
 				// TODO: Improve this test once CanonicalValue returns same result as input for PGP keys
-				_, err := verifier.CanonicalValue()
+				_, err := verifiers[0].CanonicalValue()
 				if err != nil {
 					t.Errorf("%v: unexpected error getting canonical value, got %v", tc.caseDesc, err)
 				}
 			}
 		} else {
 			if err == nil {
-				s, _ := verifier.CanonicalValue()
+				s, _ := verifiers[0].CanonicalValue()
 				t.Errorf("%v: expected error for %v, got %v", tc.caseDesc, string(s), err)
 			}
 		}

--- a/pkg/types/test_util.go
+++ b/pkg/types/test_util.go
@@ -31,7 +31,7 @@ func (u BaseUnmarshalTester) NewEntry() EntryImpl {
 	return &BaseUnmarshalTester{}
 }
 
-func (u BaseUnmarshalTester) Verifier() (pki.PublicKey, error) {
+func (u BaseUnmarshalTester) Verifiers() ([]pki.PublicKey, error) {
 	return nil, nil
 }
 

--- a/pkg/types/tuf/tuf_test.go
+++ b/pkg/types/tuf/tuf_test.go
@@ -39,7 +39,7 @@ func (u UnmarshalFailsTester) NewEntry() types.EntryImpl {
 	return &UnmarshalFailsTester{}
 }
 
-func (u UnmarshalFailsTester) Verifier() (pki.PublicKey, error) {
+func (u UnmarshalFailsTester) Verifiers() ([]pki.PublicKey, error) {
 	return nil, nil
 }
 

--- a/pkg/types/tuf/v0.0.1/entry.go
+++ b/pkg/types/tuf/v0.0.1/entry.go
@@ -369,7 +369,7 @@ func (v V001Entry) CreateFromArtifactProperties(ctx context.Context, props types
 	return &returnVal, nil
 }
 
-func (v V001Entry) Verifier() (pki.PublicKey, error) {
+func (v V001Entry) Verifiers() ([]pki.PublicKey, error) {
 	if v.TufObj.Root == nil {
 		return nil, errors.New("tuf v0.0.1 entry not initialized")
 	}
@@ -377,7 +377,11 @@ func (v V001Entry) Verifier() (pki.PublicKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ptuf.NewPublicKey(bytes.NewReader(keyBytes))
+	key, err := ptuf.NewPublicKey(bytes.NewReader(keyBytes))
+	if err != nil {
+		return nil, err
+	}
+	return []pki.PublicKey{key}, nil
 }
 
 func (v V001Entry) Insertable() (bool, error) {

--- a/pkg/types/tuf/v0.0.1/entry_test.go
+++ b/pkg/types/tuf/v0.0.1/entry_test.go
@@ -228,12 +228,12 @@ func TestCrossFieldValidation(t *testing.T) {
 				// Insertable on canonicalized content is variable so we skip testing it here
 			}
 
-			verifier, err := v.Verifier()
+			verifiers, err := v.Verifiers()
 			if tc.expectVerifierSuccess {
 				if err != nil {
 					t.Errorf("%v: unexpected error, got %v", tc.caseDesc, err)
 				} else {
-					pub, _ := verifier.CanonicalValue()
+					pub, _ := verifiers[0].CanonicalValue()
 					rootBytes := new(bytes.Buffer)
 					if err := json.Compact(rootBytes, keyBytes); err != nil {
 						t.Fatal(err)
@@ -244,7 +244,7 @@ func TestCrossFieldValidation(t *testing.T) {
 				}
 			} else {
 				if err == nil {
-					s, _ := verifier.CanonicalValue()
+					s, _ := verifiers[0].CanonicalValue()
 					t.Errorf("%v: expected error for %v, got %v", tc.caseDesc, string(s), err)
 				}
 			}


### PR DESCRIPTION
This supports DSSE and intoto types that allow for multiple keys/signatures.

Fixes https://github.com/sigstore/rekor/issues/1278

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
