### PR TITLE
Support per-shard signing keys

### DIFF
--- a/cmd/rekor-cli/app/get.go
+++ b/cmd/rekor-cli/app/get.go
@@ -115,7 +115,7 @@ var getCmd = &cobra.Command{
 				}
 				verifier, err := loadVerifier(rekorClient, strconv.FormatInt(treeID, 10))
 				if err != nil {
-					return nil, fmt.Errorf("retrieving rekor public key: %v", err)
+					return nil, fmt.Errorf("retrieving rekor public key: %w", err)
 				}
 				// verify log entry
 				e = entry
@@ -154,7 +154,7 @@ var getCmd = &cobra.Command{
 				}
 				verifier, err := loadVerifier(rekorClient, strconv.FormatInt(treeID, 10))
 				if err != nil {
-					return nil, fmt.Errorf("retrieving rekor public key: %v", err)
+					return nil, fmt.Errorf("retrieving rekor public key: %w", err)
 				}
 
 				if err := compareEntryUUIDs(params.EntryUUID, k); err != nil {

--- a/cmd/rekor-cli/app/get.go
+++ b/cmd/rekor-cli/app/get.go
@@ -115,7 +115,7 @@ var getCmd = &cobra.Command{
 				}
 				verifier, err := loadVerifier(rekorClient, strconv.FormatInt(treeID, 10))
 				if err != nil {
-					return nil, fmt.Errorf("retrieving rekor public key")
+					return nil, fmt.Errorf("retrieving rekor public key: %v", err)
 				}
 				// verify log entry
 				e = entry
@@ -154,7 +154,7 @@ var getCmd = &cobra.Command{
 				}
 				verifier, err := loadVerifier(rekorClient, strconv.FormatInt(treeID, 10))
 				if err != nil {
-					return nil, fmt.Errorf("retrieving rekor public key")
+					return nil, fmt.Errorf("retrieving rekor public key: %v", err)
 				}
 
 				if err := compareEntryUUIDs(params.EntryUUID, k); err != nil {

--- a/cmd/rekor-cli/app/log_info.go
+++ b/cmd/rekor-cli/app/log_info.go
@@ -34,6 +34,7 @@ import (
 	"github.com/sigstore/rekor/cmd/rekor-cli/app/format"
 	"github.com/sigstore/rekor/cmd/rekor-cli/app/state"
 	"github.com/sigstore/rekor/pkg/client"
+	"github.com/sigstore/rekor/pkg/generated/client/pubkey"
 	"github.com/sigstore/rekor/pkg/generated/client/tlog"
 	"github.com/sigstore/rekor/pkg/log"
 	"github.com/sigstore/rekor/pkg/util"
@@ -131,7 +132,7 @@ func verifyTree(ctx context.Context, rekorClient *rclient.Rekor, signedTreeHead,
 	if err := sth.UnmarshalText([]byte(signedTreeHead)); err != nil {
 		return err
 	}
-	verifier, err := loadVerifier(rekorClient)
+	verifier, err := loadVerifier(rekorClient, treeID)
 	if err != nil {
 		return err
 	}
@@ -160,11 +161,11 @@ func verifyTree(ctx context.Context, rekorClient *rclient.Rekor, signedTreeHead,
 	return nil
 }
 
-func loadVerifier(rekorClient *rclient.Rekor) (signature.Verifier, error) {
+func loadVerifier(rekorClient *rclient.Rekor, treeID string) (signature.Verifier, error) {
 	publicKey := viper.GetString("rekor_server_public_key")
 	if publicKey == "" {
 		// fetch key from server
-		keyResp, err := rekorClient.Pubkey.GetPublicKey(nil)
+		keyResp, err := rekorClient.Pubkey.GetPublicKey(pubkey.NewGetPublicKeyParams().WithTreeID(swag.String(treeID)))
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/rekor-cli/app/verify.go
+++ b/cmd/rekor-cli/app/verify.go
@@ -165,9 +165,14 @@ var verifyCmd = &cobra.Command{
 			}
 		}
 
+		treeID, err := sharding.TreeID(o.EntryUUID)
+		if err != nil {
+			return nil, err
+		}
+
 		// Get Rekor Pub
 		// TODO(asraa): Replace with sigstore's GetRekorPubs to use TUF.
-		verifier, err := loadVerifier(rekorClient)
+		verifier, err := loadVerifier(rekorClient, strconv.FormatInt(treeID, 10))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -17,10 +17,8 @@ package api
 
 import (
 	"context"
-	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -42,9 +40,6 @@ import (
 	"github.com/sigstore/rekor/pkg/storage"
 	"github.com/sigstore/rekor/pkg/trillianclient"
 	"github.com/sigstore/rekor/pkg/witness"
-	"github.com/sigstore/sigstore/pkg/cryptoutils"
-	"github.com/sigstore/sigstore/pkg/signature"
-	"github.com/sigstore/sigstore/pkg/signature/options"
 
 	_ "github.com/sigstore/rekor/pkg/pubsub/gcp" // Load GCP pubsub implementation
 )
@@ -92,12 +87,9 @@ func dial(rpcServer string) (*grpc.ClientConn, error) {
 }
 
 type API struct {
-	logClient  trillian.TrillianLogClient
-	logID      int64
-	logRanges  sharding.LogRanges
-	pubkey     string // PEM encoded public key
-	pubkeyHash string // SHA256 hash of DER-encoded public key
-	signer     signature.Signer
+	logClient trillian.TrillianLogClient
+	treeID    int64
+	logRanges sharding.LogRanges
 	// stops checkpoint publishing
 	checkpointPublishCancel context.CancelFunc
 	// Publishes notifications when new entries are added to the log. May be
@@ -117,12 +109,6 @@ func NewAPI(treeID uint) (*API, error) {
 	logAdminClient := trillian.NewTrillianAdminClient(tConn)
 	logClient := trillian.NewTrillianLogClient(tConn)
 
-	shardingConfig := viper.GetString("trillian_log_server.sharding_config")
-	ranges, err := sharding.NewLogRanges(ctx, logClient, shardingConfig, treeID)
-	if err != nil {
-		return nil, fmt.Errorf("unable get sharding details from sharding config: %w", err)
-	}
-
 	tid := int64(treeID)
 	if tid == 0 {
 		log.Logger.Info("No tree ID specified, attempting to create a new tree")
@@ -133,27 +119,18 @@ func NewAPI(treeID uint) (*API, error) {
 		tid = t.TreeId
 	}
 	log.Logger.Infof("Starting Rekor server with active tree %v", tid)
-	ranges.SetActive(tid)
 
-	rekorSigner, err := signer.New(ctx, viper.GetString("rekor_server.signer"),
-		viper.GetString("rekor_server.signer-passwd"),
-		viper.GetString("rekor_server.tink_kek_uri"),
-		viper.GetString("rekor_server.tink_keyset_path"),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("getting new signer: %w", err)
+	shardingConfig := viper.GetString("trillian_log_server.sharding_config")
+	signingConfig := signer.SigningConfig{
+		SigningSchemeOrKeyPath: viper.GetString("rekor_server.signer"),
+		FileSignerPassword:     viper.GetString("rekor_server.signer-passwd"),
+		TinkKEKURI:             viper.GetString("rekor_server.tink_kek_uri"),
+		TinkKeysetPath:         viper.GetString("rekor_server.tink_keyset_path"),
 	}
-	pk, err := rekorSigner.PublicKey(options.WithContext(ctx))
+	ranges, err := sharding.NewLogRanges(ctx, logClient, shardingConfig, tid, signingConfig)
 	if err != nil {
-		return nil, fmt.Errorf("getting public key: %w", err)
+		return nil, fmt.Errorf("unable get sharding details from sharding config: %w", err)
 	}
-	b, err := x509.MarshalPKIXPublicKey(pk)
-	if err != nil {
-		return nil, fmt.Errorf("marshalling public key: %w", err)
-	}
-	pubkeyHashBytes := sha256.Sum256(b)
-
-	pubkey := cryptoutils.PEMEncode(cryptoutils.PublicKeyPEMType, b)
 
 	var newEntryPublisher pubsub.Publisher
 	if p := viper.GetString("rekor_server.new_entry_publisher"); p != "" {
@@ -170,12 +147,8 @@ func NewAPI(treeID uint) (*API, error) {
 	return &API{
 		// Transparency Log Stuff
 		logClient: logClient,
-		logID:     tid,
+		treeID:    tid,
 		logRanges: ranges,
-		// Signing/verifying fields
-		pubkey:     string(pubkey),
-		pubkeyHash: hex.EncodeToString(pubkeyHashBytes[:]),
-		signer:     rekorSigner,
 		// Utility functionality not required for operation of the core service
 		newEntryPublisher: newEntryPublisher,
 	}, nil
@@ -212,8 +185,8 @@ func ConfigureAPI(treeID uint) {
 
 	if viper.GetBool("enable_stable_checkpoint") {
 		redisClient = NewRedisClient()
-		checkpointPublisher := witness.NewCheckpointPublisher(context.Background(), api.logClient, api.logRanges.ActiveTreeID(),
-			viper.GetString("rekor_server.hostname"), api.signer, redisClient, viper.GetUint("publish_frequency"), CheckpointPublishCount)
+		checkpointPublisher := witness.NewCheckpointPublisher(context.Background(), api.logClient, api.logRanges.GetActive().TreeID,
+			viper.GetString("rekor_server.hostname"), api.logRanges.GetActive().Signer, redisClient, viper.GetUint("publish_frequency"), CheckpointPublishCount)
 
 		// create context to cancel goroutine on server shutdown
 		ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -94,7 +94,7 @@ func logEntryFromLeaf(ctx context.Context, _ trillianclient.TrillianClient, leaf
 	}
 
 	logEntryAnon := models.LogEntryAnon{
-		LogID:          swag.String(logRange.PemPubKey),
+		LogID:          swag.String(logRange.LogID),
 		LogIndex:       &virtualIndex,
 		Body:           leaf.LeafValue,
 		IntegratedTime: swag.Int64(leaf.IntegrateTimestamp.AsTime().Unix()),

--- a/pkg/api/public_key.go
+++ b/pkg/api/public_key.go
@@ -27,7 +27,7 @@ import (
 
 func GetPublicKeyHandler(params pubkey.GetPublicKeyParams) middleware.Responder {
 	treeID := swag.StringValue(params.TreeID)
-	pk, err := api.logRanges.PublicKey(api.pubkey, treeID)
+	pk, err := api.logRanges.PublicKey(treeID)
 	if err != nil {
 		return handleRekorAPIError(params, http.StatusBadRequest, err, "")
 	}

--- a/pkg/sharding/log_index.go
+++ b/pkg/sharding/log_index.go
@@ -19,7 +19,7 @@ func VirtualLogIndex(leafIndex int64, tid int64, ranges LogRanges) int64 {
 	// if we have no inactive ranges, we have just one log! return the leafIndex as is
 	// as long as it matches the active tree ID
 	if ranges.NoInactive() {
-		if ranges.GetActive() == tid {
+		if ranges.GetActive().TreeID == tid {
 			return leafIndex
 		}
 		return -1
@@ -34,7 +34,7 @@ func VirtualLogIndex(leafIndex int64, tid int64, ranges LogRanges) int64 {
 	}
 
 	// If no TreeID in Inactive matches the tid, the virtual index should be the active tree
-	if ranges.GetActive() == tid {
+	if ranges.GetActive().TreeID == tid {
 		return virtualIndex + leafIndex
 	}
 

--- a/pkg/sharding/log_index_test.go
+++ b/pkg/sharding/log_index_test.go
@@ -44,7 +44,7 @@ func TestVirtualLogIndex(t *testing.T) {
 						TreeID:     100,
 						TreeLength: 5,
 					}},
-				active: 300,
+				active: LogRange{TreeID: 300},
 			},
 			expectedIndex: 7,
 		},
@@ -64,7 +64,7 @@ func TestVirtualLogIndex(t *testing.T) {
 						TreeID:     300,
 						TreeLength: 4,
 					}},
-				active: 400,
+				active: LogRange{TreeID: 400},
 			},
 			expectedIndex: 6,
 		},
@@ -74,7 +74,7 @@ func TestVirtualLogIndex(t *testing.T) {
 			leafIndex:   2,
 			tid:         30,
 			ranges: LogRanges{
-				active: 30,
+				active: LogRange{TreeID: 30},
 			},
 			expectedIndex: 2,
 		}, {
@@ -82,7 +82,7 @@ func TestVirtualLogIndex(t *testing.T) {
 			leafIndex:   2,
 			tid:         4,
 			ranges: LogRanges{
-				active: 30,
+				active: LogRange{TreeID: 30},
 			},
 			expectedIndex: -1,
 		},

--- a/pkg/sharding/ranges.go
+++ b/pkg/sharding/ranges.go
@@ -57,7 +57,7 @@ type LogRange struct {
 }
 
 func (l LogRange) String() string {
-	return fmt.Sprintf("{ TreeID: %v, TreeLength: %v, SigningConfig: %v, PemPubKey: %v, LogID: %v }", l.TreeID, l.TreeLength, l.SigningConfig, l.PemPubKey, l.LogID)
+	return fmt.Sprintf("{ TreeID: %v, TreeLength: %v, SigningScheme: %v, PemPubKey: %v, LogID: %v }", l.TreeID, l.TreeLength, l.SigningConfig.SigningSchemeOrKeyPath, l.PemPubKey, l.LogID)
 }
 
 // NewLogRanges initializes the active and any inactive log shards

--- a/pkg/sharding/ranges.go
+++ b/pkg/sharding/ranges.go
@@ -72,7 +72,6 @@ func NewLogRanges(ctx context.Context, logClient trillian.TrillianLogClient,
 	if err != nil {
 		return LogRanges{}, fmt.Errorf("creating range for active tree %d: %w", activeTreeID, err)
 	}
-	// lgtm [go/clear-text-logging]
 	log.Logger.Infof("Active log: %s", activeLog.String())
 
 	if inactiveShardsPath == "" {
@@ -97,7 +96,6 @@ func NewLogRanges(ctx context.Context, logClient trillian.TrillianLogClient,
 		ranges[i] = r
 	}
 	for i, r := range ranges {
-		// lgtm [go/clear-text-logging]
 		log.Logger.Infof("Inactive range %d: %s", i, r.String())
 	}
 

--- a/pkg/sharding/ranges.go
+++ b/pkg/sharding/ranges.go
@@ -72,6 +72,7 @@ func NewLogRanges(ctx context.Context, logClient trillian.TrillianLogClient,
 	if err != nil {
 		return LogRanges{}, fmt.Errorf("creating range for active tree %d: %w", activeTreeID, err)
 	}
+	// lgtm [go/clear-text-logging]
 	log.Logger.Infof("Active log: %s", activeLog.String())
 
 	if inactiveShardsPath == "" {
@@ -96,6 +97,7 @@ func NewLogRanges(ctx context.Context, logClient trillian.TrillianLogClient,
 		ranges[i] = r
 	}
 	for i, r := range ranges {
+		// lgtm [go/clear-text-logging]
 		log.Logger.Infof("Inactive range %d: %s", i, r.String())
 	}
 

--- a/pkg/sharding/ranges.go
+++ b/pkg/sharding/ranges.go
@@ -72,7 +72,7 @@ func NewLogRanges(ctx context.Context, logClient trillian.TrillianLogClient,
 	if err != nil {
 		return LogRanges{}, fmt.Errorf("creating range for active tree %d: %w", activeTreeID, err)
 	}
-	log.Logger.Infof("Active log: %v", activeLog)
+	log.Logger.Infof("Active log: %s", activeLog.String())
 
 	if inactiveShardsPath == "" {
 		log.Logger.Info("No config file specified, no inactive shards")
@@ -95,7 +95,9 @@ func NewLogRanges(ctx context.Context, logClient trillian.TrillianLogClient,
 		}
 		ranges[i] = r
 	}
-	log.Logger.Infof("Ranges: %v", ranges)
+	for i, r := range ranges {
+		log.Logger.Infof("Inactive range %d: %s", i, r.String())
+	}
 
 	return LogRanges{
 		inactive: ranges,

--- a/pkg/signer/signer.go
+++ b/pkg/signer/signer.go
@@ -32,6 +32,19 @@ import (
 	_ "github.com/sigstore/sigstore/pkg/signature/kms/hashivault"
 )
 
+// SigningConfig initializes the signer for a specific shard
+type SigningConfig struct {
+	SigningSchemeOrKeyPath string `json:"signingSchemeOrKeyPath" yaml:"signingSchemeOrKeyPath"`
+	FileSignerPassword     string `json:"fileSignerPassword" yaml:"fileSignerPassword"`
+	TinkKEKURI             string `json:"tinkKEKURI" yaml:"tinkKEKURI"`
+	TinkKeysetPath         string `json:"tinkKeysetPath" yaml:"tinkKeysetPath"`
+}
+
+func (sc SigningConfig) IsUnset() bool {
+	return sc.SigningSchemeOrKeyPath == "" && sc.FileSignerPassword == "" &&
+		sc.TinkKEKURI == "" && sc.TinkKeysetPath == ""
+}
+
 func New(ctx context.Context, signer, pass, tinkKEKURI, tinkKeysetPath string) (signature.Signer, error) {
 	switch {
 	case slices.ContainsFunc(kms.SupportedProviders(),

--- a/pkg/signer/signer_test.go
+++ b/pkg/signer/signer_test.go
@@ -1,0 +1,24 @@
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signer
+
+import "testing"
+
+func TestSigningConfig(t *testing.T) {
+	sc := SigningConfig{}
+	if !sc.IsUnset() {
+		t.Fatalf("expected empty signing config to be unset")
+	}
+}

--- a/pkg/signer/tink.go
+++ b/pkg/signer/tink.go
@@ -17,6 +17,7 @@ package signer
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -36,6 +37,9 @@ const TinkScheme = "tink"
 // NewTinkSignerWithHandle returns a signature.SignerVerifier that wraps crypto.Signer and a hash function.
 // Provide a path to the encrypted keyset and cloud KMS key URI for decryption
 func NewTinkSigner(ctx context.Context, kekURI, keysetPath string) (signature.Signer, error) {
+	if kekURI == "" || keysetPath == "" {
+		return nil, fmt.Errorf("key encryption key URI or keyset path unset")
+	}
 	kek, err := getKeyEncryptionKey(ctx, kekURI)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This change enables key rotation with a per-shard
signing key configuration. The LogRanges structure
now holds both active and inactive shards, with the
LogRange structure containing a signer, encoded
public key and log ID based on the public key.

This change is backwards compatible. If no signing
configuration is specified, the active shard
signing configuration is used for all shards.

Minor change: Standardized log ID vs tree ID, where
the former is the pubkey hash and the latter is the
ID for the Trillian tree.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>
