### PR TITLE
Add YAML tags to match the support indicated in the documentation

### DIFF
--- a/pkg/sharding/ranges.go
+++ b/pkg/sharding/ranges.go
@@ -39,9 +39,9 @@ type LogRanges struct {
 type Ranges []LogRange
 
 type LogRange struct {
-	TreeID           int64  `json:"treeID"`
-	TreeLength       int64  `json:"treeLength"`
-	EncodedPublicKey string `json:"encodedPublicKey"`
+	TreeID           int64  `json:"treeID" yaml:"treeID"`
+	TreeLength       int64  `json:"treeLength" yaml:"treeLength"`
+	EncodedPublicKey string `json:"encodedPublicKey" yaml:"encodedPublicKey"`
 	decodedPublicKey string
 }
 


### PR DESCRIPTION
#### Summary

Support is indicated for YAML, and the code attempts to do yaml first, however, based on the tags, only JSON is supported.

#### Release Note

(fix) add yaml tag

#### Documentation

No