### PR TITLE
Remove go-playground/validator dependency from pkg/pki

### DIFF
--- a/pkg/pki/pgp/pgp.go
+++ b/pkg/pki/pgp/pgp.go
@@ -28,7 +28,7 @@ import (
 	"io"
 	"net/http"
 
-	validator "github.com/go-playground/validator/v10"
+	"github.com/asaskevich/govalidator"
 
 	//TODO: https://github.com/sigstore/rekor/issues/286
 	"golang.org/x/crypto/openpgp"        //nolint:staticcheck
@@ -295,9 +295,7 @@ func (k PublicKey) EmailAddresses() []string {
 	// Extract from cert
 	for _, entity := range k.key {
 		for _, identity := range entity.Identities {
-			validate := validator.New()
-			errs := validate.Var(identity.UserId.Email, "required,email")
-			if errs == nil {
+			if govalidator.IsEmail(identity.UserId.Email) {
 				names = append(names, identity.UserId.Email)
 			}
 		}

--- a/pkg/pki/x509/x509.go
+++ b/pkg/pki/x509/x509.go
@@ -28,7 +28,7 @@ import (
 	"io"
 	"strings"
 
-	validator "github.com/go-playground/validator/v10"
+	"github.com/asaskevich/govalidator"
 	"github.com/sigstore/rekor/pkg/pki/identity"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	sigsig "github.com/sigstore/sigstore/pkg/signature"
@@ -184,10 +184,8 @@ func (k PublicKey) EmailAddresses() []string {
 		cert = k.certs[0]
 	}
 	if cert != nil {
-		validate := validator.New()
 		for _, name := range cert.EmailAddresses {
-			errs := validate.Var(name, "required,email")
-			if errs == nil {
+			if govalidator.IsEmail(name) {
 				names = append(names, strings.ToLower(name))
 			}
 		}


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

It might seem silly, but this reduces the size of sigstore-go by over 1 MB. See See https://github.com/sigstore/sigstore-go/issues/23.

We're already using asaskevich/govalidator elsewhere in Rekor, so no new dependencies added.

If we wanted to remove go-playground/validator entirely from Rekor (which would shrink rekor-cli by over 1 MB as well), we'd need additional work to rekor-cli/app/ files pflags.go and validate.go.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

N/A