### PR TITLE
Added support for sha384/sha512 hash algorithms in hashedrekords

### DIFF
--- a/pkg/generated/models/hashedrekord_v001_schema.go
+++ b/pkg/generated/models/hashedrekord_v001_schema.go
@@ -277,10 +277,10 @@ type HashedrekordV001SchemaDataHash struct {
 
 	// The hashing function used to compute the hash value
 	// Required: true
-	// Enum: [sha256]
+	// Enum: [sha256 sha384 sha512]
 	Algorithm *string `json:"algorithm"`
 
-	// The hash value for the content
+	// The hash value for the content, as represented by a lower case hexadecimal string
 	// Required: true
 	Value *string `json:"value"`
 }
@@ -307,7 +307,7 @@ var hashedrekordV001SchemaDataHashTypeAlgorithmPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["sha256"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["sha256","sha384","sha512"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -319,6 +319,12 @@ const (
 
 	// HashedrekordV001SchemaDataHashAlgorithmSha256 captures enum value "sha256"
 	HashedrekordV001SchemaDataHashAlgorithmSha256 string = "sha256"
+
+	// HashedrekordV001SchemaDataHashAlgorithmSha384 captures enum value "sha384"
+	HashedrekordV001SchemaDataHashAlgorithmSha384 string = "sha384"
+
+	// HashedrekordV001SchemaDataHashAlgorithmSha512 captures enum value "sha512"
+	HashedrekordV001SchemaDataHashAlgorithmSha512 string = "sha512"
 )
 
 // prop value enum

--- a/pkg/generated/restapi/embedded_spec.go
+++ b/pkg/generated/restapi/embedded_spec.go
@@ -1659,11 +1659,13 @@ func init() {
               "description": "The hashing function used to compute the hash value",
               "type": "string",
               "enum": [
-                "sha256"
+                "sha256",
+                "sha384",
+                "sha512"
               ]
             },
             "value": {
-              "description": "The hash value for the content",
+              "description": "The hash value for the content, as represented by a lower case hexadecimal string",
               "type": "string"
             }
           }
@@ -1682,11 +1684,13 @@ func init() {
           "description": "The hashing function used to compute the hash value",
           "type": "string",
           "enum": [
-            "sha256"
+            "sha256",
+            "sha384",
+            "sha512"
           ]
         },
         "value": {
-          "description": "The hash value for the content",
+          "description": "The hash value for the content, as represented by a lower case hexadecimal string",
           "type": "string"
         }
       }
@@ -3261,11 +3265,13 @@ func init() {
                   "description": "The hashing function used to compute the hash value",
                   "type": "string",
                   "enum": [
-                    "sha256"
+                    "sha256",
+                    "sha384",
+                    "sha512"
                   ]
                 },
                 "value": {
-                  "description": "The hash value for the content",
+                  "description": "The hash value for the content, as represented by a lower case hexadecimal string",
                   "type": "string"
                 }
               }

--- a/pkg/types/hashedrekord/v0.0.1/e2e_test.go
+++ b/pkg/types/hashedrekord/v0.0.1/e2e_test.go
@@ -1,0 +1,165 @@
+//
+// Copyright 2024 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+
+package hashedrekord
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/sigstore/rekor/pkg/client"
+	"github.com/sigstore/rekor/pkg/generated/client/entries"
+	"github.com/sigstore/rekor/pkg/generated/models"
+	"github.com/sigstore/rekor/pkg/types"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
+	"github.com/sigstore/sigstore/pkg/signature"
+)
+
+func rekorServer() string {
+	if s := os.Getenv("REKOR_SERVER"); s != "" {
+		return s
+	}
+	return "http://localhost:3000"
+}
+
+// TestSHA256HashedRekordEntry tests sending a valid HashedRekord proposed entry.
+func TestSHA256HashedRekordEntry(t *testing.T) {
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("error generating key: %v", err)
+	}
+	pubBytes, err := cryptoutils.MarshalPublicKeyToPEM(privKey.Public())
+	if err != nil {
+		t.Fatalf("error marshaling public key: %v", err)
+	}
+
+	data := []byte("data")
+	signer, err := signature.LoadSigner(privKey, crypto.SHA256)
+	if err != nil {
+		t.Fatalf("error loading verifier: %v", err)
+	}
+	signature, err := signer.SignMessage(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("error signing message: %v", err)
+	}
+
+	ap := types.ArtifactProperties{
+		ArtifactBytes:  []byte("data"),
+		ArtifactHash:   "sha256:3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7",
+		PublicKeyBytes: [][]byte{pubBytes},
+		PKIFormat:      "x509",
+		SignatureBytes: signature,
+	}
+
+	ei := NewEntry()
+
+	entry, err := ei.CreateFromArtifactProperties(context.Background(), ap)
+	if err != nil {
+		t.Fatalf("error creating entry: %v", err)
+	}
+
+	rc, err := client.GetRekorClient(rekorServer())
+	if err != nil {
+		t.Errorf("error getting client: %v", err)
+	}
+
+	params := &entries.CreateLogEntryParams{}
+	params.SetProposedEntry(entry)
+	params.SetContext(context.Background())
+	params.SetTimeout(5 * time.Second)
+
+	if _, err = rc.Entries.CreateLogEntry(params); err != nil {
+		t.Fatalf("expected no errors when submitting hashedrekord entry with sha256 to rekor %s", err)
+	}
+}
+
+// TestSHA1HashedRekordEntry tests sending a proposed hashedrekord entry with
+// sha1 digests that should not be accepted by Rekor as SHA1 is considered
+// insecure.
+func TestSHA1HashedRekordEntry(t *testing.T) {
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("error generating key: %v", err)
+	}
+	pubBytes, err := cryptoutils.MarshalPublicKeyToPEM(privKey.Public())
+	if err != nil {
+		t.Fatalf("error marshaling public key: %v", err)
+	}
+
+	data := []byte("data")
+	signer, err := signature.LoadSigner(privKey, crypto.SHA256)
+	if err != nil {
+		t.Fatalf("error loading verifier: %v", err)
+	}
+	signature, err := signer.SignMessage(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("error signing message: %v", err)
+	}
+
+	re := V001Entry{}
+
+	// we will need artifact, public-key, signature
+	re.HashedRekordObj.Data = &models.HashedrekordV001SchemaData{}
+
+	re.HashedRekordObj.Signature = &models.HashedrekordV001SchemaSignature{}
+	re.HashedRekordObj.Signature.Content = strfmt.Base64(signature)
+
+	re.HashedRekordObj.Signature.PublicKey = &models.HashedrekordV001SchemaSignaturePublicKey{}
+	publicKeyBytes := [][]byte{pubBytes}
+
+	re.HashedRekordObj.Signature.PublicKey.Content = strfmt.Base64(publicKeyBytes[0])
+	re.HashedRekordObj.Data.Hash = &models.HashedrekordV001SchemaDataHash{
+		Algorithm: swag.String("sha1"),
+		Value:     swag.String("a17c9aaa61e80a1bf71d0d850af4e5baa9800bbd"),
+	}
+
+	hr := models.Hashedrekord{}
+	hr.APIVersion = swag.String("0.0.1")
+	hr.Spec = re.HashedRekordObj
+
+	rc, err := client.GetRekorClient(rekorServer())
+	if err != nil {
+		t.Errorf("error getting client: %v", err)
+	}
+
+	params := &entries.CreateLogEntryParams{}
+	params.SetProposedEntry(&hr)
+	params.SetContext(context.Background())
+	params.SetTimeout(5 * time.Second)
+
+	if _, err = rc.Entries.CreateLogEntry(params); err == nil {
+		t.Fatalf("expected a failure when trying to add a hashedrekord with sha1")
+	}
+
+	e, ok := err.(*entries.CreateLogEntryBadRequest)
+	if !ok {
+		t.Errorf("unexpected error returned from rekor: %v", err.Error())
+	}
+	if !strings.Contains(e.Payload.Message, "validation failure") {
+		t.Errorf("expected error message to include 'validation failure': %v", e.Payload.Message)
+	}
+}

--- a/pkg/types/hashedrekord/v0.0.1/hashedrekord_v0_0_1_schema.json
+++ b/pkg/types/hashedrekord/v0.0.1/hashedrekord_v0_0_1_schema.json
@@ -38,10 +38,10 @@
                         "algorithm": {
                             "description": "The hashing function used to compute the hash value",
                             "type": "string",
-                            "enum": [ "sha256" ]
+                            "enum": [ "sha256", "sha384", "sha512" ]
                         },
                         "value": {
-                            "description": "The hash value for the content",
+                            "description": "The hash value for the content, as represented by a lower case hexadecimal string",
                             "type": "string"
                         }
                     },

--- a/pkg/util/sha.go
+++ b/pkg/util/sha.go
@@ -15,6 +15,7 @@
 package util
 
 import (
+	"crypto"
 	"fmt"
 	"strings"
 )
@@ -33,9 +34,46 @@ func PrefixSHA(sha string) string {
 		prefix = "sha1:"
 	case 64:
 		prefix = "sha256:"
+	case 96:
+		prefix = "sha384:"
 	case 128:
 		prefix = "sha512:"
 	}
 
 	return fmt.Sprintf("%v%v", prefix, sha)
+}
+
+func UnprefixSHA(sha string) (crypto.Hash, string) {
+	components := strings.Split(sha, ":")
+
+	if len(components) == 2 {
+		prefix := components[0]
+		sha = components[1]
+
+		switch prefix {
+		case "sha1":
+			return crypto.SHA1, sha
+		case "sha256":
+			return crypto.SHA256, sha
+		case "sha384":
+			return crypto.SHA384, sha
+		case "sha512":
+			return crypto.SHA512, sha
+		default:
+			return crypto.Hash(0), ""
+		}
+	}
+
+	switch len(sha) {
+	case 40:
+		return crypto.SHA1, sha
+	case 64:
+		return crypto.SHA256, sha
+	case 96:
+		return crypto.SHA384, sha
+	case 128:
+		return crypto.SHA512, sha
+	}
+
+	return crypto.Hash(0), ""
 }

--- a/pkg/util/sha_test.go
+++ b/pkg/util/sha_test.go
@@ -15,6 +15,7 @@
 package util
 
 import (
+	"crypto"
 	"testing"
 )
 
@@ -43,12 +44,78 @@ func TestPrefixSHA(t *testing.T) {
 			input: "cfd356237e261871e8f92ae6710a75a65a925ae121d94d28533f008bd3e00b5472d261b5d0e1ab4082e3078dd1ad2af57876ed3c1c797c4097dbed870f458408",
 			want:  "sha512:cfd356237e261871e8f92ae6710a75a65a925ae121d94d28533f008bd3e00b5472d261b5d0e1ab4082e3078dd1ad2af57876ed3c1c797c4097dbed870f458408",
 		},
+		{
+			input: "78674b244bc9cba8ecb6dcb660b059728236e36b2f30fbcd6e17b1b64255f3ac596fbe5c84d1cc9d2a0979513260de09",
+			want:  "sha384:78674b244bc9cba8ecb6dcb660b059728236e36b2f30fbcd6e17b1b64255f3ac596fbe5c84d1cc9d2a0979513260de09",
+		},
 	}
 
 	for _, tr := range testCases {
 		got := PrefixSHA(tr.input)
 		if got != tr.want {
 			t.Errorf("Got '%s' expected '%s'", got, tr.want)
+		}
+	}
+}
+
+func TestUnprefixSHA(t *testing.T) {
+	type prefixedSHA struct {
+		crypto.Hash
+		string
+	}
+	var testCases = []struct {
+		input string
+		want  prefixedSHA
+	}{
+		{
+			input: "87428fc522803d31065e7bce3cf03fe475096631e5e07bbd7a0fde60c4cf25c7",
+			want: prefixedSHA{
+				crypto.SHA256,
+				"87428fc522803d31065e7bce3cf03fe475096631e5e07bbd7a0fde60c4cf25c7",
+			},
+		},
+		{
+			input: "sha512:162b0b32f02482d5aca0a7c93dd03ceac3acd7e410a5f18f3fb990fc958ae0df6f32233b91831eaf99ca581a8c4ddf9c8ba315ac482db6d4ea01cc7884a635be",
+			want: prefixedSHA{
+				crypto.SHA512,
+				"162b0b32f02482d5aca0a7c93dd03ceac3acd7e410a5f18f3fb990fc958ae0df6f32233b91831eaf99ca581a8c4ddf9c8ba315ac482db6d4ea01cc7884a635be",
+			},
+		},
+		{
+			input: "09b80428c53912d4174162fd5b7c7d485bdcc3ab",
+			want: prefixedSHA{
+				crypto.SHA1,
+				"09b80428c53912d4174162fd5b7c7d485bdcc3ab",
+			},
+		},
+		{
+			input: "cfd356237e261871e8f92ae6710a75a65a925ae121d94d28533f008bd3e00b5472d261b5d0e1ab4082e3078dd1ad2af57876ed3c1c797c4097dbed870f458408",
+			want: prefixedSHA{
+				crypto.SHA512,
+				"cfd356237e261871e8f92ae6710a75a65a925ae121d94d28533f008bd3e00b5472d261b5d0e1ab4082e3078dd1ad2af57876ed3c1c797c4097dbed870f458408",
+			},
+		},
+		{
+			input: "78674b244bc9cba8ecb6dcb660b059728236e36b2f30fbcd6e17b1b64255f3ac596fbe5c84d1cc9d2a0979513260de09",
+			want: prefixedSHA{
+				crypto.SHA384,
+				"78674b244bc9cba8ecb6dcb660b059728236e36b2f30fbcd6e17b1b64255f3ac596fbe5c84d1cc9d2a0979513260de09",
+			},
+		},
+		{
+			input: "sha384:78674b244bc9cba8ecb6dcb660b059728236e36b2f30fbcd6e17b1b64255f3ac596fbe5c84d1cc9d2a0979513260de09",
+			want: prefixedSHA{
+				crypto.SHA384,
+				"78674b244bc9cba8ecb6dcb660b059728236e36b2f30fbcd6e17b1b64255f3ac596fbe5c84d1cc9d2a0979513260de09",
+			},
+		},
+	}
+
+	for _, tr := range testCases {
+		algo, value := UnprefixSHA(tr.input)
+		got := prefixedSHA{algo, value}
+		if got != tr.want {
+			t.Errorf("Got '%v' expected '%v' (input %s)", got, tr.want, tr.input)
 		}
 	}
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
Add support for SHA384/512 in hashedrekord type. This PR has been split from https://github.com/sigstore/rekor/pull/1945 and borrows code from https://github.com/sigstore/rekor/pull/1958 (from @bobcallaway ).

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

* Extend hashedrekord v0.0.1 schema to support sha256, sha384, and sha512 in `data.hash.algorithm`
* Changed `hashedrekord.CreateFromArtifactProperties` to accept a prefixed-checksum (e.g. `sha512:<value>`) to determine the type of hash used.
* Added `util.UnprefixSHA` API to split a string into the crypto.Hash being used and its value


#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
