### PR TITLE
Fix docker compose up --wait failing when Trillian server isn't healthy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN CGO_ENABLED=0 go build -gcflags "all=-N -l" -ldflags "${SERVER_LDFLAGS}" -o 
 RUN go test -c -ldflags "${SERVER_LDFLAGS}" -cover -covermode=count -coverpkg=./... -o rekor-server_test ./cmd/rekor-server
 
 # Multi-Stage production build
-FROM golang:1.24.3@sha256:39d9e7d9c5d9c9e4baf0d8fff579f06d5032c0f4425cdec9e86732e8e4e374dc as deploy
+FROM golang:1.24.3@sha256:39d9e7d9c5d9c9e4baf0d8fff579f06d5032c0f4425cdec9e86732e8e4e374dc AS deploy
 
 # Retrieve the binary from the previous stage
 COPY --from=builder /opt/app-root/src/rekor-server /usr/local/bin/rekor-server
@@ -40,12 +40,12 @@ COPY --from=builder /opt/app-root/src/rekor-server /usr/local/bin/rekor-server
 CMD ["rekor-server", "serve"]
 
 # debug compile options & debugger
-FROM deploy as debug
+FROM deploy AS debug
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.22.1
 
 # overwrite server and include debugger
 COPY --from=builder /opt/app-root/src/rekor-server_debug /usr/local/bin/rekor-server
 
-FROM deploy as test
+FROM deploy AS test
 # overwrite server with test build with code coverage
 COPY --from=builder /opt/app-root/src/rekor-server_test /usr/local/bin/rekor-server

--- a/Dockerfile.trillian-log-server
+++ b/Dockerfile.trillian-log-server
@@ -1,0 +1,21 @@
+# Copyright 2025 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ghcr.io/sigstore/scaffolding/trillian_log_server:v1.7.2@sha256:ff64f73b4a8acae7546ecfb5b73c90933b614130a3b43c764a35535e4f60451b AS server
+
+FROM golang:1.24.3@sha256:39d9e7d9c5d9c9e4baf0d8fff579f06d5032c0f4425cdec9e86732e8e4e374dc AS deploy
+
+COPY --from=server /ko-app/trillian_log_server /usr/local/bin/trillian-log-server
+
+ENTRYPOINT ["trillian-log-server"]

--- a/Dockerfile.trillian-log-signer
+++ b/Dockerfile.trillian-log-signer
@@ -1,0 +1,21 @@
+# Copyright 2025 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ghcr.io/sigstore/scaffolding/trillian_log_signer:v1.7.2@sha256:bfcc659dc08f87a0f4a4797edf88c93426a95f0d004032779a028bdce7b7e821 AS server
+
+FROM golang:1.24.3@sha256:39d9e7d9c5d9c9e4baf0d8fff579f06d5032c0f4425cdec9e86732e8e4e374dc AS deploy
+
+COPY --from=server /ko-app/trillian_log_signer /usr/local/bin/trillian-log-signer
+
+ENTRYPOINT ["trillian-log-signer"]

--- a/docker-compose.backfill-test.yml
+++ b/docker-compose.backfill-test.yml
@@ -51,7 +51,7 @@ services:
       - MYSQL_PASSWORD=zaphod
     restart: always # keep the MySQL server running
     healthcheck:
-      test: ["CMD", "/etc/init.d/mysql", "status"]
+      test: "mysqladmin -h 127.0.0.1 --user=$$MYSQL_USER --password=$$MYSQL_ROOT_PASSWORD -s ping"
       interval: 30s
       timeout: 3s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,9 +24,9 @@ services:
       - MYSQL_PASSWORD=zaphod
     restart: always # keep the MySQL server running
     healthcheck:
-      # better healthcheck for mysql. See https://github.com/docker-library/mysql/issues/930.
-      test: ["CMD", "mysqladmin", "-h", "localhost", "-u$MYSQL_USER",  "-p$MYSQL_ROOT_PASSWORD", "-s", "ping"]
-      interval: 10s
+      # better healthcheck for MySQL. See https://github.com/docker-library/mysql/issues/930.
+      test: "mysqladmin -h 127.0.0.1 --user=$$MYSQL_USER --password=$$MYSQL_ROOT_PASSWORD -s ping"
+      interval: 5s
       timeout: 3s
       retries: 15
       start_period: 90s
@@ -50,7 +50,9 @@ services:
       retries: 3
       start_period: 5s
   trillian-log-server:
-    image: ghcr.io/sigstore/scaffolding/trillian_log_server@sha256:beffee16bb07b5cb051dc4e476d3a1063521ed5ae0b670efc7fe6f3507d94d2b # v1.6.0
+    build:
+      context: .
+      dockerfile: Dockerfile.trillian-log-server
     command: [
       "--quota_system=noop",
       "--storage_system=mysql",
@@ -59,15 +61,23 @@ services:
       "--http_endpoint=0.0.0.0:8091",
       "--alsologtostderr",
     ]
-    restart: always # retry while mysql is starting up
+    restart: always # keep the Trillian log server up
     ports:
       - "8090:8090"
       - "8091:8091"
     depends_on:
       mysql:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8091/healthz"]
+      interval: 5s
+      timeout: 3s
+      retries: 15
+      start_period: 15s
   trillian-log-signer:
-    image: ghcr.io/sigstore/scaffolding/trillian_log_signer@sha256:79d57af375cfa997ed5452cc0c02c0396d909fcc91d11065586f119490aa9214 # v1.6.0
+    build:
+      context: .
+      dockerfile: Dockerfile.trillian-log-signer
     command: [
       "--quota_system=noop",
       "--storage_system=mysql",
@@ -77,12 +87,18 @@ services:
       "--force_master",
       "--alsologtostderr",
     ]
-    restart: always # retry while mysql is starting up
+    restart: always # keep the log signer up
     ports:
       - "8092:8091"
     depends_on:
       mysql:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8091/healthz"]
+      interval: 5s
+      timeout: 3s
+      retries: 15
+      start_period: 15s
   rekor-server:
     build:
       context: .
@@ -119,7 +135,7 @@ services:
       redis-server:
         condition: service_healthy
       trillian-log-server:
-        condition: service_started
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/ping"]
       interval: 10s

--- a/e2e-test.sh
+++ b/e2e-test.sh
@@ -41,7 +41,7 @@ go test -c ./cmd/rekor-server -o rekor-server -covermode=count -coverpkg=./...
 
 count=0
 echo -n "waiting up to 120 sec for system to start"
-until [ $(${docker_compose} ps | grep -c "(healthy)") == 4 ];
+until [ $(${docker_compose} ps | grep -c "(healthy)") == 6 ];
 do
     if [ $count -eq 12 ]; then
        echo "! timeout reached"

--- a/tests/client-algos-e2e-test.sh
+++ b/tests/client-algos-e2e-test.sh
@@ -30,7 +30,7 @@ function waitForRekorServer () {
   echo -n "* waiting up to 60 sec for system to start"
   count=0
 
-  until [ $(docker ps -a | grep -c "(healthy)") == 3 ];
+  until [ $(docker ps -a | grep -c "(healthy)") == 5 ];
   do
       if [ $count -eq 6 ]; then
         echo "! timeout reached"

--- a/tests/index-test-utils.sh
+++ b/tests/index-test-utils.sh
@@ -73,8 +73,8 @@ docker_up () {
     local count=0
     echo "waiting up to 2 min for system to start"
     until [ $(${docker_compose} ps | \
-       grep -E "(rekor[-_]mysql|rekor[-_]redis|rekor[-_]rekor-server)" | \
-       grep -c "(healthy)" ) == 3 ];
+       grep -E "(rekor[-_]mysql|rekor[-_]redis|rekor[-_]rekor-server|rekor[-_]trillian)" | \
+       grep -c "(healthy)" ) == 5 ];
     do
         if [ $count -eq 24 ]; then
            echo "! timeout reached"

--- a/tests/issue-872-e2e-test.sh
+++ b/tests/issue-872-e2e-test.sh
@@ -33,7 +33,7 @@ function waitForRekorServer () {
   echo -n "* waiting up to 60 sec for system to start"
   count=0
 
-  until [ $(docker ps -a | grep -c "(healthy)") == 3 ];
+  until [ $(docker ps -a | grep -c "(healthy)") == 5 ];
   do
       if [ $count -eq 6 ]; then
         echo "! timeout reached"

--- a/tests/rekor-harness.sh
+++ b/tests/rekor-harness.sh
@@ -46,7 +46,7 @@ function start_server () {
 
     count=0
     echo -n "waiting up to 60 sec for system to start"
-    until [ $(${docker_compose} ps | grep -c "(healthy)") == 3 ];
+    until [ $(${docker_compose} ps | grep -c "(healthy)") -ge "3" ];
     do
         if [ $count -eq 6 ]; then
             echo "! timeout reached"

--- a/tests/sharding-e2e-test.sh
+++ b/tests/sharding-e2e-test.sh
@@ -79,7 +79,7 @@ function waitForRekorServer () {
   count=0
 
   echo -n "waiting up to 60 sec for system to start"
-  until [ $(${docker_compose} ps | grep -c "(healthy)") == 3 ];
+  until [ $(${docker_compose} ps | grep -c "(healthy)") == 5 ];
   do
       if [ $count -eq 6 ]; then
         echo "! timeout reached"


### PR DESCRIPTION
As noted in https://github.com/docker/compose/issues/12424, compose --wait doesn't seem to honor healthchecks with restart:always, when the server crashes and restarts a few times and eventually becomes healthy. This was happening with Rekor:

* MySQL was not yet healthy because the healthcheck wasn't working as expected. https://github.com/docker-library/mysql/issues/930#issuecomment-1463541157 suggested using 127.0.0.1 instead of localhost
* trillian-log-server was not yet healthy even when MySQL reported as healthy, causing trillian-log-server to crash and restart a few times. There was no healthcheck for either Trillian service because the image we're using is based on Distroless, which has no curl/wget.
* rekor-server tried to start up with an unhealthy trillian-log-server, and crashed. The healthcheck reported as unhealthy, and even though the server eventually became healthy because of the restart:always policy, the healthcheck reported the startup as unhealthy.

This change adds healthchecks to trillian-log-server and log-signer by pulling the binaries out of the images and putting them into Debian 12 containers that include curl, so we can curl the /healthz endpoint. This also fixes the MySQL healthcheck as noted above. Now, docker compose up --wait properly waits for a healthy MySQL before starting trillian-log-server, and a healthy Trillian before starting Rekor.

Also fix minor Dockerfile linting errors.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
