### PR TITLE
make e2e tests more usable with docker-compose

### DIFF
--- a/e2e-test.sh
+++ b/e2e-test.sh
@@ -17,12 +17,17 @@
 set -e
 testdir=$(dirname "$0")
 
+docker_compose="docker compose -f docker-compose.yml -f docker-compose.test.yml"
+if ! ${docker_compose} version 2&>1 >/dev/null; then
+    docker_compose="docker-compose -f docker-compose.yml -f docker-compose.test.yml"
+fi
+
 rm -f /tmp/pkg-rekor-*.cov
 echo "installing gocovmerge"
 make gocovmerge
 docker kill $(docker ps -q) || true
 echo "starting services"
-docker-compose -f docker-compose.yml -f docker-compose.test.yml up -d --build
+${docker_compose} up -d --build
 
 echo "building CLI and server"
 # set the path to the root of the repo
@@ -32,7 +37,7 @@ go test -c ./cmd/rekor-server -o rekor-server -covermode=count -coverpkg=./...
 
 count=0
 echo -n "waiting up to 120 sec for system to start"
-until [ $(docker-compose ps | grep -c "(healthy)") == 3 ];
+until [ $(${docker_compose} ps | grep -c "(healthy)") == 4 ];
 do
     if [ $count -eq 12 ]; then
        echo "! timeout reached"
@@ -51,23 +56,23 @@ cp $dir/rekor-cli $REKORTMPDIR/rekor-cli
 touch $REKORTMPDIR.rekor.yaml
 trap "rm -rf $REKORTMPDIR" EXIT
 if ! REKORTMPDIR=$REKORTMPDIR go test  -tags=e2e $(go list ./... | grep -v ./tests) ; then
-   docker-compose logs --no-color > /tmp/docker-compose.log
+   ${docker_compose} logs --no-color > /tmp/docker-compose.log
    exit 1
 fi
-if docker-compose logs --no-color | grep -q "panic: runtime error:" ; then
+if ${docker_compose} logs --no-color | grep -q "panic: runtime error:" ; then
    # if we're here, we found a panic
    echo "Failing due to panics detected in logs"
-   docker-compose logs --no-color > /tmp/docker-compose.log
+   ${docker_compose} logs --no-color > /tmp/docker-compose.log
    exit 1
 fi
 
 echo "generating code coverage"
-docker-compose restart rekor-server
+${docker_compose} restart rekor-server
 
-if ! docker cp $(docker ps -aqf "name=rekor_rekor-server"):go/rekor-server.cov /tmp/pkg-rekor-server.cov ; then
+if ! docker cp $(docker ps -aqf "name=rekor_rekor-server" -f "name=rekor-rekor-server"):go/rekor-server.cov /tmp/pkg-rekor-server.cov ; then
    # failed to copy code coverage report from server
    echo "Failed to retrieve server code coverage report"
-   docker-compose logs --no-color > /tmp/docker-compose.log
+   ${docker_compose} logs --no-color > /tmp/docker-compose.log
    exit 1
 fi
 

--- a/e2e-test.sh
+++ b/e2e-test.sh
@@ -25,7 +25,11 @@ fi
 rm -f /tmp/pkg-rekor-*.cov
 echo "installing gocovmerge"
 make gocovmerge
+
+echo "building test-only containers"
+docker build -t gcp-pubsub-emulator -f Dockerfile.pubsub-emulator .
 docker kill $(docker ps -q) || true
+
 echo "starting services"
 ${docker_compose} up -d --build
 

--- a/tests/e2e-test.sh
+++ b/tests/e2e-test.sh
@@ -17,6 +17,11 @@
 set -e
 testdir=$(dirname "$0")
 
+docker_compose="docker compose -f docker-compose.yml -f docker-compose.test.yml"
+if ! ${docker_compose} version 2&>1 >/dev/null; then
+    docker_compose="docker-compose -f docker-compose.yml -f docker-compose.test.yml"
+fi
+
 rm -f /tmp/rekor-*.cov
 
 echo "installing gocovmerge"
@@ -26,7 +31,7 @@ echo "building test-only containers"
 docker build -t gcp-pubsub-emulator -f Dockerfile.pubsub-emulator .
 
 echo "starting services"
-docker compose -f docker-compose.yml -f docker-compose.test.yml up -d --build
+${docker_compose} up -d --build
 
 echo "building CLI and server"
 go test -c ./cmd/rekor-cli -o rekor-cli -cover -covermode=count -coverpkg=./...
@@ -35,8 +40,8 @@ go test -c ./cmd/rekor-server -o rekor-server -covermode=count -coverpkg=./...
 count=0
 
 echo "waiting up to 2 min for system to start"
-until [ $(docker compose ps | \
-   grep -E "(rekor-mysql|rekor-redis|rekor-server|gcp-pubsub-emulator)" | \
+until [ $(${docker_compose} ps | \
+   grep -E "(rekor[-_]mysql|rekor[-_]redis|rekor[-_]rekor-server|rekor[-_]gcp-pubsub-emulator)" | \
    grep -c "(healthy)" ) == 4 ];
 do
     if [ $count -eq 24 ]; then
@@ -55,33 +60,27 @@ REKORTMPDIR="$(mktemp -d -t rekor_test.XXXXXX)"
 touch $REKORTMPDIR.rekor.yaml
 trap "rm -rf $REKORTMPDIR" EXIT
 if ! REKORTMPDIR=$REKORTMPDIR go test -tags=e2e ./tests/ -run TestIssue1308; then
-   docker compose logs --no-color > /tmp/docker compose.log
+   ${docker_compose} logs --no-color > /tmp/docker-compose.log
    exit 1
 fi
 if ! REKORTMPDIR=$REKORTMPDIR PUBSUB_EMULATOR_HOST=localhost:8085 go test -tags=e2e ./tests/; then 
-   docker compose logs --no-color > /tmp/docker compose.log
+   ${docker_compose} logs --no-color > /tmp/docker-compose.log
    exit 1
 fi
-if docker compose logs --no-color | grep -q "panic: runtime error:" ; then
+if ${docker_compose} logs --no-color | grep -q "panic: runtime error:" ; then
    # if we're here, we found a panic
    echo "Failing due to panics detected in logs"
-   docker compose logs --no-color > /tmp/docker compose.log
+   ${docker_compose} logs --no-color > /tmp/docker-compose.log
    exit 1
 fi
 
 echo "generating code coverage"
-docker compose restart rekor-server
+${docker_compose} restart rekor-server
 
-# docker compose appears to name the containers slightly differently in GHA CI vs locally on macOS
-container_name="rekor_rekor-server"
-if [[ "$(uname -s)" -eq "Darwin" ]]; then
-   container_name="rekor-rekor-server"
-fi
-
-if ! docker cp $(docker ps -aqf "name=${container_name}"):/go/rekor-server.cov /tmp/rekor-server.cov ; then
+if ! docker cp $(docker ps -aqf "name=rekor_rekor-server" -f "name=rekor-rekor-server"):/go/rekor-server.cov /tmp/rekor-server.cov ; then
    # failed to copy code coverage report from server
    echo "Failed to retrieve server code coverage report"
-   docker compose logs --no-color > /tmp/docker compose.log
+   ${docker_compose} logs --no-color > /tmp/docker-compose.log
    exit 1
 fi
 


### PR DESCRIPTION
older versions of `docker-compose` are broken - this also cleans up some of the MacOS/linux differences as well as v1 vs v2 of docker compose.