### PR TITLE
Change Redis value for locking mechanism

### DIFF
--- a/pkg/witness/publish_checkpoint.go
+++ b/pkg/witness/publish_checkpoint.go
@@ -151,7 +151,9 @@ func (c *CheckpointPublisher) publish(tc *trillianclient.TrillianClient, sTreeID
 
 	// return value ignored, which is whether or not the entry was set
 	// no error is thrown if the key already exists
-	successNX, err := c.redisClient.SetNX(ctx, key, hexCP, 0).Result()
+	// use smallest value as it's unused
+	value := true
+	successNX, err := c.redisClient.SetNX(ctx, key, value, 0).Result()
 	if err != nil {
 		c.reqCounter.With(
 			map[string]string{

--- a/pkg/witness/publish_checkpoint_test.go
+++ b/pkg/witness/publish_checkpoint_test.go
@@ -64,7 +64,7 @@ func TestPublishCheckpoint(t *testing.T) {
 
 	redisClient, mock := redismock.NewClientMock()
 	ts := time.Now().Truncate(time.Duration(freq) * time.Minute).UnixNano()
-	mock.Regexp().ExpectSetNX(fmt.Sprintf("%d/%d", treeID, ts), "[0-9a-fA-F]+", 0).SetVal(true)
+	mock.Regexp().ExpectSetNX(fmt.Sprintf("%d/%d", treeID, ts), true, 0).SetVal(true)
 	mock.Regexp().ExpectSet(fmt.Sprintf("%d/latest", treeID), "[0-9a-fA-F]+", 0).SetVal("OK")
 
 	publisher := NewCheckpointPublisher(context.Background(), mockTrillianLogClient, int64(treeID), hostname, signer, redisClient, uint(freq), counter)
@@ -119,7 +119,7 @@ func TestPublishCheckpointMultiple(t *testing.T) {
 
 	redisClient, mock := redismock.NewClientMock()
 	ts := time.Now().Truncate(time.Duration(freq) * time.Minute).UnixNano()
-	mock.Regexp().ExpectSetNX(fmt.Sprintf("%d/%d", treeID, ts), "[0-9a-fA-F]+", 0).SetVal(true)
+	mock.Regexp().ExpectSetNX(fmt.Sprintf("%d/%d", treeID, ts), true, 0).SetVal(true)
 	mock.Regexp().ExpectSet(fmt.Sprintf("%d/latest", treeID), "[0-9a-fA-F]+", 0).SetVal("OK")
 
 	publisher := NewCheckpointPublisher(context.Background(), mockTrillianLogClient, int64(treeID), hostname, signer, redisClient, uint(freq), counter)
@@ -128,7 +128,7 @@ func TestPublishCheckpointMultiple(t *testing.T) {
 	defer cancel()
 
 	redisClientEx, mockEx := redismock.NewClientMock()
-	mockEx.Regexp().ExpectSetNX(fmt.Sprintf("%d/%d", treeID, ts), "[0-9a-fA-F]+", 0).SetVal(false)
+	mockEx.Regexp().ExpectSetNX(fmt.Sprintf("%d/%d", treeID, ts), true, 0).SetVal(false)
 	publisherEx := NewCheckpointPublisher(context.Background(), mockTrillianLogClient, int64(treeID), hostname, signer, redisClientEx, uint(freq), counter)
 	ctxEx, cancelEx := context.WithCancel(context.Background())
 	publisherEx.StartPublisher(ctxEx)
@@ -255,7 +255,7 @@ func TestPublishCheckpointRedisFailure(t *testing.T) {
 
 	redisClient, mock := redismock.NewClientMock()
 	// error on first redis call
-	mock.Regexp().ExpectSetNX(".+", "[0-9a-fA-F]+", 0).SetErr(errors.New("redis error"))
+	mock.Regexp().ExpectSetNX(".+", true, 0).SetErr(errors.New("redis error"))
 
 	publisher := NewCheckpointPublisher(context.Background(), mockTrillianLogClient, int64(treeID), hostname, signer, redisClient, uint(freq), counter)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -298,7 +298,7 @@ func TestPublishCheckpointRedisLatestFailure(t *testing.T) {
 		Return(&trillian.GetLatestSignedLogRootResponse{SignedLogRoot: &trillian.SignedLogRoot{LogRoot: mRoot}}, nil)
 
 	redisClient, mock := redismock.NewClientMock()
-	mock.Regexp().ExpectSetNX(".+", "[0-9a-fA-F]+", 0).SetVal(true)
+	mock.Regexp().ExpectSetNX(".+", true, 0).SetVal(true)
 	// error on second redis call
 	mock.Regexp().ExpectSet(".*", "[0-9a-fA-F]+", 0).SetErr(errors.New("error"))
 


### PR DESCRIPTION
The lock value is never read. Only the key is used to determine if an instance has already created a checkpoint for a given period. Changing this to the smallest primitive value to reduce storage capacity needs.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
