### PR TITLE
Cache checkpoint for inactive shards

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -145,7 +145,7 @@ func NewAPI(treeID uint) (*API, error) {
 		tc := trillianclient.NewTrillianClient(ctx, logClient, r.TreeID)
 		resp := tc.GetLatest(0)
 		if resp.Status != codes.OK {
-			return nil, fmt.Errorf("error with GetLatest(): resp code is %d", resp.Status)
+			return nil, fmt.Errorf("error fetching latest tree head for inactive shard %d: resp code is %d, err is %w", r.TreeID, resp.Status, resp.Err)
 		}
 		result := resp.GetLatestResult
 		root := &types.LogRootV1{}

--- a/pkg/sharding/ranges.go
+++ b/pkg/sharding/ranges.go
@@ -256,13 +256,14 @@ func (l *LogRanges) PublicKey(treeID string) (string, error) {
 		return "", err
 	}
 
+	if tid == int(l.GetActive().TreeID) {
+		return l.active.PemPubKey, nil
+	}
+
 	for _, i := range l.inactive {
 		if int(i.TreeID) == tid {
 			return i.PemPubKey, nil
 		}
-	}
-	if tid == int(l.GetActive().TreeID) {
-		return l.active.PemPubKey, nil
 	}
 	return "", fmt.Errorf("%d is not a valid tree ID and doesn't have an associated public key", tid)
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

On service startup, Rekor will sign checkpoints for the
inactive shards, since inactive tree lengths do not
change.

The calls to CreateAndSignCheckpoint that were not
updated are because the checkpoint is being signed
only for the active shard, e.g. on entry upload
and when returning the active shard checkpoint.

Any deployment using KMS will see a reduction in KMS
calls.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
