### PR TITLE
better mysql healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,8 @@ services:
       - MYSQL_PASSWORD=zaphod
     restart: always # keep the MySQL server running
     healthcheck:
-      test: ["CMD", "/etc/init.d/mysql", "status"]
+      # better healthcheck for mysql. See https://github.com/docker-library/mysql/issues/930.
+      test: ["CMD", "mysqladmin", "-h", "localhost", "-u$MYSQL_USER",  "-p$MYSQL_ROOT_PASSWORD", "-s", "ping"]
       interval: 30s
       timeout: 3s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,9 +26,9 @@ services:
     healthcheck:
       # better healthcheck for mysql. See https://github.com/docker-library/mysql/issues/930.
       test: ["CMD", "mysqladmin", "-h", "localhost", "-u$MYSQL_USER",  "-p$MYSQL_ROOT_PASSWORD", "-s", "ping"]
-      interval: 30s
+      interval: 10s
       timeout: 3s
-      retries: 5
+      retries: 15
       start_period: 90s
   redis-server:
     image: docker.io/redis:6.2


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Improves the healthcheck for mysql in the docker-compose.yml file.

See https://github.com/docker-library/mysql/issues/930.

With the previous healthcheck, the mysql service may be running, but the actual database may not be ready yet.

```shell
 ➜  rekor git:(main) docker compose up --wait
[+] Running 5/6
 ✔ Network rekor_default                  Created          0.1s 
 ✔ Container rekor-redis-server-1         Healthy         94.4s 
 ✔ Container rekor-mysql-1                Healthy         94.4s 
 ✔ Container rekor-trillian-log-signer-1  Healthy         94.6s 
 ✔ Container rekor-trillian-log-server-1  Healthy         94.3s 
 ⠦ Container rekor-rekor-server-1         Waiting         96.1s 
container rekor-rekor-server-1 is unhealthy
```

With the newer healthcheck mysql takes longer to be healthy, but `docker compose up --wait` succeeds.

```shell
➜  rekor git:(main) ✗ docker compose up --wait
 ✔ Network rekor_default                  Created          0.2s 
[+] Running 5/6kor-redis-server-1         Started          1.4s 
[+] Running 6/6r_default                  Created          0.2s 
 ✔ Network rekor_default                  Created          0.2s 
 ✔ Container rekor-redis-server-1         Healthy        128.3s 
 ✔ Container rekor-mysql-1                Healthy        128.4s 
 ✔ Container rekor-trillian-log-server-1  Healthy        128.2s 
 ✔ Container rekor-trillian-log-signer-1  Healthy        128.2s 
 ✔ Container rekor-rekor-server-1         Healthy        133.5s
```

**TODO**

- [ ] add this same healthceck to fulcio's.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Improve docker-compose.yml healthcheck for mysql.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
