### PR TITLE
chore: remove deprecated 'version' key from Docker

### DIFF
--- a/docker-compose.backfill-test.yml
+++ b/docker-compose.backfill-test.yml
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '3.4'
 services:
   rekor-server:
     build:

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '3.4'
 services:
   rekor-server-debug:
     build:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '3.4'
 services:
   rekor-server:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '3.4'
 services:
   mysql:
     platform: linux/amd64

--- a/tests/client-algos-e2e-test.sh
+++ b/tests/client-algos-e2e-test.sh
@@ -112,7 +112,6 @@ ${docker_compose} stop rekor-server
 # Create a new compose file with restricted algorithms
 COMPOSE_FILE=$REKORTMPDIR/docker-compose-restricted-algos.yaml
 cat << EOF > $COMPOSE_FILE
-version: '3.4'
 services:
   rekor-server:
     build:

--- a/tests/issue-872-e2e-test.sh
+++ b/tests/issue-872-e2e-test.sh
@@ -64,7 +64,6 @@ docker run --rm -v $ATT_VOLUME:/att:z busybox /bin/sh -c 'touch /att/.initialize
 
 V060_COMPOSE_FILE=$REKORTMPDIR/docker-compose-issue872-v060.yaml
 cat << EOF > $V060_COMPOSE_FILE
-version: '3.4'
 services:
   rekor-server-issue-872-v060:
     # this container image is built on v0.6.0 with the fix for issue #800
@@ -142,7 +141,6 @@ ${docker_compose} -f $V060_COMPOSE_FILE --project-directory=$PWD stop rekor-serv
 
 COMPOSE_FILE=$REKORTMPDIR/docker-compose-issue872.yaml
 cat << EOF > $COMPOSE_FILE
-version: '3.4'
 services:
   rekor-server:
     build:

--- a/tests/sharding-e2e-test.sh
+++ b/tests/sharding-e2e-test.sh
@@ -164,7 +164,6 @@ cat $SHARDING_CONFIG
 
 COMPOSE_FILE=docker-compose-sharding.yaml
 cat << EOF > $COMPOSE_FILE
-version: '3.4'
 services:
   rekor-server:
     build:


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

https://github.com/sigstore/rekor-tiles/issues/38

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Removes `'version:'` from the docker-compose files becuase it's deprecated. This reduces the warnings when running tests.

https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete

```
WARN[0000] .../rekor/docker-compose.test.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
```

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Removed `'version:'` from the docker-compose files. 

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
