### PR TITLE
bump golangci-lint to v2.2.x

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -67,4 +67,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v2.1
+          version: v2.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,6 +42,9 @@ linters:
       - linters:
           - gosec
         text: 'G115: '
+      - linters:
+          - revive
+        text: "var-naming: avoid meaningless package names"
     paths:
       - third_party$
       - builtin$


### PR DESCRIPTION

#### Summary
- bump golangci-lint to v2.2.x
