### PR TITLE
Add public key hash check in Signed Note verification

### DIFF
--- a/pkg/util/checkpoint_test.go
+++ b/pkg/util/checkpoint_test.go
@@ -355,7 +355,7 @@ func TestSigningRoundtripCheckpoint(t *testing.T) {
 
 func TestInvalidSigVerification(t *testing.T) {
 	ecdsaKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	pubKeyHash, _ := GetPublicKeyHash(ecdsaKey.Public())
+	pubKeyHash, _ := getPublicKeyHash(ecdsaKey.Public())
 
 	for _, test := range []struct {
 		checkpoint     Checkpoint

--- a/pkg/util/signed_note.go
+++ b/pkg/util/signed_note.go
@@ -54,7 +54,7 @@ func (s *SignedNote) Sign(identity string, signer signature.Signer, opts signatu
 	if err != nil {
 		return nil, fmt.Errorf("retrieving public key: %w", err)
 	}
-	pkHash, err := GetPublicKeyHash(pk)
+	pkHash, err := getPublicKeyHash(pk)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func (s SignedNote) Verify(verifier signature.Verifier) bool {
 	if err != nil {
 		return false
 	}
-	verifierPkHash, err := GetPublicKeyHash(pk)
+	verifierPkHash, err := getPublicKeyHash(pk)
 	if err != nil {
 		return false
 	}
@@ -200,7 +200,7 @@ func SignedNoteValidator(strToValidate string) bool {
 	return s.UnmarshalText([]byte(strToValidate)) == nil
 }
 
-func GetPublicKeyHash(publicKey crypto.PublicKey) (uint32, error) {
+func getPublicKeyHash(publicKey crypto.PublicKey) (uint32, error) {
 	pubKeyBytes, err := x509.MarshalPKIXPublicKey(publicKey)
 	if err != nil {
 		return 0, fmt.Errorf("marshalling public key: %w", err)

--- a/pkg/util/signed_note.go
+++ b/pkg/util/signed_note.go
@@ -54,7 +54,7 @@ func (s *SignedNote) Sign(identity string, signer signature.Signer, opts signatu
 	if err != nil {
 		return nil, fmt.Errorf("retrieving public key: %w", err)
 	}
-	pkHash, err := getPublicKeyHash(pk)
+	pkHash, err := GetPublicKeyHash(pk)
 	if err != nil {
 		return nil, err
 	}
@@ -79,21 +79,11 @@ func (s SignedNote) Verify(verifier signature.Verifier) bool {
 	msg := []byte(s.Note)
 	digest := sha256.Sum256(msg)
 
-	/*
-		Clarifications required:
-		0. Am I understanding this correctly? calculate the hash of the public key in every loop? Isn't the PK constant throughout this function call?
-		1. Would it still suffice to still only return `false` upon error?
-		2. Should I write a function to reuse the logic for generating hash of the PK?
-		3. How can I test this?
-			- unit tests
-			- end-to-end behavior test
-	*/
-
 	pk, err := verifier.PublicKey()
 	if err != nil {
 		return false
 	}
-	verifierPkHash, err := getPublicKeyHash(pk)
+	verifierPkHash, err := GetPublicKeyHash(pk)
 	if err != nil {
 		return false
 	}
@@ -210,7 +200,7 @@ func SignedNoteValidator(strToValidate string) bool {
 	return s.UnmarshalText([]byte(strToValidate)) == nil
 }
 
-func getPublicKeyHash(publicKey crypto.PublicKey) (uint32, error) {
+func GetPublicKeyHash(publicKey crypto.PublicKey) (uint32, error) {
 	pubKeyBytes, err := x509.MarshalPKIXPublicKey(publicKey)
 	if err != nil {
 		return 0, fmt.Errorf("marshalling public key: %w", err)


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

* Resolves sigstore/rekor#389

#### Summary
This PR adds a public key hash check in `SignedNote.Verify` method.
The hash stored in `note.Signature` is compared against the verifier's public key hash. If the hash mismatches, the verification fails.


#### Release Note
* `SignedNote.Sign` is updated to use `GetPublicKeyHash` function.
* `GetPublicKeyHash` is added to calculate sha256 hash of the input public key (copied the existing logic in `SignedNote.Sign` method)
* `SignedNote.Verify` is updated to compare hash stored in `note.Signature` is and the verifier's public key hash.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
