### PR TITLE
remove unneeded value in log message when getlogentrybyuuid fails

### DIFF
--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -418,7 +418,7 @@ func GetLogEntryByUUIDHandler(params entries.GetLogEntryByUUIDParams) middleware
 		}
 		var validationErr *types.InputValidationError
 		if errors.As(err, &validationErr) {
-			return handleRekorAPIError(params, http.StatusBadRequest, err, fmt.Sprintf("validation error: %v", err), params.EntryUUID)
+			return handleRekorAPIError(params, http.StatusBadRequest, err, fmt.Sprintf("validation error: %v", err))
 		}
 		return handleRekorAPIError(params, http.StatusInternalServerError, err, trillianCommunicationError)
 	}


### PR DESCRIPTION
the UUID is specified as part of the URL which is already captured in other log messages; this as previously written failed with an `Ignored key without value` error because the zap logger expects `"key", "value"` 