### PR TITLE
Fix panic for DSSE canonicalization

### DIFF
--- a/pkg/types/dsse/v0.0.1/entry.go
+++ b/pkg/types/dsse/v0.0.1/entry.go
@@ -276,6 +276,12 @@ func (v *V001Entry) Canonicalize(_ context.Context) ([]byte, error) {
 		ProposedContent: nil, // this is explicitly done as we don't want to canonicalize the envelope
 	}
 
+	for _, s := range canonicalEntry.Signatures {
+		if s.Signature == nil {
+			return nil, errors.New("canonical entry missing required signature")
+		}
+	}
+
 	sort.Slice(canonicalEntry.Signatures, func(i, j int) bool {
 		return *canonicalEntry.Signatures[i].Signature < *canonicalEntry.Signatures[j].Signature
 	})

--- a/pkg/types/dsse/v0.0.1/entry_test.go
+++ b/pkg/types/dsse/v0.0.1/entry_test.go
@@ -529,3 +529,12 @@ func TestInsertable(t *testing.T) {
 		})
 	}
 }
+
+func TestCanonicalizeHandlesInvalidInput(t *testing.T) {
+	v := &V001Entry{}
+	v.DSSEObj.Signatures = []*models.DSSEV001SchemaSignaturesItems0{{Signature: nil}, {Signature: nil}}
+	_, err := v.Canonicalize(context.TODO())
+	if err == nil {
+		t.Fatalf("expected error canonicalizing invalid input")
+	}
+}


### PR DESCRIPTION
Handles if the array of signatures contains missing data.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
