### PR TITLE
Fix 'Using config file:' log message

### DIFF
--- a/cmd/rekor-cli/app/root.go
+++ b/cmd/rekor-cli/app/root.go
@@ -115,7 +115,7 @@ func initConfig(cmd *cobra.Command) error {
 			return err
 		}
 	} else if viper.GetString("format") == "default" {
-		log.CliLogger.Infof("Using config file:", viper.ConfigFileUsed())
+		log.CliLogger.Infof("Using config file: %s", viper.ConfigFileUsed())
 	}
 
 	return nil


### PR DESCRIPTION


#### Summary
Without applying this patch, the log message will be:
```
Using config file:%!(EXTRA string=/tmp/rekor_test.q1FmiY.rekor.yaml)
```


#### Release Note
Fixed "Using config file:" log message format.

#### Documentation
None
