### PR TITLE
Extract all subjects from SANs for x509 verifier

### DIFF
--- a/pkg/pki/x509/x509.go
+++ b/pkg/pki/x509/x509.go
@@ -195,7 +195,7 @@ func (k PublicKey) EmailAddresses() []string {
 
 // Subjects implements the pki.PublicKey interface
 func (k PublicKey) Subjects() []string {
-	var names []string
+	var subjects []string
 	var cert *x509.Certificate
 	if k.cert != nil {
 		cert = k.cert.c
@@ -203,23 +203,9 @@ func (k PublicKey) Subjects() []string {
 		cert = k.certs[0]
 	}
 	if cert != nil {
-		validate := validator.New()
-		for _, name := range cert.EmailAddresses {
-			if errs := validate.Var(name, "required,email"); errs == nil {
-				names = append(names, strings.ToLower(name))
-			}
-		}
-		for _, name := range cert.URIs {
-			if errs := validate.Var(name.String(), "required,uri"); errs == nil {
-				names = append(names, strings.ToLower(name.String()))
-			}
-		}
-		otherName, _ := cryptoutils.UnmarshalOtherNameSAN(cert.Extensions)
-		if len(otherName) > 0 {
-			names = append(names, otherName)
-		}
+		subjects = cryptoutils.GetSubjectAlternateNames(cert)
 	}
-	return names
+	return subjects
 }
 
 // Identities implements the pki.PublicKey interface

--- a/pkg/pki/x509/x509_test.go
+++ b/pkg/pki/x509/x509_test.go
@@ -250,9 +250,9 @@ func TestSignature_VerifyFail(t *testing.T) {
 func TestPublicKeyWithCertChain(t *testing.T) {
 	rootCert, rootKey, _ := testutils.GenerateRootCa()
 	subCert, subKey, _ := testutils.GenerateSubordinateCa(rootCert, rootKey)
-	subjectUrl, _ := url.Parse("https://github.com/slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@refs/tags/v1.1.1")
+	subjectURL, _ := url.Parse("https://github.com/slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@refs/tags/v1.1.1")
 	leafCert, leafKey, _ := testutils.GenerateLeafCertWithSubjectAlternateNames(
-		[]string{"example.com"}, []string{"subject@example.com"}, []net.IP{{1, 1, 1, 1}}, []*url.URL{subjectUrl}, "oidc-issuer", subCert, subKey)
+		[]string{"example.com"}, []string{"subject@example.com"}, []net.IP{{1, 1, 1, 1}}, []*url.URL{subjectURL}, "oidc-issuer", subCert, subKey)
 	leafCertPEM, _ := cryptoutils.MarshalCertificateToPEM(leafCert)
 
 	pemCertChain, err := cryptoutils.MarshalCertificatesToPEM([]*x509.Certificate{leafCert, subCert, rootCert})


### PR DESCRIPTION
This was previously in Identities(), but was dropped during the refactor.

Validation is also handled during certificate creation, so the contents of the x509 cert should follow rfc5280.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
