### PR TITLE
chore: fix `backfill-redis` Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ rekor-server: $(SRCS)
 	CGO_ENABLED=0 go build -trimpath -ldflags "$(SERVER_LDFLAGS)" -o rekor-server ./cmd/rekor-server
 
 backfill-redis: $(SRCS)
-	CGO_ENABLED=0 go build -trimpath -ldflags "$(SERVER_LDFLAGS)" -o rekor-server ./cmd/backfill-redis
+	CGO_ENABLED=0 go build -trimpath -ldflags "$(SERVER_LDFLAGS)" -o backfill-redis ./cmd/backfill-redis
 
 test:
 	go test ./...


### PR DESCRIPTION
This commit makes a minor change to the Makefile's `backfill-redis` target to output a binary named `backfill-redis`, fixing what was probably a simple copy/paste error when the target was introduced.

Fixes: https://github.com/sigstore/rekor/issues/1684

#### Summary

The `backfill-redis` Makefile target outputs a binary with the name `rekor-server` instead of `backfill-redis`.


#### Release Note

NONE

#### Documentation

NONE