### PR TITLE
Correct index creation

### DIFF
--- a/scripts/storage.sql
+++ b/scripts/storage.sql
@@ -129,7 +129,7 @@ CREATE TABLE IF NOT EXISTS SequencedLeafData(
 );
 
 
-CREATE INDEX SequencedLeafMerkleIdx
+CREATE INDEX IF NOT EXISTS SequencedLeafMerkleIdx
   ON SequencedLeafData(TreeId, MerkleLeafHash);
 
 CREATE TABLE IF NOT EXISTS Unsequenced(


### PR DESCRIPTION
#### Summary
Corrects an issue upon Trillian db schema creation where an index creation is not idempotent 

#### Release Note

* Ensure Trillian db creation for `SequencedLeafMerkleIdx` is idempotent  