### PR TITLE
Add metrics for index insertion

### DIFF
--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
+	"time"
 
 	"github.com/cyberphone/json-canonicalization/go/src/webpki.org/jsoncanonicalizer"
 	"github.com/go-openapi/runtime"
@@ -246,6 +248,14 @@ func createLogEntry(params entries.CreateLogEntryParams) (models.LogEntry, middl
 
 	if indexStorageClient != nil {
 		go func() {
+			start := time.Now()
+			var err error
+			defer func() {
+				labels := map[string]string{
+					"success": strconv.FormatBool(err == nil),
+				}
+				metricIndexStorageLatency.With(labels).Observe(float64(time.Since(start)))
+			}()
 			keys, err := entry.IndexKeys()
 			if err != nil {
 				log.ContextLogger(ctx).Errorf("getting entry index keys: %v", err)

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -34,6 +34,11 @@ var (
 		Help: "The status of publishing events to Pub/Sub",
 	}, []string{"event", "content_type", "status"})
 
+	metricIndexStorageLatency = promauto.NewSummaryVec(prometheus.SummaryOpts{
+		Name: "rekor_index_storage_latency_summary",
+		Help: "Latency of backend index insertion by success/failure",
+	}, []string{"success"})
+
 	MetricLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "rekor_api_latency",
 		Help: "Api Latency on calls",


### PR DESCRIPTION
Add new summary vector metric `rekor_index_storage_latency_summary` to enable tracking latency of entry insertion in the mysql or redis index storage backend.

Since the index insertion is non-blocking, the existing API metrics are unable to measure its latency. However, the speed of insertion affects how fast the index is available to query, so it is relevant to rekor's overall performance.

This new metric along with the existing API metrics will help give an clearer picture of rekor's index storage performance.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
