### PR TITLE
move context handling in trillian RPC calls to be request based and idiomatic

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -183,8 +183,8 @@ func NewAPI(treeID uint) (*API, error) {
 
 	cachedCheckpoints := make(map[int64]string)
 	for _, r := range ranges.GetInactive() {
-		tc := trillianclient.NewTrillianClient(ctx, logClient, r.TreeID)
-		resp := tc.GetLatest(0)
+		tc := trillianclient.NewTrillianClient(logClient, r.TreeID)
+		resp := tc.GetLatest(context.Background(), 0)
 		if resp.Status != codes.OK {
 			return nil, fmt.Errorf("error fetching latest tree head for inactive shard %d: resp code is %d, err is %w", r.TreeID, resp.Status, resp.Err)
 		}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -184,7 +184,7 @@ func NewAPI(treeID uint) (*API, error) {
 	cachedCheckpoints := make(map[int64]string)
 	for _, r := range ranges.GetInactive() {
 		tc := trillianclient.NewTrillianClient(logClient, r.TreeID)
-		resp := tc.GetLatest(context.Background(), 0)
+		resp := tc.GetLatest(ctx, 0)
 		if resp.Status != codes.OK {
 			return nil, fmt.Errorf("error fetching latest tree head for inactive shard %d: resp code is %d, err is %w", r.TreeID, resp.Status, resp.Err)
 		}

--- a/pkg/witness/publish_checkpoint.go
+++ b/pkg/witness/publish_checkpoint.go
@@ -81,7 +81,7 @@ func NewCheckpointPublisher(ctx context.Context,
 // before publishing the latest checkpoint. If this occurs due to a sporadic failure, this simply
 // means that a witness will not see a fresh checkpoint for an additional period.
 func (c *CheckpointPublisher) StartPublisher(ctx context.Context) {
-	tc := trillianclient.NewTrillianClient(context.Background(), c.logClient, c.treeID)
+	tc := trillianclient.NewTrillianClient(c.logClient, c.treeID)
 	sTreeID := strconv.FormatInt(c.treeID, 10)
 
 	// publish on startup to ensure a checkpoint is available the first time Rekor starts up
@@ -103,7 +103,7 @@ func (c *CheckpointPublisher) StartPublisher(ctx context.Context) {
 // publish publishes the latest checkpoint to Redis once
 func (c *CheckpointPublisher) publish(tc *trillianclient.TrillianClient, sTreeID string) {
 	// get latest checkpoint
-	resp := tc.GetLatest(0)
+	resp := tc.GetLatest(context.Background(), 0)
 	if resp.Status != codes.OK {
 		c.reqCounter.With(
 			map[string]string{


### PR DESCRIPTION
there were a couple inconsistencies in how request contexts were being used when calling trillian. cleaning those up to ensure we have consistent behaviors across the client.