### PR TITLE
Drop conditional when verifying entry checkpoint

### DIFF
--- a/pkg/verify/verify.go
+++ b/pkg/verify/verify.go
@@ -220,13 +220,9 @@ func VerifyLogEntry(ctx context.Context, e *models.LogEntryAnon, verifier signat
 		return err
 	}
 
-	// TODO: Add support for verifying consistency against an optional provided checkpoint.
-	// See https://github.com/sigstore/rekor/issues/988
-	// TODO: Remove conditional once checkpoint is always returned by server.
-	if e.Verification.InclusionProof.Checkpoint != nil {
-		if err := VerifyCheckpointSignature(e, verifier); err != nil {
-			return err
-		}
+	// Verify checkpoint, which includes a signed root hash.
+	if err := VerifyCheckpointSignature(e, verifier); err != nil {
+		return err
 	}
 
 	// Verify the Signed Entry Timestamp.


### PR DESCRIPTION
The log has been returning checkpoints for over a year now. Additionally, there should be no persisted bundles where the inclusion proof does not include a checkpoint, because it was marked as a required field from its inception.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

VerifyLogEntry now requires a checkpoint to verify an inclusion proof for an entry.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
