### PR TITLE
allow configuring gRPC default service config for trillian client

### DIFF
--- a/cmd/rekor-server/app/root.go
+++ b/cmd/rekor-server/app/root.go
@@ -90,6 +90,7 @@ func init() {
 	rootCmd.PersistentFlags().Uint16("trillian_log_server.port", 8090, "Trillian log server port")
 	rootCmd.PersistentFlags().Uint("trillian_log_server.tlog_id", 0, "Trillian tree id")
 	rootCmd.PersistentFlags().String("trillian_log_server.sharding_config", "", "path to config file for inactive shards, in JSON or YAML")
+	rootCmd.PersistentFlags().String("trillian_log_server.grpc_default_service_config", "", "JSON string used to configure gRPC clients for communicating with Trillian")
 
 	rootCmd.PersistentFlags().Uint("publish_frequency", 5, "how often to publish a new checkpoint, in minutes")
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -27,6 +27,7 @@ services:
       "serve",
       "--trillian_log_server.address=trillian-log-server",
       "--trillian_log_server.port=8090",
+      "--trillian_log_server.grpc_default_service_config={\"loadBalancingPolicy\":\"round_robin\"}",
       "--redis_server.address=redis-server",
       "--redis_server.port=6379",
       "--redis_server.password=test",

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -82,7 +82,13 @@ func dial(rpcServer string) (*grpc.ClientConn, error) {
 	default:
 		creds = insecure.NewCredentials()
 	}
-	conn, err := grpc.NewClient(rpcServer, grpc.WithTransportCredentials(creds))
+
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(creds)}
+	grpcDefaultServiceConfig := viper.GetString("trillian_log_server.grpc_default_service_config")
+	if grpcDefaultServiceConfig != "" {
+		opts = append(opts, grpc.WithDefaultServiceConfig(grpcDefaultServiceConfig))
+	}
+	conn, err := grpc.NewClient(rpcServer, opts...)
 	if err != nil {
 		log.Logger.Fatalf("Failed to connect to RPC server:", err)
 	}


### PR DESCRIPTION
this allows deployers to configure trillian client load balancing & timeouts
