### PR TITLE
Add flags to backfill script

### DIFF
--- a/cmd/backfill-index/main.go
+++ b/cmd/backfill-index/main.go
@@ -161,7 +161,7 @@ func main() {
 		log.Fatalf("creating index client: %v", err)
 	}
 
-	rekorClient, err := client.GetRekorClient(*rekorAddress, client.WithNoDisableKeepalive(true), client.WithRetryCount(10))
+	rekorClient, err := client.GetRekorClient(*rekorAddress, client.WithNoDisableKeepalives(true), client.WithRetryCount(10))
 	if err != nil {
 		log.Fatalf("creating rekor client: %v", err)
 	}

--- a/cmd/backfill-index/main.go
+++ b/cmd/backfill-index/main.go
@@ -39,6 +39,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/go-openapi/runtime"
 	_ "github.com/go-sql-driver/mysql"
@@ -109,6 +110,10 @@ var (
 	startIndex              = flag.Int("start", -1, "First index to backfill")
 	endIndex                = flag.Int("end", -1, "Last index to backfill")
 	rekorAddress            = flag.String("rekor-address", "", "Address for Rekor, e.g. https://rekor.sigstore.dev")
+	rekorDisableKeepalives  = flag.Bool("rekor-disable-keepalives", true, "Disable Keep-Alive connections (defaults to true, meaning Keep-Alive is disabled)")
+	rekorRetryCount         = flag.Uint("rekor-retry-count", 3, "Maximum number of times to retry rekor requests")                          // https://github.com/sigstore/rekor/blob/5988bfa6b0761be3a810047d23b3d3191ed5af3d/pkg/client/options.go#L36
+	rekorRetryWaitMin       = flag.Duration("rekor-retry-wait-min", 1*time.Second, "Minimum time to wait between retrying rekor requests")  //nolint:revive // https://github.com/hashicorp/go-retryablehttp/blob/1542b31176d3973a6ecbc06c05a2d0df89b59afb/client.go#L49
+	rekorRetryWaitMax       = flag.Duration("rekor-retry-wait-max", 30*time.Second, "Maximum time to wait between retrying rekor requests") // https://github.com/hashicorp/go-retryablehttp/blob/1542b31176d3973a6ecbc06c05a2d0df89b59afb/client.go#L50
 	versionFlag             = flag.Bool("version", false, "Print the current version of Backfill MySQL")
 	concurrency             = flag.Int("concurrency", 1, "Number of workers to use for backfill")
 	dryRun                  = flag.Bool("dry-run", false, "Dry run - don't actually insert into MySQL")
@@ -161,7 +166,11 @@ func main() {
 		log.Fatalf("creating index client: %v", err)
 	}
 
-	rekorClient, err := client.GetRekorClient(*rekorAddress, client.WithNoDisableKeepalives(true), client.WithRetryCount(10))
+	opts := []client.Option{client.WithNoDisableKeepalives(!*rekorDisableKeepalives)}
+	opts = append(opts, client.WithRetryCount(*rekorRetryCount))
+	opts = append(opts, client.WithRetryWaitMin(*rekorRetryWaitMin))
+	opts = append(opts, client.WithRetryWaitMax(*rekorRetryWaitMax))
+	rekorClient, err := client.GetRekorClient(*rekorAddress, opts...)
 	if err != nil {
 		log.Fatalf("creating rekor client: %v", err)
 	}

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -73,15 +73,17 @@ func WithLogger(logger interface{}) Option {
 	}
 }
 
+// WithInsecureTLS disables TLS verification.
 func WithInsecureTLS(enabled bool) Option {
 	return func(o *options) {
 		o.InsecureTLS = enabled
 	}
 }
 
-func WithNoDisableKeepalive(noDisableKeepalive bool) Option {
+// WithNoDisableKeepalives unsets the default DisableKeepalives setting.
+func WithNoDisableKeepalives(noDisableKeepalives bool) Option {
 	return func(o *options) {
-		o.NoDisableKeepalives = noDisableKeepalive
+		o.NoDisableKeepalives = noDisableKeepalives
 	}
 }
 

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -16,6 +16,7 @@ package client
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
 )
@@ -26,6 +27,8 @@ type Option func(*options)
 type options struct {
 	UserAgent           string
 	RetryCount          uint
+	RetryWaitMin        time.Duration
+	RetryWaitMax        time.Duration
 	InsecureTLS         bool
 	Logger              interface{}
 	NoDisableKeepalives bool
@@ -60,6 +63,20 @@ func WithUserAgent(userAgent string) Option {
 func WithRetryCount(retryCount uint) Option {
 	return func(o *options) {
 		o.RetryCount = retryCount
+	}
+}
+
+// WithRetryWaitMin sets the minimum length of time to wait between retries.
+func WithRetryWaitMin(t time.Duration) Option {
+	return func(o *options) {
+		o.RetryWaitMin = t
+	}
+}
+
+// WithRetryWaitMax sets the minimum length of time to wait between retries.
+func WithRetryWaitMax(t time.Duration) Option {
+	return func(o *options) {
+		o.RetryWaitMax = t
 	}
 }
 

--- a/pkg/client/rekor_client.go
+++ b/pkg/client/rekor_client.go
@@ -49,6 +49,8 @@ func GetRekorClient(rekorServerURL string, opts ...Option) (*client.Rekor, error
 		Transport: defaultTransport,
 	}
 	retryableClient.RetryMax = int(o.RetryCount)
+	retryableClient.RetryWaitMin = o.RetryWaitMin
+	retryableClient.RetryWaitMax = o.RetryWaitMax
 	retryableClient.Logger = o.Logger
 
 	httpClient := retryableClient.StandardClient()


### PR DESCRIPTION
## Add retry options and make all configurable

Add options to the rekor client to set the minimum and maximum retry
time, and make all rekor client options configurable for the backfill
script.

## Add ability to set custom headers in backfill

Add flags to the backfill script to allow passing custom headers to the
Rekor service. The Rekor infrastructure may be configured to respond
in certain ways to certain headers.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
