### PR TITLE
update builder image to use go1.21.4 and bump golangci-lint to v1.55.x

### DIFF
--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -33,9 +33,9 @@ jobs:
     steps:
       - name: Check Signature
         run: |
-          cosign verify ghcr.io/gythialy/golang-cross:v1.21.3-0@sha256:6e2c885532ad276195d3e3f269055fb2742c8963b231d097c467758dd425a632 \
+          cosign verify ghcr.io/gythialy/golang-cross:v1.21.4-0@sha256:d18679c199db258cac9876a80abf9aff69485cf8a324bf547521f3de4cf3a366 \
           --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-          --certificate-identity "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/v1.21.3-0"
+          --certificate-identity "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/v1.21.4-0"
         env:
           TUF_ROOT: /tmp
 
@@ -44,7 +44,7 @@ jobs:
     needs:
       - check-signature
     container:
-      image: ghcr.io/gythialy/golang-cross:v1.21.3-0@sha256:6e2c885532ad276195d3e3f269055fb2742c8963b231d097c467758dd425a632
+      image: ghcr.io/gythialy/golang-cross:v1.21.4-0@sha256:d18679c199db258cac9876a80abf9aff69485cf8a324bf547521f3de4cf3a366
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -59,4 +59,4 @@ jobs:
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         timeout-minutes: 5
         with:
-          version: v1.54
+          version: v1.55

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -38,13 +38,13 @@ steps:
   - TUF_ROOT=/tmp
   args:
   - 'verify'
-  - 'ghcr.io/gythialy/golang-cross:v1.21.3-0@sha256:6e2c885532ad276195d3e3f269055fb2742c8963b231d097c467758dd425a632'
+  - 'ghcr.io/gythialy/golang-cross:v1.21.4-0@sha256:d18679c199db258cac9876a80abf9aff69485cf8a324bf547521f3de4cf3a366'
   - '--certificate-oidc-issuer'
   - "https://token.actions.githubusercontent.com"
   - '--certificate-identity'
-  - "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/v1.21.3-0"
+  - "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/v1.21.4-0"
 
-- name: ghcr.io/gythialy/golang-cross:v1.21.3-0@sha256:6e2c885532ad276195d3e3f269055fb2742c8963b231d097c467758dd425a632
+- name: ghcr.io/gythialy/golang-cross:v1.21.4-0@sha256:d18679c199db258cac9876a80abf9aff69485cf8a324bf547521f3de4cf3a366
   entrypoint: /bin/sh
   dir: "go/src/sigstore/rekor"
   env:
@@ -67,7 +67,7 @@ steps:
       gcloud auth configure-docker \
       && make release
 
-- name: ghcr.io/gythialy/golang-cross:v1.21.3-0@sha256:6e2c885532ad276195d3e3f269055fb2742c8963b231d097c467758dd425a632
+- name: ghcr.io/gythialy/golang-cross:v1.21.4-0@sha256:d18679c199db258cac9876a80abf9aff69485cf8a324bf547521f3de4cf3a366
   entrypoint: 'bash'
   dir: "go/src/sigstore/rekor"
   env:


### PR DESCRIPTION

#### Summary
- update builder image to use go1.21.4
- bump golangci-lint to v1.55.x