### PR TITLE
Add MySQL support to backfill script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,6 +118,33 @@ jobs:
           files: /tmp/rekor-merged.cov,/tmp/pkg-rekor-merged.cov
           flags: e2etests
 
+  backfill:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
+      - name: Extract version of Go to use
+        run: echo "GOVERSION=$(cat Dockerfile|grep golang | awk ' { print $2 } ' | cut -d '@' -f 1 | cut -d ':' -f 2 | uniq)" >> $GITHUB_ENV
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version: ${{ env.GOVERSION }}
+      - name: Install backfill test dependencies
+        run: |
+          go install ./cmd/rekor-cli
+          sudo add-apt-repository ppa:savoury1/minisign && sudo apt-get update && sudo apt-get install minisign
+          sudo apt install redis-tools -y
+      - name: Backfill test
+        run: ./tests/backfill-test.sh
+        env:
+          INDEX_BACKEND: redis
+      - name: Upload logs if they exist
+        uses: actions/upload-artifact@1746f4ab65b179e0ea60a494b83293b640dd5bba # v4.3.2
+        if: failure()
+        with:
+          name: E2E Docker Compose logs
+          path: /tmp/docker-compose.log
+
   sharding-e2e:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,11 +133,15 @@ jobs:
         run: |
           go install ./cmd/rekor-cli
           sudo add-apt-repository ppa:savoury1/minisign && sudo apt-get update && sudo apt-get install minisign
-          sudo apt install redis-tools -y
-      - name: Backfill test
+          sudo apt install redis-tools default-mysql-client -y
+      - name: Backfill test redis
         run: ./tests/backfill-test.sh
         env:
           INDEX_BACKEND: redis
+      - name: Backfill test mysql
+        run: ./tests/backfill-test.sh
+        env:
+          INDEX_BACKEND: mysql
       - name: Upload logs if they exist
         uses: actions/upload-artifact@1746f4ab65b179e0ea60a494b83293b640dd5bba # v4.3.2
         if: failure()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
           make ko-local
           docker run --rm $(cat rekorImagerefs) version
           docker run --rm $(cat cliImagerefs) version
-          docker run --rm $(cat redisImagerefs) --version
+          docker run --rm $(cat indexImagerefs) --version
 
   e2e:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ trillianServerImagerefs
 trillianSignerImagerefs
 rekorImagerefs
 cliImagerefs
-redisImagerefs
+indexImagerefs
 cosign.*
 signature
 rekor.pub

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -46,9 +46,9 @@ builds:
   - -extldflags "-static"
   - "{{ .Env.LDFLAGS }}"
 
-- id: backfill-redis
+- id: backfill-index
   dir: .
-  main: ./cmd/backfill-redis
+  main: ./cmd/backfill-index
   env:
   - CGO_ENABLED=0
   flags:

--- a/Makefile
+++ b/Makefile
@@ -82,8 +82,8 @@ rekor-cli: $(SRCS)
 rekor-server: $(SRCS)
 	CGO_ENABLED=0 go build -trimpath -ldflags "$(SERVER_LDFLAGS)" -o rekor-server ./cmd/rekor-server
 
-backfill-redis: $(SRCS)
-	CGO_ENABLED=0 go build -trimpath -ldflags "$(SERVER_LDFLAGS)" -o backfill-redis ./cmd/backfill-redis
+backfill-index: $(SRCS)
+	CGO_ENABLED=0 go build -trimpath -ldflags "$(SERVER_LDFLAGS)" -o backfill-index ./cmd/backfill-index
 
 test:
 	go test ./...
@@ -120,11 +120,11 @@ ko:
 		--platform=all --tags $(GIT_VERSION) --tags $(GIT_HASH) \
 		--image-refs rekorCliImagerefs github.com/sigstore/rekor/cmd/rekor-cli
 
-	# backfill-redis
+	# backfill-index
 	LDFLAGS="$(SERVER_LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
 	ko publish --base-import-paths \
 		--platform=all --tags $(GIT_VERSION) --tags $(GIT_HASH) \
-		--image-refs bRedisImagerefs github.com/sigstore/rekor/cmd/backfill-redis
+		--image-refs bIndexImagerefs github.com/sigstore/rekor/cmd/backfill-index
 
 deploy:
 	LDFLAGS="$(SERVER_LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) ko apply -f config/
@@ -154,8 +154,8 @@ ko-local:
 
 	KO_DOCKER_REPO=ko.local LDFLAGS="$(SERVER_LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
 	ko publish --base-import-paths \
-		--tags $(GIT_VERSION) --tags $(GIT_HASH) --image-refs redisImagerefs \
-		github.com/sigstore/rekor/cmd/backfill-redis
+		--tags $(GIT_VERSION) --tags $(GIT_HASH) --image-refs indexImagerefs \
+		github.com/sigstore/rekor/cmd/backfill-index
 
 .PHONY: fuzz
 # This runs the fuzz tests for a short period of time to ensure they don't crash.

--- a/docker-compose.backfill-test.yml
+++ b/docker-compose.backfill-test.yml
@@ -1,0 +1,44 @@
+#
+# Copyright 2024 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: '3.4'
+services:
+  rekor-server:
+    build:
+      context: .
+      target: "test"
+    environment:
+      TMPDIR: /var/run/attestations # workaround for https://github.com/google/go-cloud/issues/3294
+    command: [
+      "rekor-server",
+      "serve",
+      "--trillian_log_server.address=trillian-log-server",
+      "--trillian_log_server.port=8090",
+      "--redis_server.address=redis-server",
+      "--redis_server.port=6379",
+      "--redis_server.password=test",
+      "--rekor_server.address=0.0.0.0",
+      "--rekor_server.signer=memory",
+      "--enable_attestation_storage",
+      "--attestation_storage_bucket=file:///var/run/attestations",
+      "--max_request_body_size=32792576",
+      "--search_index.storage_provider=${INDEX_BACKEND:-mysql}",
+      "--search_index.mysql.dsn=test:zaphod@tcp(mysql:3306)/test",
+      ]
+    ports:
+      - "3000:3000"
+      - "2112:2112"
+    depends_on:
+      - mysql

--- a/docker-compose.backfill-test.yml
+++ b/docker-compose.backfill-test.yml
@@ -42,3 +42,20 @@ services:
       - "2112:2112"
     depends_on:
       - mysql
+  mysql:
+    platform: linux/amd64
+    image: gcr.io/trillian-opensource-ci/db_server:v1.4.0
+    environment:
+      - MYSQL_ROOT_PASSWORD=zaphod
+      - MYSQL_DATABASE=test
+      - MYSQL_USER=test
+      - MYSQL_PASSWORD=zaphod
+    restart: always # keep the MySQL server running
+    healthcheck:
+      test: ["CMD", "/etc/init.d/mysql", "status"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 10s
+    ports:
+      - "3306:3306"

--- a/release/ko-sign-release-images.sh
+++ b/release/ko-sign-release-images.sh
@@ -36,17 +36,17 @@ if [[ ! -f rekorCliImagerefs ]]; then
     exit 1
 fi
 
-if [[ ! -f bRedisImagerefs ]]; then
-    echo "bRedisImagerefs not found"
+if [[ ! -f bIndexImagerefs ]]; then
+    echo "bIndexImagerefs not found"
     exit 1
 fi
 
 echo "Signing images with GCP KMS Key..."
 cosign sign --yes --key "gcpkms://projects/$PROJECT_ID/locations/$KEY_LOCATION/keyRings/$KEY_RING/cryptoKeys/$KEY_NAME/versions/$KEY_VERSION" -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" $(cat rekorServerImagerefs)
 cosign sign --yes --key "gcpkms://projects/$PROJECT_ID/locations/$KEY_LOCATION/keyRings/$KEY_RING/cryptoKeys/$KEY_NAME/versions/$KEY_VERSION" -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" $(cat rekorCliImagerefs)
-cosign sign --yes --key "gcpkms://projects/$PROJECT_ID/locations/$KEY_LOCATION/keyRings/$KEY_RING/cryptoKeys/$KEY_NAME/versions/$KEY_VERSION" -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" $(cat bRedisImagerefs)
+cosign sign --yes --key "gcpkms://projects/$PROJECT_ID/locations/$KEY_LOCATION/keyRings/$KEY_RING/cryptoKeys/$KEY_NAME/versions/$KEY_VERSION" -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" $(cat bIndexImagerefs)
 
 echo "Signing images with Keyless..."
 cosign sign --yes -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" $(cat rekorServerImagerefs)
 cosign sign --yes -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" $(cat rekorCliImagerefs)
-cosign sign --yes -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" $(cat bRedisImagerefs)
+cosign sign --yes -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" $(cat bIndexImagerefs)

--- a/release/release.mk
+++ b/release/release.mk
@@ -33,12 +33,12 @@ copy-rekor-server-signed-release-to-ghcr:
 copy-rekor-cli-signed-release-to-ghcr:
 	cosign copy $(KO_PREFIX)/rekor-cli:$(GIT_VERSION) $(GHCR_PREFIX)/rekor-cli:$(GIT_VERSION)
 
-.PHONY: copy-backfill-redis-signed-release-to-ghcr
-copy-backfill-redis-signed-release-to-ghcr:
-	cosign copy $(KO_PREFIX)/backfill-redis:$(GIT_VERSION) $(GHCR_PREFIX)/backfill-redis:$(GIT_VERSION)
+.PHONY: copy-backfill-index-signed-release-to-ghcr
+copy-backfill-index-signed-release-to-ghcr:
+	cosign copy $(KO_PREFIX)/backfill-index:$(GIT_VERSION) $(GHCR_PREFIX)/backfill-index:$(GIT_VERSION)
 
 .PHONY: copy-signed-release-to-ghcr
-copy-signed-release-to-ghcr: copy-rekor-server-signed-release-to-ghcr copy-rekor-cli-signed-release-to-ghcr copy-backfill-redis-signed-release-to-ghcr
+copy-signed-release-to-ghcr: copy-rekor-server-signed-release-to-ghcr copy-rekor-cli-signed-release-to-ghcr copy-backfill-index-signed-release-to-ghcr
 
 ## --------------------------------------
 ## Dist / maybe we can deprecate

--- a/tests/backfill-test.sh
+++ b/tests/backfill-test.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+#
+# Copyright 2024 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+REKOR_ADDRESS=http://localhost:3000
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_PASSWORD=test
+
+testdir=$(mktemp -d)
+
+declare -A expected_artifacts
+declare -A expected_keys
+
+make_entries() {
+    set -e
+    # make 10 unique artifacts and sign each once
+    for i in $(seq 0 9) ; do
+        minisign -GW -p $testdir/mini${i}.pub -s $testdir/mini${i}.key
+        echo test${i} > $testdir/blob${i}
+        minisign -S -s $testdir/mini${i}.key -m $testdir/blob${i}
+        local rekor_out=$(rekor-cli --rekor_server $REKOR_ADDRESS upload \
+            --artifact $testdir/blob${i} \
+            --pki-format=minisign \
+            --public-key $testdir/mini${i}.pub \
+            --signature $testdir/blob${i}.minisig \
+            --format json)
+        local uuid=$(echo $rekor_out | jq -r .Location | cut -d '/' -f 6)
+        expected_keys["$testdir/mini${i}.pub"]=$uuid
+        expected_artifacts["$testdir/blob${i}"]=$uuid
+    done
+    # double-sign a few artifacts
+    for i in $(seq 7 9) ; do
+        set +e
+        let key_index=$i-5
+        set -e
+        minisign -S -s $testdir/mini${key_index}.key -m $testdir/blob${i}
+        rekor_out=$(rekor-cli --rekor_server $REKOR_ADDRESS upload \
+            --artifact $testdir/blob${i} \
+            --pki-format=minisign \
+            --public-key $testdir/mini${key_index}.pub \
+            --signature $testdir/blob${i}.minisig \
+            --format json)
+        uuid=$(echo $rekor_out | jq -r .Location | cut -d '/' -f 6)
+        local orig_key_uuid="${expected_keys[${testdir}/mini${key_index}.pub]}"
+        expected_keys[$testdir/mini${key_index}.pub]="$orig_key_uuid $uuid"
+        local orig_art_uuid="${expected_artifacts[${testdir}/blob${i}]}"
+        expected_artifacts[${testdir}/blob${i}]="$orig_art_uuid $uuid"
+    done
+    set +e
+}
+
+cleanup() {
+    rv=$?
+    if [ $rv -ne 0 ] ; then
+        docker-compose -f docker-compose.yml -f docker-compose.backfill-test.yml logs --no-color > /tmp/docker-compose.log
+    fi
+    docker-compose down --remove-orphans
+    rm -rf $testdir
+    exit $rv
+}
+trap cleanup EXIT
+
+docker_up () {
+    set -e
+    docker-compose -f docker-compose.yml -f docker-compose.backfill-test.yml up -d --build
+    local count=0
+    echo "waiting up to 2 min for system to start"
+    until [ $(docker-compose ps | \
+       grep -E "(rekor[-_]mysql|rekor[-_]redis|rekor[-_]rekor-server)" | \
+       grep -c "(healthy)" ) == 3 ];
+    do
+        if [ $count -eq 24 ]; then
+           echo "! timeout reached"
+           exit 1
+        else
+           echo -n "."
+           sleep 5
+           let 'count+=1'
+        fi
+    done
+    set +e
+}
+
+redis_cli() {
+    set -e
+    redis-cli -h $REDIS_HOST -a $REDIS_PASSWORD $@ 2>/dev/null
+    set +e
+}
+
+remove_keys() {
+    set -e
+    for i in $@ ; do
+        local rekord=$(rekor-cli --rekor_server $REKOR_ADDRESS get --log-index $i --format json)
+        local uuid=$(echo $rekord | jq -r .UUID)
+        local sha=sha256:$(echo $rekord | jq -r .Body.RekordObj.data.hash.value)
+        local key=$(echo $rekord | jq -r .Body.RekordObj.signature.publicKey.content | base64 -d | sha256sum | cut -d ' ' -f 1)
+        redis_cli LREM $sha 1 $uuid
+        redis_cli LREM $key 1 $uuid
+    done
+    set +e
+}
+
+search_expect_fail() {
+    local artifact=$1
+    rekor-cli --rekor_server $REKOR_ADDRESS search --artifact $artifact 2>/dev/null
+    if [ $? -eq 0 ] ; then
+        echo "Unexpected index found."
+        exit 1
+    fi
+}
+
+search_expect_success() {
+    local artifact=$1
+    rekor-cli --rekor_server $REKOR_ADDRESS search --artifact $artifact 2>/dev/null
+    if [ $? -ne 0 ] ; then
+        echo "Unexpected missing index."
+        exit 1
+    fi
+}
+
+check_all_entries() {
+    set -e
+    for artifact in "${!expected_artifacts[@]}" ; do
+        local expected_uuids="${expected_artifacts[$artifact]}"
+        local sha=$(sha256sum $artifact | cut -d ' ' -f 1)
+        local actual_uuids=$(rekor-cli --rekor_server $REKOR_ADDRESS search --sha $sha --format json | jq -r .UUIDs[])
+        for au in $actual_uuids ; do
+            local found=0
+            for eu in $expected_uuids ; do
+                if [ "$au" == "$eu" ] ; then
+                    found=1
+                    break
+                fi
+            done
+            if [ $found -eq 0 ] ; then
+                echo "Backfill did not add expected artifact $artifact."
+                exit 1
+            fi
+        done
+        expected_uuids=($expected_uuids)
+        local expected_length=${#expected_uuids[@]}
+        local actual_length=$(redis_cli LLEN sha256:${sha})
+        if [ $expected_length -ne $actual_length ] ; then
+            echo "Possible dupicate keys for artifact $artifact."
+            exit 1
+        fi
+    done
+    for key in "${!expected_keys[@]}" ; do
+        expected_uuids=${expected_keys[$key]}
+        actual_uuids=$(rekor-cli --rekor_server $REKOR_ADDRESS search --pki-format minisign --public-key $key --format json | jq -r .UUIDs[])
+        for au in $actual_uuids ; do
+            local found=0
+            for eu in $expected_uuids ; do
+                if [ "$au" == "$eu" ] ; then
+                    found=1
+                    break
+                fi
+            done
+            if [ $found -eq 0 ] ; then
+                echo "Backfill did not add expected key $key."
+                exit 1
+            fi
+        done
+        local keysha=$(echo -n $(tail -1 $key) | sha256sum | cut -d ' ' -f 1)
+        expected_uuids=($expected_uuids)
+        local expected_length=${#expected_uuids[@]}
+        local actual_length=$(redis_cli LLEN $keysha)
+        if [ $expected_length -ne $actual_length ] ; then
+            echo "Possible dupicate keys for artifact $artifact."
+            exit 1
+        fi
+    done
+    local dbsize=$(redis_cli DBSIZE)
+    if [ $dbsize -ne 20 ] ; then
+        echo "Found unexpected number of index entries: $dbsize."
+        exit 1
+    fi
+    set +e
+}
+
+run_backfill() {
+    set -e
+    local end_index=$1
+    go run cmd/backfill-redis/main.go --rekor-address $REKOR_ADDRESS \
+        --hostname $REDIS_HOST --port $REDIS_PORT --password $REDIS_PASSWORD \
+        --concurrency 5 --start 0 --end $end_index
+    set +e
+}
+
+docker_up
+
+make_entries
+
+set -e
+loginfo=$(rekor-cli --rekor_server $REKOR_ADDRESS loginfo --format=json)
+let end_index=$(echo $loginfo | jq .ActiveTreeSize)-1
+set +e
+
+echo
+echo "##### Scenario 1: backfill from scratch #####"
+echo
+
+# delete all keys (including the checkpoints, but those aren't needed here)
+redis_cli FLUSHALL
+
+# searching for any artifact should fail
+search_expect_fail $testdir/blob1
+
+run_backfill $end_index
+
+check_all_entries
+
+echo "Scenario 1: SUCCESS"
+
+echo
+echo "##### Scenario 2: backfill last half of entries #####"
+echo
+
+remove_keys $(seq 6 12)
+
+# searching for artifact 0-5 should succeed, but searching for later artifacts should fail
+search_expect_success $testdir/blob1
+search_expect_fail $testdir/blob9
+
+run_backfill $end_index
+
+check_all_entries
+
+echo "Scenario 2: SUCCESS"
+
+echo
+echo "##### Scenario 3: backfill sparse entries #####"
+echo
+
+remove_keys $(seq 2 2 12)
+
+# searching for odd artifacts should succeed, but searching for even artifacts should fail unless it was re-signed
+search_expect_success $testdir/blob5
+search_expect_fail $testdir/blob2
+search_expect_success $testdir/blob8
+
+run_backfill $end_index
+
+check_all_entries
+
+echo "Scenario 3: SUCCESS"
+
+echo
+echo "##### Scenario 4: backfill full instance (noop) #####"
+echo
+
+run_backfill $end_index
+
+check_all_entries
+
+echo "Scenario 4: SUCCESS"

--- a/tests/backfill-test.sh
+++ b/tests/backfill-test.sh
@@ -194,8 +194,8 @@ check_all_entries() {
 run_backfill() {
     set -e
     local end_index=$1
-    go run cmd/backfill-redis/main.go --rekor-address $REKOR_ADDRESS \
-        --hostname $REDIS_HOST --port $REDIS_PORT --password $REDIS_PASSWORD \
+    go run cmd/backfill-index/main.go --rekor-address $REKOR_ADDRESS \
+        --redis-hostname $REDIS_HOST --redis-port $REDIS_PORT --redis-password $REDIS_PASSWORD \
         --concurrency 5 --start 0 --end $end_index
     set +e
 }


### PR DESCRIPTION
Rename backfill-redis to backfill-index and add support for when MySQL
is used as the index storage backend.

Some Redis-specific parameters are renamed to clearly differentiate them
from MySQL parameters. MySQL connection parameters mirror the
rekor-server paramters, using a single --dsn flag instead of separate
host, port, password, etc flags.

To do:

- [x] Rename backfill-redis and combine both backfill scripts into one?
- [x] Functional tests for backfill-redis
- [x] Functional tests for backfill-mysql

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
