### PR TITLE
Add support for ed25519ph user keys in hashedrekord

### DIFF
--- a/pkg/pki/x509/x509.go
+++ b/pkg/pki/x509/x509.go
@@ -38,17 +38,23 @@ import (
 var EmailAddressOID asn1.ObjectIdentifier = []int{1, 2, 840, 113549, 1, 9, 1}
 
 type Signature struct {
-	signature []byte
+	signature        []byte
+	verifierLoadOpts []sigsig.LoadOption
 }
 
 // NewSignature creates and validates an x509 signature object
 func NewSignature(r io.Reader) (*Signature, error) {
+	return NewSignatureWithOpts(r)
+}
+
+func NewSignatureWithOpts(r io.Reader, opts ...sigsig.LoadOption) (*Signature, error) {
 	b, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}
 	return &Signature{
-		signature: b,
+		signature:        b,
+		verifierLoadOpts: opts,
 	}, nil
 }
 
@@ -84,7 +90,7 @@ func (s Signature) Verify(r io.Reader, k interface{}, opts ...sigsig.VerifyOptio
 		}
 	}
 
-	verifier, err := sigsig.LoadVerifier(p, crypto.SHA256)
+	verifier, err := sigsig.LoadVerifierWithOpts(p, s.verifierLoadOpts...)
 	if err != nil {
 		return err
 	}

--- a/pkg/types/hashedrekord/v0.0.1/entry.go
+++ b/pkg/types/hashedrekord/v0.0.1/entry.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"context"
 	"crypto"
-	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -148,7 +147,7 @@ func (v *V001Entry) validate() (pki.Signature, pki.PublicKey, error) {
 		return nil, nil, types.ValidationError(errors.New("missing signature"))
 	}
 	// Hashed rekord type only works for x509 signature types
-	sigObj, err := x509.NewSignature(bytes.NewReader(sig.Content))
+	sigObj, err := x509.NewSignatureWithOpts(bytes.NewReader(sig.Content), options.WithED25519ph())
 	if err != nil {
 		return nil, nil, types.ValidationError(err)
 	}
@@ -160,11 +159,6 @@ func (v *V001Entry) validate() (pki.Signature, pki.PublicKey, error) {
 	keyObj, err := x509.NewPublicKey(bytes.NewReader(key.Content))
 	if err != nil {
 		return nil, nil, types.ValidationError(err)
-	}
-
-	_, isEd25519 := keyObj.CryptoPubKey().(ed25519.PublicKey)
-	if isEd25519 {
-		return nil, nil, types.ValidationError(errors.New("ed25519 unsupported for hashedrekord"))
 	}
 
 	data := v.HashedRekordObj.Data


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
Add support for Ed25519ph user keys in hashedrekord type, so we can test #1724 better with 2 options (ecdsa+sha256 and ed25519ph).

This change requires https://github.com/sigstore/sigstore/pull/1595 and https://github.com/sigstore/rekor/pull/1959 .

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
* Added `x509.NewSignatureWithOpts` to support ED25519ph
* Allow ED25519 public keys when validating hashedrekord entries

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
