### PR TITLE
Allow parsing base64-encoded TUF metadata and root content

### DIFF
--- a/pkg/types/tuf/v0.0.1/entry_test.go
+++ b/pkg/types/tuf/v0.0.1/entry_test.go
@@ -19,6 +19,7 @@ package tuf
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"os"
 	"reflect"
@@ -135,6 +136,22 @@ func TestCrossFieldValidation(t *testing.T) {
 					},
 					Metadata: &models.TUFV001SchemaMetadata{
 						Content: dataContent,
+					},
+				},
+			},
+			expectUnmarshalSuccess:    true,
+			expectCanonicalizeSuccess: true,
+			expectVerifierSuccess:     true,
+		},
+		{
+			caseDesc: "root with manifest & content base64-encoded",
+			entry: V001Entry{
+				TufObj: models.TUFV001Schema{
+					Root: &models.TUFV001SchemaRoot{
+						Content: base64.StdEncoding.EncodeToString(keyBytes),
+					},
+					Metadata: &models.TUFV001SchemaMetadata{
+						Content: base64.StdEncoding.EncodeToString(dataBytes),
 					},
 				},
 			},


### PR DESCRIPTION
Because these fields are specified as objects, they can either be data.Signed{} structs when initially created, or base64-encoded strings after canonicalization and being constructed from the leaf node value.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
