### PR TITLE
Change values of Identity.Raw, add fingerprints

### DIFF
--- a/pkg/pki/identity/identity.go
+++ b/pkg/pki/identity/identity.go
@@ -15,11 +15,24 @@
 package identity
 
 type Identity struct {
-	// Types include: *rsa.PublicKey, *ecdsa.PublicKey, ed25519.PublicKey,
-	// *x509.Certificate, openpgp.EntityList, *minisign.PublicKey, ssh.PublicKey
+	// Types include:
+	// - *rsa.PublicKey
+	// - *ecdsa.PublicKey
+	// - ed25519.PublicKey
+	// - *x509.Certificate
+	// - openpgp.EntityList (golang.org/x/crypto/openpgp)
+	// - *minisign.PublicKey (github.com/jedisct1/go-minisign)
+	// - ssh.PublicKey (golang.org/x/crypto/ssh)
 	Crypto any
-	// Based on type of Crypto. Possible values include: PEM-encoded public key,
-	// PEM-encoded certificate, canonicalized PGP public key, encoded Minisign
-	// public key, encoded SSH public key
+	// Raw key or certificate extracted from Crypto. Values include:
+	// - PKIX ASN.1 DER-encoded public key
+	// - ASN.1 DER-encoded certificate
 	Raw []byte
+	// For keys, certificates, and minisign, hex-encoded SHA-256 digest
+	// of the public key or certificate
+	// For SSH and PGP, Fingerprint is the standard for each ecosystem
+	// For SSH, unpadded base-64 encoded SHA-256 digest of the key
+	// For PGP, hex-encoded SHA-1 digest of a key, which can be either
+	// a primary key or subkey
+	Fingerprint string
 }

--- a/pkg/pki/minisign/minisign.go
+++ b/pkg/pki/minisign/minisign.go
@@ -17,13 +17,17 @@ package minisign
 
 import (
 	"bytes"
+	"crypto/ed25519"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"strings"
 
 	minisign "github.com/jedisct1/go-minisign"
 	"github.com/sigstore/rekor/pkg/pki/identity"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	sigsig "github.com/sigstore/sigstore/pkg/signature"
 	"golang.org/x/crypto/blake2b"
 )
@@ -186,10 +190,15 @@ func (k PublicKey) Subjects() []string {
 
 // Identities implements the pki.PublicKey interface
 func (k PublicKey) Identities() ([]identity.Identity, error) {
-	// returns base64-encoded key (sig alg, key ID, and public key)
-	key, err := k.CanonicalValue()
+	// PKIX encode ed25519 public key
+	pkixKey, err := cryptoutils.MarshalPublicKeyToDER(ed25519.PublicKey(k.key.PublicKey[:]))
 	if err != nil {
 		return nil, err
 	}
-	return []identity.Identity{{Crypto: k.key, Raw: key}}, nil
+	digest := sha256.Sum256(pkixKey)
+	return []identity.Identity{{
+		Crypto:      k.key,
+		Raw:         pkixKey,
+		Fingerprint: hex.EncodeToString(digest[:]),
+	}}, nil
 }

--- a/pkg/pki/pgp/pgp.go
+++ b/pkg/pki/pgp/pgp.go
@@ -19,6 +19,10 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -32,6 +36,7 @@ import (
 	"golang.org/x/crypto/openpgp/packet" //nolint:staticcheck
 
 	"github.com/sigstore/rekor/pkg/pki/identity"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	sigsig "github.com/sigstore/sigstore/pkg/signature"
 )
 
@@ -307,9 +312,33 @@ func (k PublicKey) Subjects() []string {
 
 // Identities implements the pki.PublicKey interface
 func (k PublicKey) Identities() ([]identity.Identity, error) {
-	key, err := k.CanonicalValue()
-	if err != nil {
-		return nil, err
+	var ids []identity.Identity
+	for _, entity := range k.key {
+		var keys []*packet.PublicKey
+		keys = append(keys, entity.PrimaryKey)
+		for _, subKey := range entity.Subkeys {
+			keys = append(keys, subKey.PublicKey)
+		}
+		for _, pk := range keys {
+			pubKey := pk.PublicKey
+			// Only process supported types. Will ignore DSA
+			// and ElGamal keys.
+			// TODO: For a V2 PGP type, enforce on upload
+			switch pubKey.(type) {
+			case *rsa.PublicKey, *ecdsa.PublicKey, ed25519.PublicKey:
+			default:
+				continue
+			}
+			pkixKey, err := cryptoutils.MarshalPublicKeyToDER(pubKey)
+			if err != nil {
+				return nil, err
+			}
+			ids = append(ids, identity.Identity{
+				Crypto:      pubKey,
+				Raw:         pkixKey,
+				Fingerprint: hex.EncodeToString(pk.Fingerprint[:]),
+			})
+		}
 	}
-	return []identity.Identity{{Crypto: k.key, Raw: key}}, nil
+	return ids, nil
 }

--- a/pkg/pki/pgp/pgp_test.go
+++ b/pkg/pki/pgp/pgp_test.go
@@ -27,7 +27,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/sigstore/rekor/pkg/pki/identity"
 	"go.uber.org/goleak"
 )
 
@@ -348,6 +347,9 @@ func TestEmailAddresses(t *testing.T) {
 		caseDesc  string
 		inputFile string
 		subjects  []string
+		// number of keys in key ring
+		// verified with gpg, ignoring DSA/ElGamal keys
+		keys int
 	}
 
 	var k PublicKey
@@ -355,10 +357,10 @@ func TestEmailAddresses(t *testing.T) {
 		t.Errorf("Subjects for unitialized key should give empty slice")
 	}
 	tests := []test{
-		{caseDesc: "Valid armored public key", inputFile: "testdata/valid_armored_public.pgp", subjects: []string{}},
-		{caseDesc: "Valid armored public key with multiple subentries", inputFile: "testdata/valid_armored_complex_public.pgp", subjects: []string{"linux-packages-keymaster@google.com", "linux-packages-keymaster@google.com"}},
-		{caseDesc: "Valid binary public key", inputFile: "testdata/valid_binary_public.pgp", subjects: []string{}},
-		{caseDesc: "Valid binary public key with multiple subentries", inputFile: "testdata/valid_binary_complex_public.pgp", subjects: []string{"linux-packages-keymaster@google.com", "linux-packages-keymaster@google.com"}},
+		{caseDesc: "Valid armored public key", inputFile: "testdata/valid_armored_public.pgp", subjects: []string{}, keys: 2},
+		{caseDesc: "Valid armored public key with multiple subentries", inputFile: "testdata/valid_armored_complex_public.pgp", subjects: []string{"linux-packages-keymaster@google.com", "linux-packages-keymaster@google.com"}, keys: 4},
+		{caseDesc: "Valid binary public key", inputFile: "testdata/valid_binary_public.pgp", subjects: []string{}, keys: 2},
+		{caseDesc: "Valid binary public key with multiple subentries", inputFile: "testdata/valid_binary_complex_public.pgp", subjects: []string{"linux-packages-keymaster@google.com", "linux-packages-keymaster@google.com"}, keys: 4},
 	}
 
 	for _, tc := range tests {
@@ -388,14 +390,12 @@ func TestEmailAddresses(t *testing.T) {
 			t.Errorf("%v: Error getting subjects from keys length, got %v, expected %v", tc.caseDesc, len(subjects), len(tc.subjects))
 		}
 
-		keyVal, _ := inputKey.CanonicalValue()
-		expectedIDs := []identity.Identity{{Crypto: inputKey.key, Raw: keyVal}}
 		ids, err := inputKey.Identities()
 		if err != nil {
-			t.Fatalf("unexpected error getting identities: %v", err)
+			t.Fatalf("%v: unexpected error getting identities: %v", tc.caseDesc, err)
 		}
-		if !reflect.DeepEqual(ids, expectedIDs) {
-			t.Errorf("identities are not equal")
+		if len(ids) != tc.keys {
+			t.Fatalf("%v: expected %d keys, got %d", tc.caseDesc, tc.keys, len(ids))
 		}
 	}
 }

--- a/pkg/pki/ssh/ssh_test.go
+++ b/pkg/pki/ssh/ssh_test.go
@@ -44,6 +44,9 @@ func TestIdentities(t *testing.T) {
 
 	keyVal := expectedKey.(ssh.CryptoPublicKey).CryptoPublicKey()
 	pkixKey, err := cryptoutils.MarshalPublicKeyToDER(keyVal)
+	if err != nil {
+		t.Fatal(err)
+	}
 	ids, err := pub.Identities()
 	if err != nil {
 		t.Fatal(err)
@@ -51,7 +54,7 @@ func TestIdentities(t *testing.T) {
 	if len(ids) != 1 {
 		t.Errorf("too many identities, expected 1, got %v", len(ids))
 	}
-	if !reflect.DeepEqual(ids[0].Crypto.(ssh.PublicKey).Marshal(), expectedKey.(ssh.PublicKey).Marshal()) {
+	if !reflect.DeepEqual(ids[0].Crypto.(ssh.PublicKey).Marshal(), expectedKey.Marshal()) {
 		t.Errorf("certificates did not match")
 	}
 	if !reflect.DeepEqual(ids[0].Raw, pkixKey) {

--- a/pkg/pki/ssh/ssh_test.go
+++ b/pkg/pki/ssh/ssh_test.go
@@ -15,12 +15,13 @@
 package ssh
 
 import (
+	"encoding/base64"
 	"math/rand"
 	"reflect"
 	"strings"
 	"testing"
 
-	"github.com/sigstore/rekor/pkg/pki/identity"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -41,8 +42,8 @@ func TestIdentities(t *testing.T) {
 		t.Fatalf("expected email address as subject, got %v", pub.Subjects())
 	}
 
-	keyVal := "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDXofkiahE7uavjWvxnwkUF27qMgz7pdTwzSv0XzVG6EtirOv3PDWct4YKoXE9c0EqbxnIfYEKwEextdvB7zkgwczdJSHxf/18jQumLn/FuoCmugVSk1H5Qli/qzwBpaTnOk3WuakGuoYUl8ZAokKKgOKLA0aZJ1WRQ2ZCZggA3EkwNZiY17y9Q6HqdgQcH6XN8aAMADNVJdMAJb33hSRJjjsAPTmzBTishP8lYDoGRSsSE7/8XRBCEV5E4I8mI9GElcZwV/1KJx98mpH8QvMzXM1idFcwPRtt1NTAOshwgUU0Fu1x8lU5RQIa6ZKW36qNQLvLxy/BscC7B/mdLptoDs/ot9NimUXZcgCR1a2Q3o7Wi6jIgcgJcyV10Nba81ol4RdN4qPHnVZIzuo+dBkqwG3CMtB4Rj84+Qi+7zyU01hIPreoxQDXaayiGPBUUIiAlW9gsiuRWJzNnu3cvuWDLVfQIkjh7Wug58z+v2NOJ7IMdyERillhzDcvVHaq14+U="
-	expectedID := identity.Identity{Crypto: expectedKey, Raw: []byte(keyVal)}
+	keyVal := expectedKey.(ssh.CryptoPublicKey).CryptoPublicKey()
+	pkixKey, err := cryptoutils.MarshalPublicKeyToDER(keyVal)
 	ids, err := pub.Identities()
 	if err != nil {
 		t.Fatal(err)
@@ -50,11 +51,16 @@ func TestIdentities(t *testing.T) {
 	if len(ids) != 1 {
 		t.Errorf("too many identities, expected 1, got %v", len(ids))
 	}
-	if !reflect.DeepEqual(ids[0].Crypto.(ssh.PublicKey).Marshal(), expectedID.Crypto.(ssh.PublicKey).Marshal()) {
+	if !reflect.DeepEqual(ids[0].Crypto.(ssh.PublicKey).Marshal(), expectedKey.(ssh.PublicKey).Marshal()) {
 		t.Errorf("certificates did not match")
 	}
-	if !reflect.DeepEqual(ids[0].Raw, expectedID.Raw) {
-		t.Errorf("raw identities did not match, expected %v, got %v", string(ids[0].Raw), string(expectedID.Raw))
+	if !reflect.DeepEqual(ids[0].Raw, pkixKey) {
+		t.Errorf("raw identities did not match, expected %v, got %v", string(pkixKey), string(ids[0].Raw))
+	}
+	// removing "SHA256:" prefix
+	fp, _ := base64.RawStdEncoding.DecodeString(ids[0].Fingerprint[7:])
+	if len(fp) != 32 {
+		t.Errorf("fingerprint is not expected length of 32 (32-byte sha256): %d", len(fp))
 	}
 }
 


### PR DESCRIPTION
Raw now contains only PKIX public keys or DER encoded certificates. The keys are extracted from minisign, pgp, and TUF verifiers.

Also added fingerprints for each verifier. Keys, certificates, and ed25519 keys from minisign are hex-encoded sha-256 digests of the raw key. SSH and PGP use their ecosystem-standard fingerprints.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
