### PR TITLE
Update .ko.yaml

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # We need a shell for a lot of redirection/piping to work
-defaultBaseImage: gcr.io/distroless/base:debug-nonroot
+defaultBaseImage: gcr.io/distroless/base-debian12:debug-nonroot
 
 builds:
 - id: rekor-server

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -13,8 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# We need a shell for a lot of redirection/piping to work
-defaultBaseImage: gcr.io/distroless/base-debian12:debug-nonroot
+defaultBaseImage: gcr.io/distroless/static-debian12:nonroot
 
 builds:
 - id: rekor-server


### PR DESCRIPTION
Use debian12 base image

Open questions?
- [ ] do we need libssl? if not we should use `base-nossl-debian12:debug-nonroot`
- [ ] what's all this redirecting piping stuff going on? is that comment still relevant?