### PR TITLE
chore: improve mysql readiness checks

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -46,6 +46,8 @@ services:
     depends_on:
       - gcp-pubsub-emulator
       - mysql
+      - redis-server
+      - trillian-log-server
   gcp-pubsub-emulator:
     image: gcp-pubsub-emulator
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,8 +27,8 @@ services:
       test: ["CMD", "/etc/init.d/mysql", "status"]
       interval: 30s
       timeout: 3s
-      retries: 3
-      start_period: 10s
+      retries: 5
+      start_period: 90s
   redis-server:
     image: docker.io/redis:6.2
     command: [
@@ -63,7 +63,8 @@ services:
       - "8090:8090"
       - "8091:8091"
     depends_on:
-      - mysql
+      mysql:
+        condition: service_healthy
   trillian-log-signer:
     image: ghcr.io/sigstore/scaffolding/trillian_log_signer@sha256:79d57af375cfa997ed5452cc0c02c0396d909fcc91d11065586f119490aa9214 # v1.6.0
     command: [
@@ -79,7 +80,8 @@ services:
     ports:
       - "8092:8091"
     depends_on:
-      - mysql
+      mysql:
+        condition: service_healthy
   rekor-server:
     build:
       context: .


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

https://github.com/sigstore/rekor-tiles/issues/38

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Improves the docker-compose.yml file by enforcing healtchecks between mysql and the trillian services. It also increases the timeouts for the healthchecks.

See https://docs.docker.com/reference/dockerfile/#healthcheck

This improves the developer experience, so we don't see so many startup errors for the trillian services, like

```log
 *  Executing task: docker logs --tail 1000 -f 6791b7d7b4e977cd371144b7a752018d4077d7b3c65a9a7b12a5d3da556bb3ef 

I0307 19:57:55.500513       1 main.go:97] **** Log Server Starting ****
W0307 19:57:55.502723       1 tree_storage.go:89] Failed to set strict mode on mysql db: dial tcp 192.168.8.4:3306: connect: connection refused
F0307 19:57:55.502831       1 main.go:118] Failed to get storage provider: dial tcp 192.168.8.4:3306: connect: connection refused
...
I0307 19:58:01.096252       1 main.go:97] **** Log Server Starting ****
W0307 19:58:01.098489       1 tree_storage.go:89] Failed to set strict mode on mysql db: dial tcp 192.168.8.4:3306: connect: connection refused
F0307 19:58:01.098555       1 main.go:118] Failed to get storage provider: dial tcp 192.168.8.4:3306: connect: connection refused
...
```

## Testing process

On a personal machine, it can take 90s for mysql to be ready.

```
rekor git:(main) ✗ docker compose up -d
[+] Running 5/6
 ✔ Network rekor_default                  Created                                                0.2s 
 ✔ Container rekor-redis-server-1         Started                                                0.9s 
 ⠴ Container rekor-mysql-1                Waiting                                               74.6s 
 ✔ Container rekor-trillian-log-signer-1  Created                                                0.0s 
 ✔ Container rekor-trillian-log-server-1  Created                                                0.1s 
 ✔ Container rekor-rekor-server-1         Created                                                0.0s
```

trillian-log-signer starts cleanly

```log
 *  Executing task: docker logs --tail 1000 -f e857bcb48a25bbe038a4100a7a68c50e94bf34e82756edfddf485193232cc151 

I0307 19:50:31.772888       1 main.go:108] **** Log Signer Starting ****
W0307 19:50:31.776053       1 main.go:147] **** Acting as master for all logs ****
I0307 19:50:31.776630       1 operation_manager.go:328] Log operation manager starting
I0307 19:50:31.776821       1 main.go:188] RPC server starting on 0.0.0.0:8090
I0307 19:50:31.777010       1 main.go:149] HTTP server starting on 0.0.0.0:8091
I0307 19:50:31.777957       1 operation_manager.go:285] Acting as master for 0 / 0 active logs: master for:
I0307 19:50:33.287933       1 operation_manager.go:243] create master election goroutine for 4643029436978467864
I0307 19:50:33.938962       1 runner.go:130] 4643029436978467864: Now, I am the master
I0307 19:50:33.995308       1 operation_manager.go:285] Acting as master for 1 / 1 active logs: master for: <log-4643029436978467864>
...
I0307 19:51:05.615560       1 operation_manager.go:453] 4643029436978467864: processed 1 items in 0.02 seconds (60.26 qps)
I0307 19:51:40.781837       1 runner.go:148] 4643029436978467864: queue up resignation of mastership
I0307 19:51:40.821169       1 runner.go:172] 4643029436978467864: deliberately resigning mastership
I0307 19:51:40.821239       1 runner.go:130] 4643029436978467864: Now, I am the master
I0307 19:53:06.594238       1 runner.go:148] 4643029436978467864: queue up resignation of mastership
I0307 19:53:06.655440       1 runner.go:172] 4643029436978467864: deliberately resigning mastership
I0307 19:53:06.655525       1 runner.go:130] 4643029436978467864: Now, I am the master
```

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Better timeouts and readiness checks in docker-compose.yml.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
