### PR TITLE
fix: Do not check for pubsub.topics.get on initialization

### DIFF
--- a/pkg/pubsub/gcp/publisher.go
+++ b/pkg/pubsub/gcp/publisher.go
@@ -45,7 +45,6 @@ var (
 	// Minimal set of permissions needed to check if the server can publish to the configured topic.
 	// https://cloud.google.com/pubsub/docs/access-control#required_permissions
 	requiredIAMPermissions = []string{
-		"pubsub.topics.get",
 		"pubsub.topics.publish",
 	}
 )


### PR DESCRIPTION
This permission is not strictly needed and is not included in the `pubsub.publisher` role.

https://cloud.google.com/pubsub/docs/access-control#pubsub.publisher