### PR TITLE
Add method to get artifact hash for an entry

### DIFF
--- a/pkg/types/alpine/v0.0.1/entry.go
+++ b/pkg/types/alpine/v0.0.1/entry.go
@@ -362,6 +362,13 @@ func (v V001Entry) Verifiers() ([]pki.PublicKey, error) {
 	return []pki.PublicKey{key}, nil
 }
 
+func (v V001Entry) ArtifactHash() (string, error) {
+	if v.AlpineModel.Package == nil || v.AlpineModel.Package.Hash == nil || v.AlpineModel.Package.Hash.Value == nil || v.AlpineModel.Package.Hash.Algorithm == nil {
+		return "", errors.New("alpine v0.0.1 entry not initialized")
+	}
+	return strings.ToLower(fmt.Sprintf("%s:%s", *v.AlpineModel.Package.Hash.Algorithm, *v.AlpineModel.Package.Hash.Value)), nil
+}
+
 func (v V001Entry) Insertable() (bool, error) {
 	if v.AlpineModel.Package == nil {
 		return false, fmt.Errorf("missing package entry")

--- a/pkg/types/alpine/v0.0.1/entry_test.go
+++ b/pkg/types/alpine/v0.0.1/entry_test.go
@@ -18,6 +18,8 @@ package alpine
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"reflect"
 	"testing"
@@ -176,6 +178,13 @@ func TestCrossFieldValidation(t *testing.T) {
 			}
 			if ok, err := ei.Insertable(); ok || err == nil {
 				t.Errorf("unexpected success calling Insertable on entry created from canonicalized content")
+			}
+			hash, err := ei.ArtifactHash()
+			expectedHash := sha256.Sum256(dataBytes)
+			if err != nil {
+				t.Errorf("unexpected failure with ArtifactHash: %v", err)
+			} else if hash != "sha256:"+hex.EncodeToString(expectedHash[:]) {
+				t.Errorf("unexpected match with ArtifactHash: %s", hash)
 			}
 		}
 

--- a/pkg/types/cose/v0.0.1/entry.go
+++ b/pkg/types/cose/v0.0.1/entry.go
@@ -359,6 +359,13 @@ func (v V001Entry) Verifiers() ([]pki.PublicKey, error) {
 	return []pki.PublicKey{key}, nil
 }
 
+func (v V001Entry) ArtifactHash() (string, error) {
+	if v.CoseObj.Data == nil || v.CoseObj.Data.PayloadHash == nil || v.CoseObj.Data.PayloadHash.Value == nil || v.CoseObj.Data.PayloadHash.Algorithm == nil {
+		return "", errors.New("cose v0.0.1 entry not initialized")
+	}
+	return strings.ToLower(fmt.Sprintf("%s:%s", *v.CoseObj.Data.PayloadHash.Algorithm, *v.CoseObj.Data.PayloadHash.Value)), nil
+}
+
 func (v V001Entry) Insertable() (bool, error) {
 	if len(v.CoseObj.Message) == 0 {
 		return false, errors.New("missing COSE Sign1 message")

--- a/pkg/types/cose/v0.0.1/entry_test.go
+++ b/pkg/types/cose/v0.0.1/entry_test.go
@@ -303,6 +303,13 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 						if ok, err := ei.Insertable(); ok || err == nil {
 							t.Errorf("entry created from canonicalized entry should not also be insertable")
 						}
+						hash, err := ei.ArtifactHash()
+						expectedHash := sha256.Sum256([]byte("hello"))
+						if err != nil {
+							t.Errorf("unexpected failure with ArtifactHash: %v", err)
+						} else if hash != "sha256:"+hex.EncodeToString(expectedHash[:]) {
+							t.Errorf("unexpected match with ArtifactHash: %s", hash)
+						}
 					}
 				}
 

--- a/pkg/types/dsse/v0.0.1/entry.go
+++ b/pkg/types/dsse/v0.0.1/entry.go
@@ -419,6 +419,13 @@ func (v V001Entry) Verifiers() ([]pki.PublicKey, error) {
 	return keys, nil
 }
 
+func (v V001Entry) ArtifactHash() (string, error) {
+	if v.DSSEObj.PayloadHash == nil || v.DSSEObj.PayloadHash.Algorithm == nil || v.DSSEObj.PayloadHash.Value == nil {
+		return "", errors.New("dsse v0.0.1 entry not initialized")
+	}
+	return strings.ToLower(fmt.Sprintf("%s:%s", *v.DSSEObj.PayloadHash.Algorithm, *v.DSSEObj.PayloadHash.Value)), nil
+}
+
 func (v V001Entry) Insertable() (bool, error) {
 	if v.DSSEObj.ProposedContent == nil {
 		return false, errors.New("missing proposed content")

--- a/pkg/types/dsse/v0.0.1/entry_test.go
+++ b/pkg/types/dsse/v0.0.1/entry_test.go
@@ -306,6 +306,14 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 					t.Errorf("index keys from hydrated object do not match those generated from canonicalized (and re-hydrated) object: %v %v", got, canonicalIndexKeys)
 				}
 
+				hash, err := canonicalV001.ArtifactHash()
+				expectedHash := sha256.Sum256([]byte(validPayload))
+				if err != nil {
+					t.Errorf("unexpected failure with ArtifactHash: %v", err)
+				} else if hash != "sha256:"+hex.EncodeToString(expectedHash[:]) {
+					t.Errorf("unexpected match with ArtifactHash: %s", hash)
+				}
+
 				return nil
 			}
 			if err := uv(); (err != nil) != tt.wantErr {

--- a/pkg/types/entries.go
+++ b/pkg/types/entries.go
@@ -37,8 +37,9 @@ type EntryImpl interface {
 	Canonicalize(ctx context.Context) ([]byte, error) // marshal the canonical entry to be put into the tlog
 	Unmarshal(e models.ProposedEntry) error           // unmarshal the abstract entry into the specific struct for this versioned type
 	CreateFromArtifactProperties(context.Context, ArtifactProperties) (models.ProposedEntry, error)
-	Verifiers() ([]pki.PublicKey, error)
-	Insertable() (bool, error) // denotes whether the entry that was unmarshalled has the writeOnly fields required to validate and insert into the log
+	Verifiers() ([]pki.PublicKey, error) // list of keys or certificates that can verify an entry's signature
+	ArtifactHash() (string, error)       // hex-encoded artifact hash prefixed with hash name, e.g. sha256:abcdef
+	Insertable() (bool, error)           // denotes whether the entry that was unmarshalled has the writeOnly fields required to validate and insert into the log
 }
 
 // EntryWithAttestationImpl specifies the behavior of a versioned type that also stores attestations

--- a/pkg/types/hashedrekord/hashedrekord_test.go
+++ b/pkg/types/hashedrekord/hashedrekord_test.go
@@ -47,6 +47,10 @@ func (u UnmarshalFailsTester) Verifiers() ([]pki.PublicKey, error) {
 	return nil, nil
 }
 
+func (u UnmarshalFailsTester) ArtifactHash() (string, error) {
+	return "", nil
+}
+
 func TestRekordType(t *testing.T) {
 	// empty to start
 	if VersionMap.Count() != 0 {

--- a/pkg/types/hashedrekord/v0.0.1/entry.go
+++ b/pkg/types/hashedrekord/v0.0.1/entry.go
@@ -257,6 +257,13 @@ func (v V001Entry) Verifiers() ([]pki.PublicKey, error) {
 	return []pki.PublicKey{key}, nil
 }
 
+func (v V001Entry) ArtifactHash() (string, error) {
+	if v.HashedRekordObj.Data == nil || v.HashedRekordObj.Data.Hash == nil || v.HashedRekordObj.Data.Hash.Value == nil || v.HashedRekordObj.Data.Hash.Algorithm == nil {
+		return "", errors.New("hashedrekord v0.0.1 entry not initialized")
+	}
+	return strings.ToLower(fmt.Sprintf("%s:%s", *v.HashedRekordObj.Data.Hash.Algorithm, *v.HashedRekordObj.Data.Hash.Value)), nil
+}
+
 func (v V001Entry) Insertable() (bool, error) {
 	if v.HashedRekordObj.Signature == nil {
 		return false, errors.New("missing signature property")

--- a/pkg/types/hashedrekord/v0.0.1/entry_test.go
+++ b/pkg/types/hashedrekord/v0.0.1/entry_test.go
@@ -289,6 +289,13 @@ func TestCrossFieldValidation(t *testing.T) {
 			if !ok || err != nil {
 				t.Errorf("unexpected failure in testing insertable on valid entry: %v", err)
 			}
+
+			hash, err := v.ArtifactHash()
+			if err != nil {
+				t.Errorf("unexpected failure with ArtifactHash: %v", err)
+			} else if hash != "sha256:"+dataSHA {
+				t.Errorf("unexpected match with ArtifactHash: %s", hash)
+			}
 		}
 
 		b, err := v.Canonicalize(context.TODO())
@@ -312,6 +319,12 @@ func TestCrossFieldValidation(t *testing.T) {
 			ok, err := ei.Insertable()
 			if !ok || err != nil {
 				t.Errorf("unexpected failure in testing insertable on entry created from canonicalized content: %v", err)
+			}
+			hash, err := ei.ArtifactHash()
+			if err != nil {
+				t.Errorf("unexpected failure with ArtifactHash: %v", err)
+			} else if hash != "sha256:"+dataSHA {
+				t.Errorf("unexpected match with ArtifactHash: %s", hash)
 			}
 		}
 

--- a/pkg/types/helm/v0.0.1/entry.go
+++ b/pkg/types/helm/v0.0.1/entry.go
@@ -360,6 +360,13 @@ func (v V001Entry) Verifiers() ([]pki.PublicKey, error) {
 	return []pki.PublicKey{key}, nil
 }
 
+func (v V001Entry) ArtifactHash() (string, error) {
+	if v.HelmObj.Chart == nil || v.HelmObj.Chart.Hash == nil || v.HelmObj.Chart.Hash.Algorithm == nil || v.HelmObj.Chart.Hash.Value == nil {
+		return "", errors.New("helm v0.0.1 entry not initialized")
+	}
+	return strings.ToLower(fmt.Sprintf("%s:%s", *v.HelmObj.Chart.Hash.Algorithm, *v.HelmObj.Chart.Hash.Value)), nil
+}
+
 func (v V001Entry) Insertable() (bool, error) {
 	if v.HelmObj.PublicKey == nil {
 		return false, errors.New("missing public key property")

--- a/pkg/types/helm/v0.0.1/entry_test.go
+++ b/pkg/types/helm/v0.0.1/entry_test.go
@@ -209,6 +209,12 @@ func TestCrossFieldValidation(t *testing.T) {
 				if ok, err := ei.Insertable(); ok || err == nil {
 					t.Errorf("unexpected success calling Insertable on entry created from canonicalized content")
 				}
+				hash, err := ei.ArtifactHash()
+				if err != nil {
+					t.Errorf("unexpected failure with ArtifactHash: %v", err)
+				} else if hash != "sha256:6dec7ea21e655d5796c1e214cfb75b73428b2abfa2e66c8f7bc64ff4a7b3b29f" {
+					t.Errorf("unexpected match with ArtifactHash: %s", hash)
+				}
 			}
 
 			verifiers, err := v.Verifiers()

--- a/pkg/types/intoto/v0.0.1/entry.go
+++ b/pkg/types/intoto/v0.0.1/entry.go
@@ -364,6 +364,13 @@ func (v V001Entry) Verifiers() ([]pki.PublicKey, error) {
 	return []pki.PublicKey{key}, nil
 }
 
+func (v V001Entry) ArtifactHash() (string, error) {
+	if v.IntotoObj.Content == nil || v.IntotoObj.Content.PayloadHash == nil || v.IntotoObj.Content.PayloadHash.Algorithm == nil || v.IntotoObj.Content.PayloadHash.Value == nil {
+		return "", errors.New("hashedrekord v0.0.1 entry not initialized")
+	}
+	return strings.ToLower(fmt.Sprintf("%s:%s", *v.IntotoObj.Content.PayloadHash.Algorithm, *v.IntotoObj.Content.PayloadHash.Value)), nil
+}
+
 func (v V001Entry) Insertable() (bool, error) {
 	if v.IntotoObj.Content == nil {
 		return false, errors.New("missing content property")

--- a/pkg/types/intoto/v0.0.1/entry_test.go
+++ b/pkg/types/intoto/v0.0.1/entry_test.go
@@ -336,6 +336,14 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 					t.Errorf("index keys from hydrated object do not match those generated from canonicalized (and re-hydrated) object: %v %v", got, canonicalIndexKeys)
 				}
 
+				hash, err := canonicalV001.ArtifactHash()
+				expectedHash := sha256.Sum256([]byte(validPayload))
+				if err != nil {
+					t.Errorf("unexpected failure with ArtifactHash: %v", err)
+				} else if hash != "sha256:"+hex.EncodeToString(expectedHash[:]) {
+					t.Errorf("unexpected match with ArtifactHash: %s", hash)
+				}
+
 				verifiers, err := v.Verifiers()
 				if !tt.wantVerifierErr {
 					if err != nil {

--- a/pkg/types/intoto/v0.0.2/entry.go
+++ b/pkg/types/intoto/v0.0.2/entry.go
@@ -478,6 +478,13 @@ func (v V002Entry) Verifiers() ([]pki.PublicKey, error) {
 	return keys, nil
 }
 
+func (v V002Entry) ArtifactHash() (string, error) {
+	if v.IntotoObj.Content == nil || v.IntotoObj.Content.PayloadHash == nil || v.IntotoObj.Content.PayloadHash.Algorithm == nil || v.IntotoObj.Content.PayloadHash.Value == nil {
+		return "", errors.New("intoto v0.0.2 entry not initialized")
+	}
+	return strings.ToLower(fmt.Sprintf("%s:%s", *v.IntotoObj.Content.PayloadHash.Algorithm, *v.IntotoObj.Content.PayloadHash.Value)), nil
+}
+
 func (v V002Entry) Insertable() (bool, error) {
 	if v.IntotoObj.Content == nil {
 		return false, errors.New("missing content property")

--- a/pkg/types/intoto/v0.0.2/entry_test.go
+++ b/pkg/types/intoto/v0.0.2/entry_test.go
@@ -377,6 +377,14 @@ func TestV002Entry_Unmarshal(t *testing.T) {
 					t.Errorf("index keys from hydrated object do not match those generated from canonicalized (and re-hydrated) object: %v %v", got, canonicalIndexKeys)
 				}
 
+				hash, err := canonicalV002.ArtifactHash()
+				expectedHash := sha256.Sum256([]byte(validPayload))
+				if err != nil {
+					t.Errorf("unexpected failure with ArtifactHash: %v", err)
+				} else if hash != "sha256:"+hex.EncodeToString(expectedHash[:]) {
+					t.Errorf("unexpected match with ArtifactHash: %s", hash)
+				}
+
 				verifiers, err := v.Verifiers()
 				if !tt.wantVerifierErr {
 					if err != nil {

--- a/pkg/types/jar/v0.0.1/entry.go
+++ b/pkg/types/jar/v0.0.1/entry.go
@@ -349,6 +349,13 @@ func (v V001Entry) Verifiers() ([]pki.PublicKey, error) {
 	return []pki.PublicKey{key}, nil
 }
 
+func (v V001Entry) ArtifactHash() (string, error) {
+	if v.JARModel.Archive == nil || v.JARModel.Archive.Hash == nil || v.JARModel.Archive.Hash.Value == nil || v.JARModel.Archive.Hash.Algorithm == nil {
+		return "", errors.New("jar v0.0.1 entry not initialized")
+	}
+	return strings.ToLower(fmt.Sprintf("%s:%s", *v.JARModel.Archive.Hash.Algorithm, *v.JARModel.Archive.Hash.Value)), nil
+}
+
 func (v V001Entry) Insertable() (bool, error) {
 	if v.JARModel.Archive == nil {
 		return false, errors.New("missing archive property")

--- a/pkg/types/jar/v0.0.1/entry_test.go
+++ b/pkg/types/jar/v0.0.1/entry_test.go
@@ -140,6 +140,12 @@ Hr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ==
 			if ok, err := ei.Insertable(); ok || err == nil {
 				t.Errorf("unexpected err from calling Insertable on entry created from canonicalized content")
 			}
+			hash, err := ei.ArtifactHash()
+			if err != nil {
+				t.Errorf("unexpected failure with ArtifactHash: %v", err)
+			} else if hash != "sha256:4a9d0ab4e10597497ed6c4617c983c35fa9e964e75cdd6f9fae3a0da1929acc6" {
+				t.Errorf("unexpected match with ArtifactHash: %s", hash)
+			}
 		}
 
 		verifiers, err := v.Verifiers()

--- a/pkg/types/rekord/v0.0.1/entry.go
+++ b/pkg/types/rekord/v0.0.1/entry.go
@@ -450,6 +450,13 @@ func (v V001Entry) Verifiers() ([]pki.PublicKey, error) {
 	return []pki.PublicKey{key}, nil
 }
 
+func (v V001Entry) ArtifactHash() (string, error) {
+	if v.RekordObj.Data == nil || v.RekordObj.Data.Hash == nil || v.RekordObj.Data.Hash.Value == nil || v.RekordObj.Data.Hash.Algorithm == nil {
+		return "", errors.New("rekord v0.0.1 entry not initialized")
+	}
+	return strings.ToLower(fmt.Sprintf("%s:%s", *v.RekordObj.Data.Hash.Algorithm, *v.RekordObj.Data.Hash.Value)), nil
+}
+
 func (v V001Entry) Insertable() (bool, error) {
 	if v.RekordObj.Signature == nil {
 		return false, errors.New("missing signature property")

--- a/pkg/types/rekord/v0.0.1/entry_test.go
+++ b/pkg/types/rekord/v0.0.1/entry_test.go
@@ -18,6 +18,8 @@ package rekord
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"reflect"
 	"testing"
@@ -255,6 +257,13 @@ func TestCrossFieldValidation(t *testing.T) {
 			}
 			if ok, err := ei.Insertable(); ok || err == nil {
 				t.Errorf("unexpected success calling Insertable on entry created from canonicalized content")
+			}
+			hash, err := ei.ArtifactHash()
+			expectedHash := sha256.Sum256(dataBytes)
+			if err != nil {
+				t.Errorf("unexpected failure with ArtifactHash: %v", err)
+			} else if hash != "sha256:"+hex.EncodeToString(expectedHash[:]) {
+				t.Errorf("unexpected match with ArtifactHash: %s", hash)
 			}
 		}
 

--- a/pkg/types/rfc3161/v0.0.1/entry.go
+++ b/pkg/types/rfc3161/v0.0.1/entry.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/sigstore/rekor/pkg/pki"
 	"github.com/sigstore/rekor/pkg/types/rfc3161"
@@ -209,6 +210,18 @@ func (v V001Entry) CreateFromArtifactProperties(_ context.Context, props types.A
 
 func (v V001Entry) Verifiers() ([]pki.PublicKey, error) {
 	return nil, errors.New("Verifiers() does not support rfc3161 entry type")
+}
+
+func (v V001Entry) ArtifactHash() (string, error) {
+	if v.Rfc3161Obj.Tsr == nil || v.Rfc3161Obj.Tsr.Content == nil {
+		return "", errors.New("rfc3161 v0.0.1 entry not initialized")
+	}
+	tsrDecoded, err := base64.StdEncoding.DecodeString(v.Rfc3161Obj.Tsr.Content.String())
+	if err != nil {
+		return "", err
+	}
+	h := sha256.Sum256(tsrDecoded)
+	return strings.ToLower(fmt.Sprintf("sha256:%s", hex.EncodeToString(h[:]))), nil
 }
 
 func (v V001Entry) Insertable() (bool, error) {

--- a/pkg/types/rfc3161/v0.0.1/entry_test.go
+++ b/pkg/types/rfc3161/v0.0.1/entry_test.go
@@ -197,6 +197,12 @@ func TestCrossFieldValidation(t *testing.T) {
 			if ok, err := ei.Insertable(); !ok || err != nil {
 				t.Errorf("unexpected error calling insertable on entry created from canonicalized content")
 			}
+			hash, err := ei.ArtifactHash()
+			if err != nil {
+				t.Errorf("unexpected failure with ArtifactHash: %v", err)
+			} else if hash != "sha256:6dbda791c778454d0baa96e1dec5fa2c50867fd22d119ebe75c60c513b254c91" {
+				t.Errorf("unexpected match with ArtifactHash: %s", hash)
+			}
 		}
 	}
 }

--- a/pkg/types/rpm/v0.0.1/entry.go
+++ b/pkg/types/rpm/v0.0.1/entry.go
@@ -382,6 +382,13 @@ func (v V001Entry) Verifiers() ([]pki.PublicKey, error) {
 	return []pki.PublicKey{key}, nil
 }
 
+func (v V001Entry) ArtifactHash() (string, error) {
+	if v.RPMModel.Package == nil || v.RPMModel.Package.Hash == nil || v.RPMModel.Package.Hash.Value == nil || v.RPMModel.Package.Hash.Algorithm == nil {
+		return "", errors.New("rpm v0.0.1 entry not initialized")
+	}
+	return strings.ToLower(fmt.Sprintf("%s:%s", *v.RPMModel.Package.Hash.Algorithm, *v.RPMModel.Package.Hash.Value)), nil
+}
+
 func (v V001Entry) Insertable() (bool, error) {
 	if v.RPMModel.PublicKey == nil {
 		return false, errors.New("missing publicKey property")

--- a/pkg/types/rpm/v0.0.1/entry_test.go
+++ b/pkg/types/rpm/v0.0.1/entry_test.go
@@ -194,6 +194,12 @@ func TestCrossFieldValidation(t *testing.T) {
 			if ok, err := ei.Insertable(); ok || err == nil {
 				t.Errorf("unexpected success calling Insertable on entry created from canonicalized content")
 			}
+			hash, err := ei.ArtifactHash()
+			if err != nil {
+				t.Errorf("unexpected failure with ArtifactHash: %v", err)
+			} else if hash != "sha256:c8b0bc59708d74f53aab0089ac587d5c348d6ead143dab9f6d9c4b48c973bfd8" {
+				t.Errorf("unexpected match with ArtifactHash: %s", hash)
+			}
 		}
 
 		verifiers, err := v.Verifiers()

--- a/pkg/types/test_util.go
+++ b/pkg/types/test_util.go
@@ -31,6 +31,10 @@ func (u BaseUnmarshalTester) NewEntry() EntryImpl {
 	return &BaseUnmarshalTester{}
 }
 
+func (u BaseUnmarshalTester) ArtifactHash() (string, error) {
+	return "", nil
+}
+
 func (u BaseUnmarshalTester) Verifiers() ([]pki.PublicKey, error) {
 	return nil, nil
 }

--- a/pkg/types/tuf/v0.0.1/entry_test.go
+++ b/pkg/types/tuf/v0.0.1/entry_test.go
@@ -239,10 +239,17 @@ func TestCrossFieldValidation(t *testing.T) {
 				if err != nil {
 					t.Errorf("unexpected err from Unmarshalling canonicalized entry for '%v': %v", tc.caseDesc, err)
 				}
-				if _, err := types.UnmarshalEntry(pe); err != nil {
+				ei, err := types.UnmarshalEntry(pe)
+				if err != nil {
 					t.Errorf("unexpected err from type-specific unmarshalling for '%v': %v", tc.caseDesc, err)
 				}
 				// Insertable on canonicalized content is variable so we skip testing it here
+				hash, err := ei.ArtifactHash()
+				if err != nil {
+					t.Errorf("unexpected failure with ArtifactHash: %v", err)
+				} else if hash != "sha256:c170ae288c93f56031639bac1ad085fc47918346f733b3d76b07a8124ebd24f9" {
+					t.Errorf("unexpected match with ArtifactHash: %s", hash)
+				}
 			}
 
 			verifiers, err := v.Verifiers()


### PR DESCRIPTION
This can be used to get the entry's artifact hash without requiring unmarshaling the type.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
