### PR TITLE
add support for sha384 and sha512 to hashedrekord type

### DIFF
--- a/pkg/generated/models/hashedrekord_v001_schema.go
+++ b/pkg/generated/models/hashedrekord_v001_schema.go
@@ -277,10 +277,10 @@ type HashedrekordV001SchemaDataHash struct {
 
 	// The hashing function used to compute the hash value
 	// Required: true
-	// Enum: [sha256]
+	// Enum: [sha256 sha384 sha512]
 	Algorithm *string `json:"algorithm"`
 
-	// The hash value for the content
+	// The hash value for the content, as represented by a lower case hexadecimal string
 	// Required: true
 	Value *string `json:"value"`
 }
@@ -307,7 +307,7 @@ var hashedrekordV001SchemaDataHashTypeAlgorithmPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["sha256"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["sha256","sha384","sha512"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -319,6 +319,12 @@ const (
 
 	// HashedrekordV001SchemaDataHashAlgorithmSha256 captures enum value "sha256"
 	HashedrekordV001SchemaDataHashAlgorithmSha256 string = "sha256"
+
+	// HashedrekordV001SchemaDataHashAlgorithmSha384 captures enum value "sha384"
+	HashedrekordV001SchemaDataHashAlgorithmSha384 string = "sha384"
+
+	// HashedrekordV001SchemaDataHashAlgorithmSha512 captures enum value "sha512"
+	HashedrekordV001SchemaDataHashAlgorithmSha512 string = "sha512"
 )
 
 // prop value enum

--- a/pkg/generated/restapi/embedded_spec.go
+++ b/pkg/generated/restapi/embedded_spec.go
@@ -1659,11 +1659,13 @@ func init() {
               "description": "The hashing function used to compute the hash value",
               "type": "string",
               "enum": [
-                "sha256"
+                "sha256",
+                "sha384",
+                "sha512"
               ]
             },
             "value": {
-              "description": "The hash value for the content",
+              "description": "The hash value for the content, as represented by a lower case hexadecimal string",
               "type": "string"
             }
           }
@@ -1682,11 +1684,13 @@ func init() {
           "description": "The hashing function used to compute the hash value",
           "type": "string",
           "enum": [
-            "sha256"
+            "sha256",
+            "sha384",
+            "sha512"
           ]
         },
         "value": {
-          "description": "The hash value for the content",
+          "description": "The hash value for the content, as represented by a lower case hexadecimal string",
           "type": "string"
         }
       }
@@ -3261,11 +3265,13 @@ func init() {
                   "description": "The hashing function used to compute the hash value",
                   "type": "string",
                   "enum": [
-                    "sha256"
+                    "sha256",
+                    "sha384",
+                    "sha512"
                   ]
                 },
                 "value": {
-                  "description": "The hash value for the content",
+                  "description": "The hash value for the content, as represented by a lower case hexadecimal string",
                   "type": "string"
                 }
               }

--- a/pkg/types/hashedrekord/v0.0.1/hashedrekord_v0_0_1_schema.json
+++ b/pkg/types/hashedrekord/v0.0.1/hashedrekord_v0_0_1_schema.json
@@ -38,10 +38,10 @@
                         "algorithm": {
                             "description": "The hashing function used to compute the hash value",
                             "type": "string",
-                            "enum": [ "sha256" ]
+                            "enum": [ "sha256", "sha384", "sha512" ]
                         },
                         "value": {
-                            "description": "The hash value for the content",
+                            "description": "The hash value for the content, as represented by a lower case hexadecimal string",
                             "type": "string"
                         }
                     },


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
