### PR TITLE
Batch entries in cleanup script

### DIFF
--- a/cmd/cleanup-index/main.go
+++ b/cmd/cleanup-index/main.go
@@ -63,8 +63,8 @@ var (
 	redisEnableTLS          = flag.Bool("redis-enable-tls", false, "Enable TLS for Redis client")
 	redisInsecureSkipVerify = flag.Bool("redis-insecure-skip-verify", false, "Whether to skip TLS verification for Redis client or not")
 	mysqlDSN                = flag.String("mysql-dsn", "", "MySQL Data Source Name")
-	versionFlag             = flag.Bool("version", false, "Print the current version of Backfill MySQL")
-	dryRun                  = flag.Bool("dry-run", false, "Dry run - don't actually insert into MySQL")
+	versionFlag             = flag.Bool("version", false, "Print the current version of cleanup-index")
+	dryRun                  = flag.Bool("dry-run", false, "Dry run - don't actually delete from Redis")
 )
 
 func main() {

--- a/cmd/cleanup-index/main.go
+++ b/cmd/cleanup-index/main.go
@@ -97,13 +97,9 @@ func main() {
 
 	ctx, _ := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 
-	keys, err := getKeysToDelete(ctx, mysqlClient)
+	err = batchQueryAndDelete(ctx, mysqlClient, redisClient)
 	if err != nil {
-		log.Fatalf("getting keys from mysql: %v", err)
-	}
-	err = removeFromRedis(ctx, redisClient, keys)
-	if err != nil {
-		log.Fatalf("deleting keys from redis: %v", err)
+		log.Fatal(err)
 	}
 }
 
@@ -136,16 +132,42 @@ func getMySQLClient() (*sqlx.DB, error) {
 	return dbClient, nil
 }
 
-// getKeysToDelete looks up entries in the EntryIndex table in MySQL.
-func getKeysToDelete(ctx context.Context, dbClient *sqlx.DB) ([]string, error) {
-	keys := []string{}
-	err := dbClient.SelectContext(ctx, &keys, mysqlSelectStmt)
-	return keys, err
+// batchQueryAndDelete looks up entries in the EntryIndex table in MySQL and removes them from Redis.
+// The SQL query is processed in batches because the entire data set is too large to store in memory at once.
+func batchQueryAndDelete(ctx context.Context, dbClient *sqlx.DB, redisClient *redis.Client) error {
+	const batchSize = 10000
+	keys := [batchSize]string{}
+	rows, err := dbClient.QueryContext(ctx, mysqlSelectStmt)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	index := 0
+	batchIndex := 1
+	for rows.Next() {
+		if err := rows.Scan(&keys[index]); err != nil {
+			return err
+		}
+		index++
+		if index == batchSize {
+			if err := removeFromRedis(ctx, redisClient, keys[:], batchIndex); err != nil {
+				return err
+			}
+			index = 0
+			batchIndex++
+		}
+	}
+	if index != 0 {
+		if err := removeFromRedis(ctx, redisClient, keys[:index], batchIndex); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // removeFromRedis delete the given keys from Redis.
-func removeFromRedis(ctx context.Context, redisClient *redis.Client, keys []string) error {
-	fmt.Printf("attempting to remove %d keys from redis\n", len(keys))
+func removeFromRedis(ctx context.Context, redisClient *redis.Client, keys []string, batchIndex int) error {
+	fmt.Printf("attempting to remove %d keys from redis (batch %d)\n", len(keys), batchIndex)
 	if *dryRun {
 		return nil
 	}


### PR DESCRIPTION
The number of index keys is nearly a trillion and is too many for the
script to process at once. Chunk the MySQL results up and remove them
from Redis in small batches instead.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
