### PR TITLE
Additional unique index correction

### DIFF
--- a/scripts/storage.sql
+++ b/scripts/storage.sql
@@ -75,7 +75,7 @@ CREATE TABLE IF NOT EXISTS TreeHead(
   FOREIGN KEY(TreeId) REFERENCES Trees(TreeId) ON DELETE CASCADE
 );
 
-CREATE UNIQUE INDEX TreeHeadRevisionIdx
+CREATE UNIQUE INDEX IF NOT EXISTS TreeHeadRevisionIdx
   ON TreeHead(TreeId, TreeRevision);
 
 -- ---------------------------------------------


### PR DESCRIPTION
#### Summary

Additional correction to storage init script to be idopoent 

relates to #1708

#### Release Note

* Ensure Trillian db creation for `TreeHeadRevisionIdx` is idempotent