### PR TITLE
Add TLS support for Trillian server

### DIFF
--- a/cmd/rekor-server/app/root.go
+++ b/cmd/rekor-server/app/root.go
@@ -117,7 +117,7 @@ Memory and file-based signers should only be used for testing.`)
 	rootCmd.PersistentFlags().String("redis_server.password", "", "Redis server password")
 	rootCmd.PersistentFlags().Bool("redis_server.enable-tls", false, "Whether to enable TLS verification when connecting to Redis endpoint")
 	rootCmd.PersistentFlags().Bool("redis_server.insecure-skip-verify", false, "Whether to skip TLS verification when connecting to Redis endpoint, only applicable when 'redis_server.enable-tls' is set to 'true'")
-	rootCmd.PersistentFlags().String("tls_ca_cert", "", "Certificate file to use for secure connections with Trillian server")
+	rootCmd.PersistentFlags().String("trillian_log_server.tls_ca_cert", "", "Certificate file to use for secure connections with Trillian server")
 	rootCmd.PersistentFlags().Bool("trillian_log_server.tls", false, "Use TLS when connecting to Trillian Server")
 
 	rootCmd.PersistentFlags().Bool("enable_attestation_storage", false, "enables rich attestation storage")

--- a/cmd/rekor-server/app/root.go
+++ b/cmd/rekor-server/app/root.go
@@ -117,6 +117,8 @@ Memory and file-based signers should only be used for testing.`)
 	rootCmd.PersistentFlags().String("redis_server.password", "", "Redis server password")
 	rootCmd.PersistentFlags().Bool("redis_server.enable-tls", false, "Whether to enable TLS verification when connecting to Redis endpoint")
 	rootCmd.PersistentFlags().Bool("redis_server.insecure-skip-verify", false, "Whether to skip TLS verification when connecting to Redis endpoint, only applicable when 'redis_server.enable-tls' is set to 'true'")
+	rootCmd.PersistentFlags().String("tls_ca_cert", "", "Certificate file to use for secure connections with Trillian server")
+	rootCmd.PersistentFlags().Bool("trillian_log_server.tls", false, "Use TLS when connecting to Trillian Server")
 
 	rootCmd.PersistentFlags().Bool("enable_attestation_storage", false, "enables rich attestation storage")
 	rootCmd.PersistentFlags().String("attestation_storage_bucket", "", "url for attestation storage bucket")

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -22,12 +22,15 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/google/trillian"
 	"github.com/redis/go-redis/v9"
 	"github.com/spf13/viper"
 	"golang.org/x/exp/slices"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/sigstore/rekor/pkg/indexstorage"
@@ -47,7 +50,33 @@ import (
 
 func dial(rpcServer string) (*grpc.ClientConn, error) {
 	// Set up and test connection to rpc server
-	creds := insecure.NewCredentials()
+	var creds credentials.TransportCredentials
+	tlsCACertFile := viper.GetString("tls_ca_cert")
+	useSystemTrustStore := viper.GetBool("trillian_log_server.tls")
+
+	switch {
+	case useSystemTrustStore:
+		creds = credentials.NewTLS(&tls.Config{
+			ServerName: rpcServer,
+			MinVersion: tls.VersionTLS12,
+		})
+	case tlsCACertFile != "":
+		tlsCaCert, err := os.ReadFile(filepath.Clean(tlsCACertFile))
+		if err != nil {
+			log.Logger.Fatalf("Failed to load tls_ca_cert:", err)
+		}
+		certPool := x509.NewCertPool()
+		if !certPool.AppendCertsFromPEM(tlsCaCert) {
+			return nil, fmt.Errorf("failed to append CA certificate to pool")
+		}
+		creds = credentials.NewTLS(&tls.Config{
+			ServerName: rpcServer,
+			RootCAs:    certPool,
+			MinVersion: tls.VersionTLS12,
+		})
+	default:
+		creds = insecure.NewCredentials()
+	}
 	conn, err := grpc.NewClient(rpcServer, grpc.WithTransportCredentials(creds))
 	if err != nil {
 		log.Logger.Fatalf("Failed to connect to RPC server:", err)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -51,7 +51,7 @@ import (
 func dial(rpcServer string) (*grpc.ClientConn, error) {
 	// Set up and test connection to rpc server
 	var creds credentials.TransportCredentials
-	tlsCACertFile := viper.GetString("tls_ca_cert")
+	tlsCACertFile := viper.GetString("trillian_log_server.tls_ca_cert")
 	useSystemTrustStore := viper.GetBool("trillian_log_server.tls")
 
 	switch {


### PR DESCRIPTION
#### Summary
This pull request introduces support for enabling TLS in communications with the Trillian server. By adding a new command-line flag `--tls-ca-cert` and implementing the necessary logic to handle TLS certificates, this update enhances the security of Rekor.


#### Release Note

- Feature: Added support for TLS in communication with the Trillian server.
- New Flag: --tls-ca-cert to specify the CA certificate file path for secure connections.
- Behavior: If the --tls-ca-cert flag is not provided, the system will default to insecure connections.
- Security: This update significantly enhances the security of data in transit by enabling TLS.

Resolves Issue: https://github.com/sigstore/rekor/issues/2163


#### Documentation
