### PR TITLE
Unset DisableKeepalive for backfill HTTP client

### DIFF
--- a/cmd/backfill-index/main.go
+++ b/cmd/backfill-index/main.go
@@ -161,7 +161,7 @@ func main() {
 		log.Fatalf("creating index client: %v", err)
 	}
 
-	rekorClient, err := client.GetRekorClient(*rekorAddress)
+	rekorClient, err := client.GetRekorClient(*rekorAddress, client.WithNoDisableKeepalive(true))
 	if err != nil {
 		log.Fatalf("creating rekor client: %v", err)
 	}

--- a/cmd/backfill-index/main.go
+++ b/cmd/backfill-index/main.go
@@ -161,7 +161,7 @@ func main() {
 		log.Fatalf("creating index client: %v", err)
 	}
 
-	rekorClient, err := client.GetRekorClient(*rekorAddress, client.WithNoDisableKeepalive(true))
+	rekorClient, err := client.GetRekorClient(*rekorAddress, client.WithNoDisableKeepalive(true), client.WithRetryCount(10))
 	if err != nil {
 		log.Fatalf("creating rekor client: %v", err)
 	}

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -24,10 +24,11 @@ import (
 type Option func(*options)
 
 type options struct {
-	UserAgent   string
-	RetryCount  uint
-	InsecureTLS bool
-	Logger      interface{}
+	UserAgent           string
+	RetryCount          uint
+	InsecureTLS         bool
+	Logger              interface{}
+	NoDisableKeepalives bool
 }
 
 const (
@@ -75,6 +76,12 @@ func WithLogger(logger interface{}) Option {
 func WithInsecureTLS(enabled bool) Option {
 	return func(o *options) {
 		o.InsecureTLS = enabled
+	}
+}
+
+func WithNoDisableKeepalive(noDisableKeepalive bool) Option {
+	return func(o *options) {
+		o.NoDisableKeepalives = noDisableKeepalive
 	}
 }
 

--- a/pkg/client/rekor_client.go
+++ b/pkg/client/rekor_client.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+
 	"github.com/hashicorp/go-cleanhttp"
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
 	"github.com/sigstore/rekor/pkg/generated/client"
@@ -37,6 +38,9 @@ func GetRekorClient(rekorServerURL string, opts ...Option) (*client.Rekor, error
 
 	retryableClient := retryablehttp.NewClient()
 	defaultTransport := cleanhttp.DefaultTransport()
+	if o.NoDisableKeepalives {
+		defaultTransport.DisableKeepAlives = false
+	}
 	if o.InsecureTLS {
 		/* #nosec G402 */
 		defaultTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}


### PR DESCRIPTION
Disabling Keep-Alive, as done by the default transport setting in the hashicorp cleanhttp package, seems to conflict with a network setting between the public good Rekor instances and the bastion and results in GET requests stalling or timing out after processing a few entries. This change adds an option to the rekor client to unset the DisableKeepalive setting and has the backfill script utilize that option. Other uses of the rekor client will see no change.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
