### PR TITLE
update indexstorage interface to reduce roundtrips

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -195,7 +195,9 @@ func StopAPI() {
 	api.checkpointPublishCancel()
 
 	if api.newEntryPublisher != nil {
-		api.newEntryPublisher.Close()
+		if err := api.newEntryPublisher.Close(); err != nil {
+			log.Logger.Errorf("shutting down newEntryPublisher: %v", err)
+		}
 	}
 
 	if indexStorageClient != nil {


### PR DESCRIPTION
This changes the interface for `indexstorage` in two ways:

1. Adds a `Shutdown()` method to clean up resources upon server shutdown
2. Takes `[]string` on both read and write paths

The redis implementation now pipelines requests into a single roundtrip between Rekor and Redis on both the read and write path (where possible). 