### PR TITLE
move to direct decoding instead of mapstructure

### DIFF
--- a/pkg/types/alpine/v0.0.1/benchmark_test.go
+++ b/pkg/types/alpine/v0.0.1/benchmark_test.go
@@ -1,3 +1,18 @@
+//
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package alpine
 
 import (

--- a/pkg/types/alpine/v0.0.1/benchmark_test.go
+++ b/pkg/types/alpine/v0.0.1/benchmark_test.go
@@ -1,0 +1,79 @@
+package alpine
+
+import (
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/sigstore/rekor/pkg/generated/models"
+	"github.com/sigstore/rekor/pkg/types"
+)
+
+// Sample test data for benchmarking - using proper base64 encoded data
+var sampleAlpineData = map[string]any{
+	"publicKey": map[string]any{
+		"content": "dGVzdFB1YmxpY0tleQ==", // "testPublicKey" base64 encoded
+	},
+	"package": map[string]any{
+		"hash": map[string]any{
+			"algorithm": "sha256",
+			"value":     "abcdef123456",
+		},
+		"content": "dGVzdFBhY2thZ2VDb250ZW50", // "testPackageContent" base64 encoded
+	},
+}
+
+// BenchmarkDecodeEntryMapstructure benchmarks the original mapstructure-based DecodeEntry
+func BenchmarkDecodeEntryMapstructure(b *testing.B) {
+	for b.Loop() {
+		var alpineObj models.AlpineV001Schema
+		err := types.DecodeEntry(sampleAlpineData, &alpineObj)
+		if err != nil {
+			b.Fatalf("DecodeEntry failed: %v", err)
+		}
+
+		// Validate the result to ensure it's properly decoded
+		if err := alpineObj.Validate(strfmt.Default); err != nil {
+			b.Fatalf("Validation failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryDirect benchmarks the new direct JSON unmarshaling method
+func BenchmarkDecodeEntryDirect(b *testing.B) {
+	for b.Loop() {
+		entry := &V001Entry{}
+		err := DecodeEntry(sampleAlpineData, &entry.AlpineModel)
+		if err != nil {
+			b.Fatalf("DecodeEntryDirect failed: %v", err)
+		}
+
+		// Validate the result to ensure it's properly decoded
+		if err := entry.AlpineModel.Validate(strfmt.Default); err != nil {
+			b.Fatalf("Validation failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryMapstructureMemory benchmarks memory allocation for mapstructure
+func BenchmarkDecodeEntryMapstructureMemory(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		var alpineObj models.AlpineV001Schema
+		err := types.DecodeEntry(sampleAlpineData, &alpineObj)
+		if err != nil {
+			b.Fatalf("DecodeEntry failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryDirectMemory benchmarks memory allocation for direct method
+func BenchmarkDecodeEntryDirectMemory(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		entry := &V001Entry{}
+		err := DecodeEntry(sampleAlpineData, &entry.AlpineModel)
+		if err != nil {
+			b.Fatalf("DecodeEntryDirect failed: %v", err)
+		}
+	}
+}

--- a/pkg/types/alpine/v0.0.1/entry.go
+++ b/pkg/types/alpine/v0.0.1/entry.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -88,13 +89,85 @@ func (v V001Entry) IndexKeys() ([]string, error) {
 	return result, nil
 }
 
+// DecodeEntry performs direct JSON unmarshaling without reflection,
+// equivalent to types.DecodeEntry but with better performance for alpine v0.0.1.
+func DecodeEntry(input any, output *models.AlpineV001Schema) error {
+	var m models.AlpineV001Schema
+	switch data := input.(type) {
+	case map[string]any:
+		mp := data
+		if pk, ok := mp["publicKey"].(map[string]any); ok {
+			if cs, ok := pk["content"].(string); ok && cs != "" {
+				outBuf := make([]byte, base64.StdEncoding.DecodedLen(len(cs)))
+				n, err := base64.StdEncoding.Decode(outBuf, []byte(cs))
+				if err != nil {
+					return fmt.Errorf("failed parsing base64 data for public key content: %w", err)
+				}
+				m.PublicKey = &models.AlpineV001SchemaPublicKey{}
+				content := strfmt.Base64(outBuf[:n])
+				m.PublicKey.Content = &content
+			}
+		}
+		if p, ok := mp["package"].(map[string]any); ok {
+			m.Package = &models.AlpineV001SchemaPackage{}
+			if pi, ok := p["pkginfo"].(map[string]any); ok {
+				mm := make(map[string]string, len(pi))
+				for k, vv := range pi {
+					if s, ok := vv.(string); ok {
+						mm[k] = s
+					}
+				}
+				if len(mm) > 0 {
+					m.Package.Pkginfo = mm
+				}
+			}
+			if h, ok := p["hash"].(map[string]any); ok {
+				var alg, val *string
+				if a, ok := h["algorithm"].(string); ok {
+					alg = &a
+				}
+				if s, ok := h["value"].(string); ok {
+					val = &s
+				}
+				if alg != nil || val != nil {
+					m.Package.Hash = &models.AlpineV001SchemaPackageHash{
+						Algorithm: alg,
+						Value:     val,
+					}
+				}
+			}
+			if cs, ok := p["content"].(string); ok && cs != "" {
+				outBuf := make([]byte, base64.StdEncoding.DecodedLen(len(cs)))
+				n, err := base64.StdEncoding.Decode(outBuf, []byte(cs))
+				if err != nil {
+					return fmt.Errorf("failed parsing base64 data for package content: %w", err)
+				}
+				m.Package.Content = strfmt.Base64(outBuf[:n])
+			}
+		}
+		*output = m
+		return nil
+	case *models.AlpineV001Schema:
+		if data == nil {
+			return fmt.Errorf("nil *models.AlpineV001Schema")
+		}
+		*output = *data
+		return nil
+	case models.AlpineV001Schema:
+		*output = data
+		return nil
+	default:
+		return fmt.Errorf("unsupported input type %T for DecodeEntry", input)
+	}
+}
+
 func (v *V001Entry) Unmarshal(pe models.ProposedEntry) error {
 	apk, ok := pe.(*models.Alpine)
 	if !ok {
 		return errors.New("cannot unmarshal non Alpine v0.0.1 type")
 	}
 
-	if err := types.DecodeEntry(apk.Spec, &v.AlpineModel); err != nil {
+	if err := DecodeEntry(apk.Spec, &v.AlpineModel); err != nil {
 		return err
 	}
 

--- a/pkg/types/alpine/v0.0.1/fuzz_test.go
+++ b/pkg/types/alpine/v0.0.1/fuzz_test.go
@@ -17,10 +17,12 @@ package alpine
 
 import (
 	"context"
+	"encoding/base64"
 	"sync"
 	"testing"
 
 	fuzz "github.com/AdamKorcz/go-fuzz-headers-1"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 
 	fuzzUtils "github.com/sigstore/rekor/pkg/fuzz"
@@ -93,5 +95,51 @@ func FuzzAlpineUnmarshalAndCanonicalize(f *testing.F) {
 		if _, err := types.CanonicalizeEntry(context.Background(), ei); err != nil {
 			t.Skip()
 		}
+	})
+}
+
+// New: fuzz the direct decoder map fast-path and raw JSON fallbacks
+func FuzzAlpineDecodeEntryDirectMapAndRaw(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		initter.Do(fuzzUtils.SetFuzzLogger)
+		ff := fuzz.NewConsumer(data)
+		choice, _ := ff.GetInt()
+		choice %= 2
+
+		toB64 := func(limit int) string {
+			b, _ := ff.GetBytes()
+			if len(b) > limit {
+				b = b[:limit]
+			}
+			return base64.StdEncoding.EncodeToString(b)
+		}
+
+		var input any
+		switch choice {
+		case 0:
+			m := map[string]any{}
+			if b, _ := ff.GetBool(); b {
+				m["publicKey"] = map[string]any{"content": toB64(256)}
+			}
+			if b, _ := ff.GetBool(); b {
+				m["package"] = map[string]any{
+					"content": toB64(512),
+					"hash":    map[string]any{"algorithm": "sha256", "value": "deadbeef"},
+				}
+			}
+			input = m
+		case 1:
+			mdl := &models.AlpineV001Schema{}
+			if err := ff.GenerateStruct(mdl); err != nil {
+				t.Skip()
+			}
+			input = mdl
+		}
+
+		entry := &V001Entry{}
+		if err := DecodeEntry(input, &entry.AlpineModel); err != nil {
+			t.Skip()
+		}
+		_ = entry.AlpineModel.Validate(strfmt.Default)
 	})
 }

--- a/pkg/types/cose/v0.0.1/benchmark_test.go
+++ b/pkg/types/cose/v0.0.1/benchmark_test.go
@@ -1,3 +1,18 @@
+//
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cose
 
 import (

--- a/pkg/types/cose/v0.0.1/benchmark_test.go
+++ b/pkg/types/cose/v0.0.1/benchmark_test.go
@@ -1,0 +1,82 @@
+package cose
+
+import (
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/sigstore/rekor/pkg/generated/models"
+	"github.com/sigstore/rekor/pkg/types"
+)
+
+// Sample test data for benchmarking - using proper base64 encoded data
+var sampleCOSEData = map[string]any{
+	"message":   "dGVzdE1lc3NhZ2U=",     // "testMessage" base64 encoded
+	"publicKey": "dGVzdFB1YmxpY0tleQ==", // "testPublicKey" base64 encoded
+	"data": map[string]any{
+		"payloadHash": map[string]any{
+			"algorithm": "sha256",
+			"value":     "abcdef123456",
+		},
+		"envelopeHash": map[string]any{
+			"algorithm": "sha256",
+			"value":     "fedcba654321",
+		},
+		"aad": "dGVzdEFBRA==", // "testAAD" base64 encoded
+	},
+}
+
+// BenchmarkDecodeEntryMapstructure benchmarks the original mapstructure-based DecodeEntry
+func BenchmarkDecodeEntryMapstructure(b *testing.B) {
+	for b.Loop() {
+		var coseObj models.CoseV001Schema
+		err := types.DecodeEntry(sampleCOSEData, &coseObj)
+		if err != nil {
+			b.Fatalf("DecodeEntry failed: %v", err)
+		}
+
+		// Validate the result to ensure it's properly decoded
+		if err := coseObj.Validate(strfmt.Default); err != nil {
+			b.Fatalf("Validation failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryDirect benchmarks the new direct JSON unmarshaling method
+func BenchmarkDecodeEntryDirect(b *testing.B) {
+	for b.Loop() {
+		entry := &V001Entry{}
+		err := DecodeEntry(sampleCOSEData, &entry.CoseObj)
+		if err != nil {
+			b.Fatalf("DecodeEntryDirect failed: %v", err)
+		}
+
+		// Validate the result to ensure it's properly decoded
+		if err := entry.CoseObj.Validate(strfmt.Default); err != nil {
+			b.Fatalf("Validation failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryMapstructureMemory benchmarks memory allocation for mapstructure
+func BenchmarkDecodeEntryMapstructureMemory(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		var coseObj models.CoseV001Schema
+		err := types.DecodeEntry(sampleCOSEData, &coseObj)
+		if err != nil {
+			b.Fatalf("DecodeEntry failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryDirectMemory benchmarks memory allocation for direct method
+func BenchmarkDecodeEntryDirectMemory(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		entry := &V001Entry{}
+		err := DecodeEntry(sampleCOSEData, &entry.CoseObj)
+		if err != nil {
+			b.Fatalf("DecodeEntryDirect failed: %v", err)
+		}
+	}
+}

--- a/pkg/types/cose/v0.0.1/fuzz_test.go
+++ b/pkg/types/cose/v0.0.1/fuzz_test.go
@@ -17,10 +17,12 @@ package cose
 
 import (
 	"context"
+	"encoding/base64"
 	"sync"
 	"testing"
 
 	fuzz "github.com/AdamKorcz/go-fuzz-headers-1"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 
 	fuzzUtils "github.com/sigstore/rekor/pkg/fuzz"
@@ -97,5 +99,63 @@ func FuzzCoseUnmarshalAndCanonicalize(f *testing.F) {
 		if _, err := types.CanonicalizeEntry(context.Background(), ei); err != nil {
 			t.Errorf("error canonicalizing unmarshalled entry: %v", err)
 		}
+	})
+}
+
+// New: fuzz the direct decoder map fast-path and raw JSON fallbacks
+func FuzzCoseDecodeEntryDirectMapAndRaw(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		initter.Do(fuzzUtils.SetFuzzLogger)
+		ff := fuzz.NewConsumer(data)
+		choice, _ := ff.GetInt()
+		choice %= 2
+
+		toB64 := func(limit int) string {
+			b, _ := ff.GetBytes()
+			if len(b) > limit {
+				b = b[:limit]
+			}
+			return base64.StdEncoding.EncodeToString(b)
+		}
+
+		var input any
+		switch choice {
+		case 0:
+			m := map[string]any{}
+			// Optional message and publicKey
+			if b, _ := ff.GetBool(); b {
+				m["message"] = toB64(256)
+			}
+			if b, _ := ff.GetBool(); b {
+				m["publicKey"] = toB64(256)
+			}
+			// Data block
+			if b, _ := ff.GetBool(); b {
+				d := map[string]any{}
+				if b2, _ := ff.GetBool(); b2 {
+					d["payloadHash"] = map[string]any{"algorithm": "sha256", "value": "deadbeef"}
+				}
+				if b3, _ := ff.GetBool(); b3 {
+					d["envelopeHash"] = map[string]any{"algorithm": "sha256", "value": "cafebabe"}
+				}
+				if b4, _ := ff.GetBool(); b4 {
+					d["aad"] = toB64(128)
+				}
+				m["data"] = d
+			}
+			input = m
+		case 1:
+			mdl := &models.CoseV001Schema{}
+			if err := ff.GenerateStruct(mdl); err != nil {
+				t.Skip()
+			}
+			input = mdl
+		}
+
+		entry := &V001Entry{}
+		if err := DecodeEntry(input, &entry.CoseObj); err != nil {
+			t.Skip()
+		}
+		_ = entry.CoseObj.Validate(strfmt.Default)
 	})
 }

--- a/pkg/types/dsse/v0.0.1/benchmark_test.go
+++ b/pkg/types/dsse/v0.0.1/benchmark_test.go
@@ -1,0 +1,88 @@
+package dsse
+
+import (
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/sigstore/rekor/pkg/generated/models"
+	"github.com/sigstore/rekor/pkg/types"
+)
+
+// Sample test data for benchmarking - using proper base64 signatures that match the regex
+
+var sampleDSSEData = map[string]any{
+	"proposedContent": map[string]any{
+		"envelope":  `{"payload":"dGVzdA==","payloadType":"application/vnd.in-toto+json","signatures":[{"sig":"MEUCIQDGk7qkVHnVahoEn4cLP9DRjxBArABCDEFGHIJKLMNOPQ=="}]}`,
+		"verifiers": []string{"dGVzdFZlcmlmaWVyMQ==", "dGVzdFZlcmlmaWVyMg=="},
+	},
+	"signatures": []map[string]any{
+		{
+			"signature": "MEUCIQDGk7qkVHnVahoEn4cLP9DRjxBArABCDEFGHIJKLMNOPQ==",
+			"verifier":  "dGVzdFZlcmlmaWVyMQ==",
+		},
+	},
+	"envelopeHash": map[string]any{
+		"algorithm": "sha256",
+		"value":     "abc123",
+	},
+	"payloadHash": map[string]any{
+		"algorithm": "sha256",
+		"value":     "def456",
+	},
+}
+
+// BenchmarkDecodeEntryMapstructure benchmarks the original mapstructure-based DecodeEntry
+func BenchmarkDecodeEntryMapstructure(b *testing.B) {
+	for b.Loop() {
+		var dsseObj models.DSSEV001Schema
+		err := types.DecodeEntry(sampleDSSEData, &dsseObj)
+		if err != nil {
+			b.Fatalf("DecodeEntry failed: %v", err)
+		}
+
+		// Validate the result to ensure it's properly decoded
+		if err := dsseObj.Validate(strfmt.Default); err != nil {
+			b.Fatalf("Validation failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryDirect benchmarks the new direct JSON unmarshaling method
+func BenchmarkDecodeEntryDirect(b *testing.B) {
+	for b.Loop() {
+		entry := &V001Entry{}
+		err := DecodeEntry(sampleDSSEData, &entry.DSSEObj)
+		if err != nil {
+			b.Fatalf("DecodeEntryDirect failed: %v", err)
+		}
+
+		// Validate the result to ensure it's properly decoded
+		if err := entry.DSSEObj.Validate(strfmt.Default); err != nil {
+			b.Fatalf("Validation failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryMapstructureMemory benchmarks memory allocation for mapstructure
+func BenchmarkDecodeEntryMapstructureMemory(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		var dsseObj models.DSSEV001Schema
+		err := types.DecodeEntry(sampleDSSEData, &dsseObj)
+		if err != nil {
+			b.Fatalf("DecodeEntry failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryDirectMemory benchmarks memory allocation for direct method
+func BenchmarkDecodeEntryDirectMemory(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		entry := &V001Entry{}
+		err := DecodeEntry(sampleDSSEData, &entry.DSSEObj)
+		if err != nil {
+			b.Fatalf("DecodeEntryDirect failed: %v", err)
+		}
+	}
+}

--- a/pkg/types/dsse/v0.0.1/benchmark_test.go
+++ b/pkg/types/dsse/v0.0.1/benchmark_test.go
@@ -1,3 +1,18 @@
+//
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package dsse
 
 import (

--- a/pkg/types/hashedrekord/v0.0.1/benchmark_test.go
+++ b/pkg/types/hashedrekord/v0.0.1/benchmark_test.go
@@ -1,3 +1,18 @@
+//
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package hashedrekord
 
 import (

--- a/pkg/types/hashedrekord/v0.0.1/benchmark_test.go
+++ b/pkg/types/hashedrekord/v0.0.1/benchmark_test.go
@@ -1,0 +1,81 @@
+package hashedrekord
+
+import (
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/sigstore/rekor/pkg/generated/models"
+	"github.com/sigstore/rekor/pkg/types"
+)
+
+// Sample test data for benchmarking
+var sampleHashedRekordData = map[string]any{
+	"signature": map[string]any{
+		"content": "dGVzdFNpZ25hdHVyZQ==",
+		"publicKey": map[string]any{
+			"content": "dGVzdFB1YmxpY0tleQ==",
+		},
+	},
+	"data": map[string]any{
+		"hash": map[string]any{
+			"algorithm": "sha256",
+			"value":     "abc123def456",
+		},
+	},
+}
+
+// BenchmarkDecodeEntryMapstructure benchmarks the original mapstructure-based DecodeEntry
+func BenchmarkDecodeEntryMapstructure(b *testing.B) {
+	for b.Loop() {
+		var hashedRekordObj models.HashedrekordV001Schema
+		err := types.DecodeEntry(sampleHashedRekordData, &hashedRekordObj)
+		if err != nil {
+			b.Fatalf("DecodeEntry failed: %v", err)
+		}
+
+		// Validate the result to ensure it's properly decoded
+		if err := hashedRekordObj.Validate(strfmt.Default); err != nil {
+			b.Fatalf("Validation failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryDirect benchmarks the new direct JSON unmarshaling method
+func BenchmarkDecodeEntryDirect(b *testing.B) {
+	for b.Loop() {
+		entry := &V001Entry{}
+		err := DecodeEntry(sampleHashedRekordData, &entry.HashedRekordObj)
+		if err != nil {
+			b.Fatalf("DecodeEntryDirect failed: %v", err)
+		}
+
+		// Validate the result to ensure it's properly decoded
+		if err := entry.HashedRekordObj.Validate(strfmt.Default); err != nil {
+			b.Fatalf("Validation failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryMapstructureMemory benchmarks memory allocation for mapstructure
+func BenchmarkDecodeEntryMapstructureMemory(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		var hashedRekordObj models.HashedrekordV001Schema
+		err := types.DecodeEntry(sampleHashedRekordData, &hashedRekordObj)
+		if err != nil {
+			b.Fatalf("DecodeEntry failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryDirectMemory benchmarks memory allocation for direct method
+func BenchmarkDecodeEntryDirectMemory(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		entry := &V001Entry{}
+		err := DecodeEntry(sampleHashedRekordData, &entry.HashedRekordObj)
+		if err != nil {
+			b.Fatalf("DecodeEntryDirect failed: %v", err)
+		}
+	}
+}

--- a/pkg/types/hashedrekord/v0.0.1/entry.go
+++ b/pkg/types/hashedrekord/v0.0.1/entry.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -85,13 +86,73 @@ func (v V001Entry) IndexKeys() ([]string, error) {
 	return result, nil
 }
 
+// DecodeEntry performs direct decode into the provided output pointer
+// without mutating the receiver on error.
+func DecodeEntry(input any, output *models.HashedrekordV001Schema) error {
+	if output == nil {
+		return fmt.Errorf("nil output *models.HashedrekordV001Schema")
+	}
+	var m models.HashedrekordV001Schema
+	// Single type-switch with map fast path
+	switch data := input.(type) {
+	case map[string]any:
+		mm := data
+		if sigRaw, ok := mm["signature"].(map[string]any); ok {
+			m.Signature = &models.HashedrekordV001SchemaSignature{}
+			if c, ok := sigRaw["content"].(string); ok && c != "" {
+				outb := make([]byte, base64.StdEncoding.DecodedLen(len(c)))
+				n, err := base64.StdEncoding.Decode(outb, []byte(c))
+				if err != nil {
+					return fmt.Errorf("failed parsing base64 data for signature content: %w", err)
+				}
+				m.Signature.Content = outb[:n]
+			}
+			if pkRaw, ok := sigRaw["publicKey"].(map[string]any); ok {
+				m.Signature.PublicKey = &models.HashedrekordV001SchemaSignaturePublicKey{}
+				if c, ok := pkRaw["content"].(string); ok && c != "" {
+					outb := make([]byte, base64.StdEncoding.DecodedLen(len(c)))
+					n, err := base64.StdEncoding.Decode(outb, []byte(c))
+					if err != nil {
+						return fmt.Errorf("failed parsing base64 data for public key content: %w", err)
+					}
+					m.Signature.PublicKey.Content = outb[:n]
+				}
+			}
+		}
+		if dataRaw, ok := mm["data"].(map[string]any); ok {
+			if hRaw, ok := dataRaw["hash"].(map[string]any); ok {
+				m.Data = &models.HashedrekordV001SchemaData{Hash: &models.HashedrekordV001SchemaDataHash{}}
+				if alg, ok := hRaw["algorithm"].(string); ok {
+					m.Data.Hash.Algorithm = &alg
+				}
+				if val, ok := hRaw["value"].(string); ok {
+					m.Data.Hash.Value = &val
+				}
+			}
+		}
+		*output = m
+		return nil
+	case *models.HashedrekordV001Schema:
+		if data == nil {
+			return fmt.Errorf("nil *models.HashedrekordV001Schema")
+		}
+		*output = *data
+		return nil
+	case models.HashedrekordV001Schema:
+		*output = data
+		return nil
+	default:
+		return fmt.Errorf("unsupported input type %T for DecodeEntry", input)
+	}
+}
+
 func (v *V001Entry) Unmarshal(pe models.ProposedEntry) error {
 	rekord, ok := pe.(*models.Hashedrekord)
 	if !ok {
 		return errors.New("cannot unmarshal non Rekord v0.0.1 type")
 	}
 
-	if err := types.DecodeEntry(rekord.Spec, &v.HashedRekordObj); err != nil {
+	if err := DecodeEntry(rekord.Spec, &v.HashedRekordObj); err != nil {
 		return err
 	}
 

--- a/pkg/types/hashedrekord/v0.0.1/fuzz_test.go
+++ b/pkg/types/hashedrekord/v0.0.1/fuzz_test.go
@@ -17,10 +17,12 @@ package hashedrekord
 
 import (
 	"context"
+	"encoding/base64"
 	"sync"
 	"testing"
 
 	fuzz "github.com/AdamKorcz/go-fuzz-headers-1"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 
 	fuzzUtils "github.com/sigstore/rekor/pkg/fuzz"
@@ -97,5 +99,49 @@ func FuzzHashedRekordUnmarshalAndCanonicalize(f *testing.F) {
 		if _, err := types.CanonicalizeEntry(context.Background(), ei); err != nil {
 			t.Errorf("error canonicalizing unmarshalled entry: %v", err)
 		}
+	})
+}
+
+// New: fuzz the direct decoder map fast-path and typed-model inputs
+func FuzzHashedRekordDecodeEntryDirectMapAndRaw(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		initter.Do(fuzzUtils.SetFuzzLogger)
+		ff := fuzz.NewConsumer(data)
+		choice, _ := ff.GetInt()
+		choice %= 2
+		toB64 := func(limit int) string {
+			b, _ := ff.GetBytes()
+			if len(b) > limit {
+				b = b[:limit]
+			}
+			return base64.StdEncoding.EncodeToString(b)
+		}
+
+		var input any
+		switch choice {
+		case 0:
+			m := map[string]any{}
+			if b, _ := ff.GetBool(); b {
+				m["signature"] = map[string]any{
+					"content":   toB64(256),
+					"publicKey": map[string]any{"content": toB64(256)},
+				}
+			}
+			if b, _ := ff.GetBool(); b {
+				m["data"] = map[string]any{"hash": map[string]any{"algorithm": "sha256", "value": "deadbeef"}}
+			}
+			input = m
+		case 1:
+			mdl := &models.HashedrekordV001Schema{}
+			if err := ff.GenerateStruct(mdl); err != nil {
+				t.Skip()
+			}
+			input = mdl
+		}
+		entry := &V001Entry{}
+		if err := DecodeEntry(input, &entry.HashedRekordObj); err != nil {
+			t.Skip()
+		}
+		_ = entry.HashedRekordObj.Validate(strfmt.Default)
 	})
 }

--- a/pkg/types/helm/v0.0.1/benchmark_test.go
+++ b/pkg/types/helm/v0.0.1/benchmark_test.go
@@ -1,3 +1,18 @@
+//
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package helm
 
 import (

--- a/pkg/types/helm/v0.0.1/benchmark_test.go
+++ b/pkg/types/helm/v0.0.1/benchmark_test.go
@@ -1,0 +1,81 @@
+package helm
+
+import (
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/sigstore/rekor/pkg/generated/models"
+	"github.com/sigstore/rekor/pkg/types"
+)
+
+// Sample test data for benchmarking - using proper base64 encoded data
+var sampleHelmData = map[string]any{
+	"publicKey": map[string]any{
+		"content": "dGVzdFB1YmxpY0tleQ==", // "testPublicKey" base64 encoded
+	},
+	"chart": map[string]any{
+		"hash": map[string]any{
+			"algorithm": "sha256",
+			"value":     "abcdef123456",
+		},
+		"provenance": map[string]any{
+			"content": "dGVzdFByb3ZlbmFuY2U=", // "testProvenance" base64 encoded
+		},
+	},
+}
+
+// BenchmarkDecodeEntryMapstructure benchmarks the original mapstructure-based DecodeEntry
+func BenchmarkDecodeEntryMapstructure(b *testing.B) {
+	for b.Loop() {
+		var helmObj models.HelmV001Schema
+		err := types.DecodeEntry(sampleHelmData, &helmObj)
+		if err != nil {
+			b.Fatalf("DecodeEntry failed: %v", err)
+		}
+
+		// Validate the result to ensure it's properly decoded
+		if err := helmObj.Validate(strfmt.Default); err != nil {
+			b.Fatalf("Validation failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryDirect benchmarks the new direct JSON unmarshaling method
+func BenchmarkDecodeEntryDirect(b *testing.B) {
+	for b.Loop() {
+		entry := &V001Entry{}
+		err := DecodeEntry(sampleHelmData, &entry.HelmObj)
+		if err != nil {
+			b.Fatalf("DecodeEntryDirect failed: %v", err)
+		}
+
+		// Validate the result to ensure it's properly decoded
+		if err := entry.HelmObj.Validate(strfmt.Default); err != nil {
+			b.Fatalf("Validation failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryMapstructureMemory benchmarks memory allocation for mapstructure
+func BenchmarkDecodeEntryMapstructureMemory(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		var helmObj models.HelmV001Schema
+		err := types.DecodeEntry(sampleHelmData, &helmObj)
+		if err != nil {
+			b.Fatalf("DecodeEntry failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryDirectMemory benchmarks memory allocation for direct method
+func BenchmarkDecodeEntryDirectMemory(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		entry := &V001Entry{}
+		err := DecodeEntry(sampleHelmData, &entry.HelmObj)
+		if err != nil {
+			b.Fatalf("DecodeEntryDirect failed: %v", err)
+		}
+	}
+}

--- a/pkg/types/helm/v0.0.1/fuzz_test.go
+++ b/pkg/types/helm/v0.0.1/fuzz_test.go
@@ -139,7 +139,7 @@ func FuzzHelmDecodeEntryDirectMapAndRaw(f *testing.F) {
 				}
 				prov["content"] = toB64(512)
 				m["chart"] = map[string]any{
-					"hash":      map[string]any{"algorithm": "sha256", "value": "deadbeef"},
+					"hash":       map[string]any{"algorithm": "sha256", "value": "deadbeef"},
 					"provenance": prov,
 				}
 			}

--- a/pkg/types/helm/v0.0.1/fuzz_test.go
+++ b/pkg/types/helm/v0.0.1/fuzz_test.go
@@ -18,10 +18,12 @@ package helm
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"sync"
 	"testing"
 
 	fuzz "github.com/AdamKorcz/go-fuzz-headers-1"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 
 	fuzzUtils "github.com/sigstore/rekor/pkg/fuzz"
@@ -105,5 +107,54 @@ func FuzzHelmProvenanceUnmarshal(f *testing.F) {
 		p := &helm.Provenance{}
 		r := bytes.NewReader(provenanceData)
 		p.Unmarshal(r)
+	})
+}
+
+// New: fuzz the direct decoder map fast-path and typed-model inputs
+func FuzzHelmDecodeEntryDirectMapAndRaw(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		initter.Do(fuzzUtils.SetFuzzLogger)
+		ff := fuzz.NewConsumer(data)
+		choice, _ := ff.GetInt()
+		choice %= 2
+		toB64 := func(limit int) string {
+			b, _ := ff.GetBytes()
+			if len(b) > limit {
+				b = b[:limit]
+			}
+			return base64.StdEncoding.EncodeToString(b)
+		}
+
+		var input any
+		switch choice {
+		case 0:
+			m := map[string]any{}
+			if b, _ := ff.GetBool(); b {
+				m["publicKey"] = map[string]any{"content": toB64(256)}
+			}
+			if b, _ := ff.GetBool(); b {
+				prov := map[string]any{}
+				if b2, _ := ff.GetBool(); b2 {
+					prov["signature"] = map[string]any{"content": toB64(256)}
+				}
+				prov["content"] = toB64(512)
+				m["chart"] = map[string]any{
+					"hash":      map[string]any{"algorithm": "sha256", "value": "deadbeef"},
+					"provenance": prov,
+				}
+			}
+			input = m
+		case 1:
+			mdl := &models.HelmV001Schema{}
+			if err := ff.GenerateStruct(mdl); err != nil {
+				t.Skip()
+			}
+			input = mdl
+		}
+		entry := &V001Entry{}
+		if err := DecodeEntry(input, &entry.HelmObj); err != nil {
+			t.Skip()
+		}
+		_ = entry.HelmObj.Validate(strfmt.Default)
 	})
 }

--- a/pkg/types/intoto/v0.0.1/benchmark_test.go
+++ b/pkg/types/intoto/v0.0.1/benchmark_test.go
@@ -1,3 +1,18 @@
+//
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package intoto
 
 import (

--- a/pkg/types/intoto/v0.0.1/benchmark_test.go
+++ b/pkg/types/intoto/v0.0.1/benchmark_test.go
@@ -1,0 +1,81 @@
+package intoto
+
+import (
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/sigstore/rekor/pkg/generated/models"
+	"github.com/sigstore/rekor/pkg/types"
+)
+
+// Sample test data for benchmarking
+var sampleIntotoV001Data = map[string]any{
+	"content": map[string]any{
+		"envelope": `{"_type":"https://in-toto.io/Statement/v0.1","predicateType":"https://slsa.dev/provenance/v0.2","subject":[{"name":"test","digest":{"sha256":"abc123"}}],"predicate":{"builder":{"id":"test-builder"}}}`,
+		"hash": map[string]any{
+			"algorithm": "sha256",
+			"value":     "abc123",
+		},
+		"payloadHash": map[string]any{
+			"algorithm": "sha256",
+			"value":     "def456",
+		},
+	},
+	"publicKey": "dGVzdFB1YmxpY0tleQ==",
+}
+
+// BenchmarkDecodeEntryMapstructure benchmarks the original mapstructure-based DecodeEntry
+func BenchmarkDecodeEntryMapstructure(b *testing.B) {
+	for b.Loop() {
+		var intotoObj models.IntotoV001Schema
+		err := types.DecodeEntry(sampleIntotoV001Data, &intotoObj)
+		if err != nil {
+			b.Fatalf("DecodeEntry failed: %v", err)
+		}
+
+		// Validate the result to ensure it's properly decoded
+		if err := intotoObj.Validate(strfmt.Default); err != nil {
+			b.Fatalf("Validation failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryDirect benchmarks the new direct JSON unmarshaling method
+func BenchmarkDecodeEntryDirect(b *testing.B) {
+	for b.Loop() {
+		entry := &V001Entry{}
+		err := DecodeEntry(sampleIntotoV001Data, &entry.IntotoObj)
+		if err != nil {
+			b.Fatalf("DecodeEntryDirect failed: %v", err)
+		}
+
+		// Validate the result to ensure it's properly decoded
+		if err := entry.IntotoObj.Validate(strfmt.Default); err != nil {
+			b.Fatalf("Validation failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryMapstructureMemory benchmarks memory allocation for mapstructure
+func BenchmarkDecodeEntryMapstructureMemory(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		var intotoObj models.IntotoV001Schema
+		err := types.DecodeEntry(sampleIntotoV001Data, &intotoObj)
+		if err != nil {
+			b.Fatalf("DecodeEntry failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryDirectMemory benchmarks memory allocation for direct method
+func BenchmarkDecodeEntryDirectMemory(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		entry := &V001Entry{}
+		err := DecodeEntry(sampleIntotoV001Data, &entry.IntotoObj)
+		if err != nil {
+			b.Fatalf("DecodeEntryDirect failed: %v", err)
+		}
+	}
+}

--- a/pkg/types/intoto/v0.0.1/fuzz_test.go
+++ b/pkg/types/intoto/v0.0.1/fuzz_test.go
@@ -17,10 +17,12 @@ package intoto
 
 import (
 	"context"
+	"encoding/base64"
 	"sync"
 	"testing"
 
 	fuzz "github.com/AdamKorcz/go-fuzz-headers-1"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 
 	fuzzUtils "github.com/sigstore/rekor/pkg/fuzz"
@@ -96,5 +98,54 @@ func FuzzIntotoUnmarshalAndCanonicalize(f *testing.F) {
 		if _, err := types.CanonicalizeEntry(context.Background(), ei); err != nil {
 			t.Errorf("error canonicalizing unmarshalled entry: %v", err)
 		}
+	})
+}
+
+// New: fuzz the direct decoder map fast-path and raw JSON fallbacks
+func FuzzIntotoV001DecodeEntryDirectMapAndRaw(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		initter.Do(fuzzUtils.SetFuzzLogger)
+		ff := fuzz.NewConsumer(data)
+		choice, _ := ff.GetInt()
+		choice %= 2
+		toB64 := func(limit int) string {
+			b, _ := ff.GetBytes()
+			if len(b) > limit {
+				b = b[:limit]
+			}
+			return base64.StdEncoding.EncodeToString(b)
+		}
+
+		var input any
+		switch choice {
+		case 0:
+			m := map[string]any{}
+			if b, _ := ff.GetBool(); b {
+				m["publicKey"] = toB64(256)
+			}
+			content := map[string]any{}
+			if b, _ := ff.GetBool(); b {
+				content["envelope"] = string(append([]byte(`{"payload":"`), []byte(toB64(128))...))
+			}
+			if b, _ := ff.GetBool(); b {
+				content["hash"] = map[string]any{"algorithm": "sha256", "value": "deadbeef"}
+			}
+			if b, _ := ff.GetBool(); b {
+				content["payloadHash"] = map[string]any{"algorithm": "sha256", "value": "cafebabe"}
+			}
+			m["content"] = content
+			input = m
+		case 1:
+			mdl := &models.IntotoV001Schema{}
+			if err := ff.GenerateStruct(mdl); err != nil {
+				t.Skip()
+			}
+			input = mdl
+		}
+		entry := &V001Entry{}
+		if err := DecodeEntry(input, &entry.IntotoObj); err != nil {
+			t.Skip()
+		}
+		_ = entry.IntotoObj.Validate(strfmt.Default)
 	})
 }

--- a/pkg/types/intoto/v0.0.2/benchmark_test.go
+++ b/pkg/types/intoto/v0.0.2/benchmark_test.go
@@ -1,3 +1,18 @@
+//
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package intoto
 
 import (

--- a/pkg/types/intoto/v0.0.2/entry.go
+++ b/pkg/types/intoto/v0.0.2/entry.go
@@ -160,6 +160,126 @@ func parseSlsaPredicate(p []byte) (*in_toto.ProvenanceStatement, error) {
 	return &predicate, nil
 }
 
+// DecodeEntry performs direct decode into the provided output pointer
+// without mutating the receiver on error.
+func DecodeEntry(input any, output *models.IntotoV002Schema) error {
+	if output == nil {
+		return fmt.Errorf("nil output *models.IntotoV002Schema")
+	}
+	var m models.IntotoV002Schema
+	switch in := input.(type) {
+	case map[string]any:
+		mm := in
+		m.Content = &models.IntotoV002SchemaContent{Envelope: &models.IntotoV002SchemaContentEnvelope{}}
+		if c, ok := mm["content"].(map[string]any); ok {
+			if env, ok := c["envelope"].(map[string]any); ok {
+				if pt, ok := env["payloadType"].(string); ok {
+					m.Content.Envelope.PayloadType = &pt
+				}
+				if p, ok := env["payload"].(string); ok && p != "" {
+					outb := make([]byte, base64.StdEncoding.DecodedLen(len(p)))
+					n, err := base64.StdEncoding.Decode(outb, []byte(p))
+					if err != nil {
+						return fmt.Errorf("failed parsing base64 data for payload: %w", err)
+					}
+					m.Content.Envelope.Payload = strfmt.Base64(outb[:n])
+				}
+				if raw, ok := env["signatures"]; ok {
+					switch sigs := raw.(type) {
+					case []any:
+						m.Content.Envelope.Signatures = make([]*models.IntotoV002SchemaContentEnvelopeSignaturesItems0, 0, len(sigs))
+						for _, s := range sigs {
+							if sm, ok := s.(map[string]any); ok {
+								item := &models.IntotoV002SchemaContentEnvelopeSignaturesItems0{}
+								if kid, ok := sm["keyid"].(string); ok {
+									item.Keyid = kid
+								}
+								if sig, ok := sm["sig"].(string); ok {
+									outb := make([]byte, base64.StdEncoding.DecodedLen(len(sig)))
+									n, err := base64.StdEncoding.Decode(outb, []byte(sig))
+									if err != nil {
+										return fmt.Errorf("failed parsing base64 data for signature: %w", err)
+									}
+									b := strfmt.Base64(outb[:n])
+									item.Sig = &b
+								}
+								if pk, ok := sm["publicKey"].(string); ok {
+									outb := make([]byte, base64.StdEncoding.DecodedLen(len(pk)))
+									n, err := base64.StdEncoding.Decode(outb, []byte(pk))
+									if err != nil {
+										return fmt.Errorf("failed parsing base64 data for public key: %w", err)
+									}
+									b := strfmt.Base64(outb[:n])
+									item.PublicKey = &b
+								}
+								m.Content.Envelope.Signatures = append(m.Content.Envelope.Signatures, item)
+							}
+						}
+					case []map[string]any:
+						m.Content.Envelope.Signatures = make([]*models.IntotoV002SchemaContentEnvelopeSignaturesItems0, 0, len(sigs))
+						for _, sm := range sigs {
+							item := &models.IntotoV002SchemaContentEnvelopeSignaturesItems0{}
+							if kid, ok := sm["keyid"].(string); ok {
+								item.Keyid = kid
+							}
+							if sig, ok := sm["sig"].(string); ok {
+								outb := make([]byte, base64.StdEncoding.DecodedLen(len(sig)))
+								n, err := base64.StdEncoding.Decode(outb, []byte(sig))
+								if err != nil {
+									return fmt.Errorf("failed parsing base64 data for signature: %w", err)
+								}
+								b := strfmt.Base64(outb[:n])
+								item.Sig = &b
+							}
+							if pk, ok := sm["publicKey"].(string); ok {
+								outb := make([]byte, base64.StdEncoding.DecodedLen(len(pk)))
+								n, err := base64.StdEncoding.Decode(outb, []byte(pk))
+								if err != nil {
+									return fmt.Errorf("failed parsing base64 data for public key: %w", err)
+								}
+								b := strfmt.Base64(outb[:n])
+								item.PublicKey = &b
+							}
+							m.Content.Envelope.Signatures = append(m.Content.Envelope.Signatures, item)
+						}
+					}
+				}
+			}
+			if h, ok := c["hash"].(map[string]any); ok {
+				m.Content.Hash = &models.IntotoV002SchemaContentHash{}
+				if alg, ok := h["algorithm"].(string); ok {
+					m.Content.Hash.Algorithm = &alg
+				}
+				if val, ok := h["value"].(string); ok {
+					m.Content.Hash.Value = &val
+				}
+			}
+			if ph, ok := c["payloadHash"].(map[string]any); ok {
+				m.Content.PayloadHash = &models.IntotoV002SchemaContentPayloadHash{}
+				if alg, ok := ph["algorithm"].(string); ok {
+					m.Content.PayloadHash.Algorithm = &alg
+				}
+				if val, ok := ph["value"].(string); ok {
+					m.Content.PayloadHash.Value = &val
+				}
+			}
+		}
+		*output = m
+		return nil
+	case *models.IntotoV002Schema:
+		if in == nil {
+			return fmt.Errorf("nil *models.IntotoV002Schema")
+		}
+		*output = *in
+		return nil
+	case models.IntotoV002Schema:
+		*output = in
+		return nil
+	default:
+		return fmt.Errorf("unsupported input type %T for DecodeEntry", input)
+	}
+}
+
 func (v *V002Entry) Unmarshal(pe models.ProposedEntry) error {
 	it, ok := pe.(*models.Intoto)
 	if !ok {
@@ -167,7 +287,7 @@ func (v *V002Entry) Unmarshal(pe models.ProposedEntry) error {
 	}
 
 	var err error
-	if err := types.DecodeEntry(it.Spec, &v.IntotoObj); err != nil {
+	if err := DecodeEntry(it.Spec, &v.IntotoObj); err != nil {
 		return err
 	}
 

--- a/pkg/types/intoto/v0.0.2/fuzz_test.go
+++ b/pkg/types/intoto/v0.0.2/fuzz_test.go
@@ -17,10 +17,12 @@ package intoto
 
 import (
 	"context"
+	"encoding/base64"
 	"sync"
 	"testing"
 
 	fuzz "github.com/AdamKorcz/go-fuzz-headers-1"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 
 	fuzzUtils "github.com/sigstore/rekor/pkg/fuzz"
@@ -96,5 +98,62 @@ func FuzzIntotoUnmarshalAndCanonicalize(f *testing.F) {
 		if _, err := types.CanonicalizeEntry(context.Background(), ei); err != nil {
 			t.Errorf("error canonicalizing unmarshalled entry: %v", err)
 		}
+	})
+}
+
+// New: fuzz the direct decoder map fast-path and typed-model inputs
+func FuzzIntotoDecodeEntryDirectMapAndRaw(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		initter.Do(fuzzUtils.SetFuzzLogger)
+		ff := fuzz.NewConsumer(data)
+		choice, _ := ff.GetInt()
+		choice %= 2
+		toB64 := func(limit int) string {
+			b, _ := ff.GetBytes()
+			if len(b) > limit {
+				b = b[:limit]
+			}
+			return base64.StdEncoding.EncodeToString(b)
+		}
+
+		var input any
+		switch choice {
+		case 0:
+			// Construct a minimal map resembling the schema
+			m := map[string]any{}
+			content := map[string]any{}
+			env := map[string]any{}
+			if b, _ := ff.GetBool(); b {
+				env["payloadType"] = "application/vnd.in-toto+json"
+				env["payload"] = toB64(512)
+			}
+			if b, _ := ff.GetBool(); b {
+				env["signatures"] = []any{map[string]any{"keyid": "k", "sig": toB64(128), "publicKey": toB64(256)}}
+			}
+			if len(env) > 0 {
+				content["envelope"] = env
+			}
+			if b, _ := ff.GetBool(); b {
+				content["hash"] = map[string]any{"algorithm": "sha256", "value": "deadbeef"}
+			}
+			if b, _ := ff.GetBool(); b {
+				content["payloadHash"] = map[string]any{"algorithm": "sha256", "value": "deadbeef"}
+			}
+			if len(content) > 0 {
+				m["content"] = content
+			}
+			input = m
+		case 1:
+			mdl := &models.IntotoV002Schema{}
+			if err := ff.GenerateStruct(mdl); err != nil {
+				t.Skip()
+			}
+			input = mdl
+		}
+		entry := &V002Entry{}
+		if err := DecodeEntry(input, &entry.IntotoObj); err != nil {
+			t.Skip()
+		}
+		_ = entry.IntotoObj.Validate(strfmt.Default)
 	})
 }

--- a/pkg/types/jar/v0.0.1/benchmark_test.go
+++ b/pkg/types/jar/v0.0.1/benchmark_test.go
@@ -1,0 +1,82 @@
+package jar
+
+import (
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/sigstore/rekor/pkg/generated/models"
+	"github.com/sigstore/rekor/pkg/types"
+)
+
+// Sample test data for benchmarking - using proper base64 encoded data
+var sampleJARData = map[string]any{
+	"signature": map[string]any{
+		"content": "dGVzdFNpZ25hdHVyZQ==", // "testSignature" base64 encoded
+		"publicKey": map[string]any{
+			"content": "dGVzdFB1YmxpY0tleQ==", // "testPublicKey" base64 encoded
+		},
+	},
+	"archive": map[string]any{
+		"hash": map[string]any{
+			"algorithm": "sha256",
+			"value":     "abcdef123456",
+		},
+		"content": "dGVzdEFyY2hpdmU=", // "testArchive" base64 encoded
+	},
+}
+
+// BenchmarkDecodeEntryMapstructure benchmarks the original mapstructure-based DecodeEntry
+func BenchmarkDecodeEntryMapstructure(b *testing.B) {
+	for b.Loop() {
+		var jarObj models.JarV001Schema
+		err := types.DecodeEntry(sampleJARData, &jarObj)
+		if err != nil {
+			b.Fatalf("DecodeEntry failed: %v", err)
+		}
+
+		// Validate the result to ensure it's properly decoded
+		if err := jarObj.Validate(strfmt.Default); err != nil {
+			b.Fatalf("Validation failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryDirect benchmarks the new direct JSON unmarshaling method
+func BenchmarkDecodeEntryDirect(b *testing.B) {
+	for b.Loop() {
+		entry := &V001Entry{}
+		err := DecodeEntry(sampleJARData, &entry.JARModel)
+		if err != nil {
+			b.Fatalf("DecodeEntryDirect failed: %v", err)
+		}
+
+		// Validate the result to ensure it's properly decoded
+		if err := entry.JARModel.Validate(strfmt.Default); err != nil {
+			b.Fatalf("Validation failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryMapstructureMemory benchmarks memory allocation for mapstructure
+func BenchmarkDecodeEntryMapstructureMemory(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		var jarObj models.JarV001Schema
+		err := types.DecodeEntry(sampleJARData, &jarObj)
+		if err != nil {
+			b.Fatalf("DecodeEntry failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryDirectMemory benchmarks memory allocation for direct method
+func BenchmarkDecodeEntryDirectMemory(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		entry := &V001Entry{}
+		err := DecodeEntry(sampleJARData, &entry.JARModel)
+		if err != nil {
+			b.Fatalf("DecodeEntryDirect failed: %v", err)
+		}
+	}
+}

--- a/pkg/types/jar/v0.0.1/benchmark_test.go
+++ b/pkg/types/jar/v0.0.1/benchmark_test.go
@@ -1,3 +1,18 @@
+//
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package jar
 
 import (

--- a/pkg/types/jar/v0.0.1/entry.go
+++ b/pkg/types/jar/v0.0.1/entry.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -98,7 +99,7 @@ func (v *V001Entry) Unmarshal(pe models.ProposedEntry) error {
 		return errors.New("cannot unmarshal non JAR v0.0.1 type")
 	}
 
-	if err := types.DecodeEntry(jar.Spec, &v.JARModel); err != nil {
+	if err := DecodeEntry(jar.Spec, &v.JARModel); err != nil {
 		return err
 	}
 
@@ -108,6 +109,75 @@ func (v *V001Entry) Unmarshal(pe models.ProposedEntry) error {
 	}
 
 	return v.validate()
+}
+
+// DecodeEntry performs direct decode into the provided output pointer
+// without mutating the receiver on error.
+func DecodeEntry(input any, output *models.JarV001Schema) error {
+	if output == nil {
+		return fmt.Errorf("nil output *models.JarV001Schema")
+	}
+	var m models.JarV001Schema
+	switch data := input.(type) {
+	case map[string]any:
+		mm := data
+		if sig, ok := mm["signature"].(map[string]any); ok {
+			m.Signature = &models.JarV001SchemaSignature{}
+			if c, ok := sig["content"].(string); ok && c != "" {
+				outb := make([]byte, base64.StdEncoding.DecodedLen(len(c)))
+				n, err := base64.StdEncoding.Decode(outb, []byte(c))
+				if err != nil {
+					return fmt.Errorf("failed parsing base64 data for signature content: %w", err)
+				}
+				m.Signature.Content = strfmt.Base64(outb[:n])
+			}
+			if pk, ok := sig["publicKey"].(map[string]any); ok {
+				m.Signature.PublicKey = &models.JarV001SchemaSignaturePublicKey{}
+				if c, ok := pk["content"].(string); ok && c != "" {
+					outb := make([]byte, base64.StdEncoding.DecodedLen(len(c)))
+					n, err := base64.StdEncoding.Decode(outb, []byte(c))
+					if err != nil {
+						return fmt.Errorf("failed parsing base64 data for signature publicKey content: %w", err)
+					}
+					b := strfmt.Base64(outb[:n])
+					m.Signature.PublicKey.Content = &b
+				}
+			}
+		}
+		if ar, ok := mm["archive"].(map[string]any); ok {
+			m.Archive = &models.JarV001SchemaArchive{}
+			if h, ok := ar["hash"].(map[string]any); ok {
+				m.Archive.Hash = &models.JarV001SchemaArchiveHash{}
+				if alg, ok := h["algorithm"].(string); ok {
+					m.Archive.Hash.Algorithm = &alg
+				}
+				if val, ok := h["value"].(string); ok {
+					m.Archive.Hash.Value = &val
+				}
+			}
+			if c, ok := ar["content"].(string); ok && c != "" {
+				outb := make([]byte, base64.StdEncoding.DecodedLen(len(c)))
+				n, err := base64.StdEncoding.Decode(outb, []byte(c))
+				if err != nil {
+					return fmt.Errorf("failed parsing base64 data for archive content: %w", err)
+				}
+				m.Archive.Content = strfmt.Base64(outb[:n])
+			}
+		}
+		*output = m
+		return nil
+	case *models.JarV001Schema:
+		if data == nil {
+			return fmt.Errorf("nil *models.JarV001Schema")
+		}
+		*output = *data
+		return nil
+	case models.JarV001Schema:
+		*output = data
+		return nil
+	default:
+		return fmt.Errorf("unsupported input type %T for DecodeEntry", input)
+	}
 }
 
 func (v *V001Entry) fetchExternalEntities(_ context.Context) (*pkcs7.PublicKey, *pkcs7.Signature, error) {

--- a/pkg/types/jar/v0.0.1/fuzz_test.go
+++ b/pkg/types/jar/v0.0.1/fuzz_test.go
@@ -19,10 +19,12 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"encoding/base64"
 	"sync"
 	"testing"
 
 	fuzz "github.com/AdamKorcz/go-fuzz-headers-1"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 
 	jarutils "github.com/sassoftware/relic/lib/signjar"
@@ -101,6 +103,47 @@ func FuzzJarUnmarshalAndCanonicalize(f *testing.F) {
 		if _, err := types.CanonicalizeEntry(context.Background(), ei); err != nil {
 			t.Skip()
 		}
+	})
+}
+
+// New: fuzz the direct decoder map fast-path and raw JSON fallbacks
+func FuzzJarDecodeEntryDirectMapAndRaw(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		initter.Do(fuzzUtils.SetFuzzLogger)
+		ff := fuzz.NewConsumer(data)
+		choice, _ := ff.GetInt()
+		choice %= 2
+		toB64 := func(limit int) string {
+			b, _ := ff.GetBytes()
+			if len(b) > limit {
+				b = b[:limit]
+			}
+			return base64.StdEncoding.EncodeToString(b)
+		}
+
+		var input any
+		switch choice {
+		case 0:
+			m := map[string]any{}
+			if b, _ := ff.GetBool(); b {
+				m["signature"] = map[string]any{"content": toB64(256), "publicKey": map[string]any{"content": toB64(256)}}
+			}
+			if b, _ := ff.GetBool(); b {
+				m["archive"] = map[string]any{"content": toB64(512), "hash": map[string]any{"algorithm": "sha256", "value": "deadbeef"}}
+			}
+			input = m
+		case 1:
+			mdl := &models.JarV001Schema{}
+			if err := ff.GenerateStruct(mdl); err != nil {
+				t.Skip()
+			}
+			input = mdl
+		}
+		entry := &V001Entry{}
+		if err := DecodeEntry(input, &entry.JARModel); err != nil {
+			t.Skip()
+		}
+		_ = entry.JARModel.Validate(strfmt.Default)
 	})
 }
 

--- a/pkg/types/rekord/v0.0.1/benchmark_test.go
+++ b/pkg/types/rekord/v0.0.1/benchmark_test.go
@@ -1,3 +1,18 @@
+//
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package rekord
 
 import (

--- a/pkg/types/rekord/v0.0.1/benchmark_test.go
+++ b/pkg/types/rekord/v0.0.1/benchmark_test.go
@@ -1,0 +1,83 @@
+package rekord
+
+import (
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/sigstore/rekor/pkg/generated/models"
+	"github.com/sigstore/rekor/pkg/types"
+)
+
+// Sample test data for benchmarking - using proper base64 encoded data
+var sampleRekordData = map[string]any{
+	"signature": map[string]any{
+		"format":  "x509",
+		"content": "dGVzdFNpZ25hdHVyZQ==", // "testSignature" base64 encoded
+		"publicKey": map[string]any{
+			"content": "dGVzdFB1YmxpY0tleQ==", // "testPublicKey" base64 encoded
+		},
+	},
+	"data": map[string]any{
+		"hash": map[string]any{
+			"algorithm": "sha256",
+			"value":     "abcdef123456",
+		},
+		"content": "dGVzdERhdGE=", // "testData" base64 encoded
+	},
+}
+
+// BenchmarkDecodeEntryMapstructure benchmarks the original mapstructure-based DecodeEntry
+func BenchmarkDecodeEntryMapstructure(b *testing.B) {
+	for b.Loop() {
+		var rekordObj models.RekordV001Schema
+		err := types.DecodeEntry(sampleRekordData, &rekordObj)
+		if err != nil {
+			b.Fatalf("DecodeEntry failed: %v", err)
+		}
+
+		// Validate the result to ensure it's properly decoded
+		if err := rekordObj.Validate(strfmt.Default); err != nil {
+			b.Fatalf("Validation failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryDirect benchmarks the new direct JSON unmarshaling method
+func BenchmarkDecodeEntryDirect(b *testing.B) {
+	for b.Loop() {
+		entry := &V001Entry{}
+		err := DecodeEntry(sampleRekordData, &entry.RekordObj)
+		if err != nil {
+			b.Fatalf("DecodeEntryDirect failed: %v", err)
+		}
+
+		// Validate the result to ensure it's properly decoded
+		if err := entry.RekordObj.Validate(strfmt.Default); err != nil {
+			b.Fatalf("Validation failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryMapstructureMemory benchmarks memory allocation for mapstructure
+func BenchmarkDecodeEntryMapstructureMemory(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		var rekordObj models.RekordV001Schema
+		err := types.DecodeEntry(sampleRekordData, &rekordObj)
+		if err != nil {
+			b.Fatalf("DecodeEntry failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryDirectMemory benchmarks memory allocation for direct method
+func BenchmarkDecodeEntryDirectMemory(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		entry := &V001Entry{}
+		err := DecodeEntry(sampleRekordData, &entry.RekordObj)
+		if err != nil {
+			b.Fatalf("DecodeEntryDirect failed: %v", err)
+		}
+	}
+}

--- a/pkg/types/rekord/v0.0.1/entry.go
+++ b/pkg/types/rekord/v0.0.1/entry.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -102,7 +103,7 @@ func (v *V001Entry) Unmarshal(pe models.ProposedEntry) error {
 		return errors.New("cannot unmarshal non Rekord v0.0.1 type")
 	}
 
-	if err := types.DecodeEntry(rekord.Spec, &v.RekordObj); err != nil {
+	if err := DecodeEntry(rekord.Spec, &v.RekordObj); err != nil {
 		return err
 	}
 
@@ -114,6 +115,81 @@ func (v *V001Entry) Unmarshal(pe models.ProposedEntry) error {
 	// cross field validation
 	return v.validate()
 
+}
+
+// DecodeEntry performs direct JSON unmarshaling without reflection,
+// equivalent to types.DecodeEntry but with better performance for Rekord v0.0.1.
+// It avoids mutating the receiver on error.
+func DecodeEntry(input any, output *models.RekordV001Schema) error {
+	if output == nil {
+		return fmt.Errorf("nil output *models.RekordV001Schema")
+	}
+	var m models.RekordV001Schema
+	// Single switch including map[string]any fast path
+	switch data := input.(type) {
+	case map[string]any:
+		mm := data
+		if s, ok := mm["signature"].(map[string]any); ok {
+			m.Signature = &models.RekordV001SchemaSignature{}
+			if f, ok := s["format"].(string); ok {
+				m.Signature.Format = &f
+			}
+			if c, ok := s["content"].(string); ok && c != "" {
+				outb := make([]byte, base64.StdEncoding.DecodedLen(len(c)))
+				n, err := base64.StdEncoding.Decode(outb, []byte(c))
+				if err != nil {
+					return fmt.Errorf("failed parsing base64 data for signature content: %w", err)
+				}
+				b := strfmt.Base64(outb[:n])
+				m.Signature.Content = &b
+			}
+			if pk, ok := s["publicKey"].(map[string]any); ok {
+				m.Signature.PublicKey = &models.RekordV001SchemaSignaturePublicKey{}
+				if c, ok := pk["content"].(string); ok && c != "" {
+					outb := make([]byte, base64.StdEncoding.DecodedLen(len(c)))
+					n, err := base64.StdEncoding.Decode(outb, []byte(c))
+					if err != nil {
+						return fmt.Errorf("failed parsing base64 data for signature publicKey content: %w", err)
+					}
+					b := strfmt.Base64(outb[:n])
+					m.Signature.PublicKey.Content = &b
+				}
+			}
+		}
+		if d, ok := mm["data"].(map[string]any); ok {
+			m.Data = &models.RekordV001SchemaData{}
+			if h, ok := d["hash"].(map[string]any); ok {
+				m.Data.Hash = &models.RekordV001SchemaDataHash{}
+				if alg, ok := h["algorithm"].(string); ok {
+					m.Data.Hash.Algorithm = &alg
+				}
+				if val, ok := h["value"].(string); ok {
+					m.Data.Hash.Value = &val
+				}
+			}
+			if c, ok := d["content"].(string); ok && c != "" {
+				outb := make([]byte, base64.StdEncoding.DecodedLen(len(c)))
+				n, err := base64.StdEncoding.Decode(outb, []byte(c))
+				if err != nil {
+					return fmt.Errorf("failed parsing base64 data for data content: %w", err)
+				}
+				m.Data.Content = strfmt.Base64(outb[:n])
+			}
+		}
+		*output = m
+		return nil
+	case *models.RekordV001Schema:
+		if data == nil {
+			return fmt.Errorf("nil *models.RekordV001Schema")
+		}
+		*output = *data
+		return nil
+	case models.RekordV001Schema:
+		*output = data
+		return nil
+	default:
+		return fmt.Errorf("unsupported input type %T for DecodeEntry", input)
+	}
 }
 
 func (v *V001Entry) fetchExternalEntities(_ context.Context) (pki.PublicKey, pki.Signature, error) {

--- a/pkg/types/rekord/v0.0.1/fuzz_test.go
+++ b/pkg/types/rekord/v0.0.1/fuzz_test.go
@@ -17,10 +17,12 @@ package rekord
 
 import (
 	"context"
+	"encoding/base64"
 	"sync"
 	"testing"
 
 	fuzz "github.com/AdamKorcz/go-fuzz-headers-1"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 
 	fuzzUtils "github.com/sigstore/rekor/pkg/fuzz"
@@ -96,5 +98,46 @@ func FuzzRekordUnmarshalAndCanonicalize(f *testing.F) {
 		if _, err := types.CanonicalizeEntry(context.Background(), ei); err != nil {
 			t.Skip()
 		}
+	})
+}
+
+// New: fuzz the direct decoder map fast-path and raw JSON fallbacks
+func FuzzRekordDecodeEntryDirectMapAndRaw(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		initter.Do(fuzzUtils.SetFuzzLogger)
+		ff := fuzz.NewConsumer(data)
+		choice, _ := ff.GetInt()
+		choice %= 2
+		toB64 := func(limit int) string {
+			b, _ := ff.GetBytes()
+			if len(b) > limit {
+				b = b[:limit]
+			}
+			return base64.StdEncoding.EncodeToString(b)
+		}
+
+		var input any
+		switch choice {
+		case 0:
+			m := map[string]any{}
+			if b, _ := ff.GetBool(); b {
+				m["signature"] = map[string]any{"format": "x509", "content": toB64(256), "publicKey": map[string]any{"content": toB64(256)}}
+			}
+			if b, _ := ff.GetBool(); b {
+				m["data"] = map[string]any{"content": toB64(512), "hash": map[string]any{"algorithm": "sha256", "value": "deadbeef"}}
+			}
+			input = m
+		case 1:
+			mdl := &models.RekordV001Schema{}
+			if err := ff.GenerateStruct(mdl); err != nil {
+				t.Skip()
+			}
+			input = mdl
+		}
+		entry := &V001Entry{}
+		if err := DecodeEntry(input, &entry.RekordObj); err != nil {
+			t.Skip()
+		}
+		_ = entry.RekordObj.Validate(strfmt.Default)
 	})
 }

--- a/pkg/types/rfc3161/v0.0.1/benchmark_test.go
+++ b/pkg/types/rfc3161/v0.0.1/benchmark_test.go
@@ -1,3 +1,18 @@
+//
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package rfc3161
 
 import (

--- a/pkg/types/rfc3161/v0.0.1/benchmark_test.go
+++ b/pkg/types/rfc3161/v0.0.1/benchmark_test.go
@@ -1,0 +1,72 @@
+package rfc3161
+
+import (
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/sigstore/rekor/pkg/generated/models"
+	"github.com/sigstore/rekor/pkg/types"
+)
+
+// Sample test data for benchmarking - using proper base64 encoded data
+var sampleRFC3161Data = map[string]any{
+	"tsr": map[string]any{
+		"content": "dGVzdFRTUg==", // "testTSR" base64 encoded
+	},
+}
+
+// BenchmarkDecodeEntryMapstructure benchmarks the original mapstructure-based DecodeEntry
+func BenchmarkDecodeEntryMapstructure(b *testing.B) {
+	for b.Loop() {
+		var rfc3161Obj models.Rfc3161V001Schema
+		err := types.DecodeEntry(sampleRFC3161Data, &rfc3161Obj)
+		if err != nil {
+			b.Fatalf("DecodeEntry failed: %v", err)
+		}
+
+		// Validate the result to ensure it's properly decoded
+		if err := rfc3161Obj.Validate(strfmt.Default); err != nil {
+			b.Fatalf("Validation failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryDirect benchmarks the new direct JSON unmarshaling method
+func BenchmarkDecodeEntryDirect(b *testing.B) {
+	for b.Loop() {
+		entry := &V001Entry{}
+		err := DecodeEntry(sampleRFC3161Data, &entry.Rfc3161Obj)
+		if err != nil {
+			b.Fatalf("DecodeEntryDirect failed: %v", err)
+		}
+
+		// Validate the result to ensure it's properly decoded
+		if err := entry.Rfc3161Obj.Validate(strfmt.Default); err != nil {
+			b.Fatalf("Validation failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryMapstructureMemory benchmarks memory allocation for mapstructure
+func BenchmarkDecodeEntryMapstructureMemory(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		var rfc3161Obj models.Rfc3161V001Schema
+		err := types.DecodeEntry(sampleRFC3161Data, &rfc3161Obj)
+		if err != nil {
+			b.Fatalf("DecodeEntry failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryDirectMemory benchmarks memory allocation for direct method
+func BenchmarkDecodeEntryDirectMemory(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		entry := &V001Entry{}
+		err := DecodeEntry(sampleRFC3161Data, &entry.Rfc3161Obj)
+		if err != nil {
+			b.Fatalf("DecodeEntryDirect failed: %v", err)
+		}
+	}
+}

--- a/pkg/types/rfc3161/v0.0.1/fuzz_test.go
+++ b/pkg/types/rfc3161/v0.0.1/fuzz_test.go
@@ -17,10 +17,12 @@ package rfc3161
 
 import (
 	"context"
+	"encoding/base64"
 	"sync"
 	"testing"
 
 	fuzz "github.com/AdamKorcz/go-fuzz-headers-1"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 
 	fuzzUtils "github.com/sigstore/rekor/pkg/fuzz"
@@ -96,5 +98,39 @@ func FuzzRfc3161UnmarshalAndCanonicalize(f *testing.F) {
 		if _, err := types.CanonicalizeEntry(context.Background(), ei); err != nil {
 			t.Errorf("error canonicalizing unmarshalled entry: %v", err)
 		}
+	})
+}
+
+// New: fuzz the direct decoder map fast-path and raw JSON fallbacks
+func FuzzRfc3161DecodeEntryDirectMapAndRaw(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		initter.Do(fuzzUtils.SetFuzzLogger)
+		ff := fuzz.NewConsumer(data)
+		choice, _ := ff.GetInt()
+		choice %= 2
+		toB64 := func(limit int) string {
+			b, _ := ff.GetBytes()
+			if len(b) > limit {
+				b = b[:limit]
+			}
+			return base64.StdEncoding.EncodeToString(b)
+		}
+
+		var input any
+		switch choice {
+		case 0:
+			input = map[string]any{"tsr": map[string]any{"content": toB64(512)}}
+		case 1:
+			mdl := &models.Rfc3161V001Schema{}
+			if err := ff.GenerateStruct(mdl); err != nil {
+				t.Skip()
+			}
+			input = mdl
+		}
+		entry := &V001Entry{}
+		if err := DecodeEntry(input, &entry.Rfc3161Obj); err != nil {
+			t.Skip()
+		}
+		_ = entry.Rfc3161Obj.Validate(strfmt.Default)
 	})
 }

--- a/pkg/types/rpm/v0.0.1/benchmark_test.go
+++ b/pkg/types/rpm/v0.0.1/benchmark_test.go
@@ -1,3 +1,18 @@
+//
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package rpm
 
 import (

--- a/pkg/types/rpm/v0.0.1/benchmark_test.go
+++ b/pkg/types/rpm/v0.0.1/benchmark_test.go
@@ -1,0 +1,83 @@
+package rpm
+
+import (
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/sigstore/rekor/pkg/generated/models"
+	"github.com/sigstore/rekor/pkg/types"
+)
+
+// Sample test data for benchmarking - using proper base64 encoded data
+var sampleRPMData = map[string]any{
+	"publicKey": map[string]any{
+		"content": "dGVzdFB1YmxpY0tleQ==", // "testPublicKey" base64 encoded
+	},
+	"package": map[string]any{
+		"headers": map[string]string{
+			"name":    "test-package",
+			"version": "1.0.0",
+		},
+		"hash": map[string]any{
+			"algorithm": "sha256",
+			"value":     "abcdef123456",
+		},
+		"content": "dGVzdFBhY2thZ2VDb250ZW50", // "testPackageContent" base64 encoded
+	},
+}
+
+// BenchmarkDecodeEntryMapstructure benchmarks the original mapstructure-based DecodeEntry
+func BenchmarkDecodeEntryMapstructure(b *testing.B) {
+	for b.Loop() {
+		var rpmObj models.RpmV001Schema
+		err := types.DecodeEntry(sampleRPMData, &rpmObj)
+		if err != nil {
+			b.Fatalf("DecodeEntry failed: %v", err)
+		}
+
+		// Validate the result to ensure it's properly decoded
+		if err := rpmObj.Validate(strfmt.Default); err != nil {
+			b.Fatalf("Validation failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryDirect benchmarks the new direct JSON unmarshaling method
+func BenchmarkDecodeEntryDirect(b *testing.B) {
+	for b.Loop() {
+		entry := &V001Entry{}
+		err := DecodeEntry(sampleRPMData, &entry.RPMModel)
+		if err != nil {
+			b.Fatalf("DecodeEntryDirect failed: %v", err)
+		}
+
+		// Validate the result to ensure it's properly decoded
+		if err := entry.RPMModel.Validate(strfmt.Default); err != nil {
+			b.Fatalf("Validation failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryMapstructureMemory benchmarks memory allocation for mapstructure
+func BenchmarkDecodeEntryMapstructureMemory(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		var rpmObj models.RpmV001Schema
+		err := types.DecodeEntry(sampleRPMData, &rpmObj)
+		if err != nil {
+			b.Fatalf("DecodeEntry failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryDirectMemory benchmarks memory allocation for direct method
+func BenchmarkDecodeEntryDirectMemory(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		entry := &V001Entry{}
+		err := DecodeEntry(sampleRPMData, &entry.RPMModel)
+		if err != nil {
+			b.Fatalf("DecodeEntryDirect failed: %v", err)
+		}
+	}
+}

--- a/pkg/types/rpm/v0.0.1/fuzz_test.go
+++ b/pkg/types/rpm/v0.0.1/fuzz_test.go
@@ -17,10 +17,12 @@ package rpm
 
 import (
 	"context"
+	"encoding/base64"
 	"sync"
 	"testing"
 
 	fuzz "github.com/AdamKorcz/go-fuzz-headers-1"
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 
 	fuzzUtils "github.com/sigstore/rekor/pkg/fuzz"
@@ -96,5 +98,50 @@ func FuzzRpmUnmarshalAndCanonicalize(f *testing.F) {
 		if _, err := types.CanonicalizeEntry(context.Background(), ei); err != nil {
 			t.Skip()
 		}
+	})
+}
+
+// New: fuzz the direct decoder map fast-path and raw JSON fallbacks
+func FuzzRpmDecodeEntryDirectMapAndRaw(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		initter.Do(fuzzUtils.SetFuzzLogger)
+		ff := fuzz.NewConsumer(data)
+		choice, _ := ff.GetInt()
+		choice %= 2
+		toB64 := func(limit int) string {
+			b, _ := ff.GetBytes()
+			if len(b) > limit {
+				b = b[:limit]
+			}
+			return base64.StdEncoding.EncodeToString(b)
+		}
+
+		var input any
+		switch choice {
+		case 0:
+			m := map[string]any{}
+			if b, _ := ff.GetBool(); b {
+				m["publicKey"] = map[string]any{"content": toB64(256)}
+			}
+			if b, _ := ff.GetBool(); b {
+				m["package"] = map[string]any{
+					"headers": map[string]any{"name": "n", "version": "1"},
+					"hash":    map[string]any{"algorithm": "sha256", "value": "deadbeef"},
+					"content": toB64(512),
+				}
+			}
+			input = m
+		case 1:
+			mdl := &models.RpmV001Schema{}
+			if err := ff.GenerateStruct(mdl); err != nil {
+				t.Skip()
+			}
+			input = mdl
+		}
+		entry := &V001Entry{}
+		if err := DecodeEntry(input, &entry.RPMModel); err != nil {
+			t.Skip()
+		}
+		_ = entry.RPMModel.Validate(strfmt.Default)
 	})
 }

--- a/pkg/types/tuf/v0.0.1/benchmark_test.go
+++ b/pkg/types/tuf/v0.0.1/benchmark_test.go
@@ -1,0 +1,71 @@
+package tuf
+
+import (
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/sigstore/rekor/pkg/generated/models"
+	"github.com/sigstore/rekor/pkg/types"
+)
+
+// Sample test data for benchmarking
+var sampleTufData = map[string]any{
+	"metadata": map[string]any{
+		"content": map[string]any{
+			"signed": map[string]any{"_type": "targets", "version": 1},
+		},
+	},
+	"root": map[string]any{
+		"content": map[string]any{
+			"signed": map[string]any{"_type": "root", "version": 1},
+		},
+	},
+}
+
+// BenchmarkDecodeEntryMapstructure benchmarks the generic mapstructure-based DecodeEntry
+func BenchmarkDecodeEntryMapstructure(b *testing.B) {
+	for b.Loop() {
+		var obj models.TUFV001Schema
+		if err := types.DecodeEntry(sampleTufData, &obj); err != nil {
+			b.Fatalf("DecodeEntry failed: %v", err)
+		}
+		if err := obj.Validate(strfmt.Default); err != nil {
+			b.Fatalf("Validation failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryDirect benchmarks the new direct decode method
+func BenchmarkDecodeEntryDirect(b *testing.B) {
+	for b.Loop() {
+		var obj models.TUFV001Schema
+		if err := DecodeEntry(sampleTufData, &obj); err != nil {
+			b.Fatalf("DecodeEntry direct failed: %v", err)
+		}
+		if err := obj.Validate(strfmt.Default); err != nil {
+			b.Fatalf("Validation failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryMapstructureMemory benchmarks memory allocation for mapstructure
+func BenchmarkDecodeEntryMapstructureMemory(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		var obj models.TUFV001Schema
+		if err := types.DecodeEntry(sampleTufData, &obj); err != nil {
+			b.Fatalf("DecodeEntry failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkDecodeEntryDirectMemory benchmarks memory allocation for direct method
+func BenchmarkDecodeEntryDirectMemory(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		var obj models.TUFV001Schema
+		if err := DecodeEntry(sampleTufData, &obj); err != nil {
+			b.Fatalf("DecodeEntry direct failed: %v", err)
+		}
+	}
+}

--- a/pkg/types/tuf/v0.0.1/benchmark_test.go
+++ b/pkg/types/tuf/v0.0.1/benchmark_test.go
@@ -1,3 +1,18 @@
+//
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package tuf
 
 import (

--- a/tests/oss_fuzz.sh
+++ b/tests/oss_fuzz.sh
@@ -37,32 +37,44 @@ compile_native_go_fuzzer github.com/sigstore/rekor/pkg/sharding FuzzValidateEntr
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/signer FuzzNewFile FuzzNewFile
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/cose/v0.0.1 FuzzCoseCreateProposedEntry FuzzCoseCreateProposedEntry
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/cose/v0.0.1 FuzzCoseUnmarshalAndCanonicalize FuzzCoseUnmarshalAndCanonicalize
+compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/cose/v0.0.1 FuzzCoseDecodeEntryDirectMapAndRaw FuzzCoseDecodeEntryDirectMapAndRaw
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/hashedrekord FuzzHashedRekord FuzzHashedRekord
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/hashedrekord/v0.0.1 FuzzHashedRekordCreateProposedEntry FuzzHashedRekordCreateProposedEntry
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/hashedrekord/v0.0.1 FuzzHashedRekordUnmarshalAndCanonicalize FuzzHashedRekordUnmarshalAndCanonicalize
+compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/hashedrekord/v0.0.1 FuzzHashedRekordDecodeEntryDirectMapAndRaw FuzzHashedRekordDecodeEntryDirectMapAndRaw
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/alpine FuzzPackageUnmarshal FuzzPackageUnmarshal
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/alpine/v0.0.1 FuzzAlpineCreateProposedEntry FuzzAlpineCreateProposedEntry
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/alpine/v0.0.1 FuzzAlpineUnmarshalAndCanonicalize FuzzAlpineUnmarshalAndCanonicalize
+compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/alpine/v0.0.1 FuzzAlpineDecodeEntryDirectMapAndRaw FuzzAlpineDecodeEntryDirectMapAndRaw
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/jar FuzzJarUnmarshal FuzzJarUnmarshal
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/jar/v0.0.1 FuzzJarCreateProposedEntry FuzzJarCreateProposedEntry
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/jar/v0.0.1 FuzzJarUnmarshalAndCanonicalize FuzzJarUnmarshalAndCanonicalize
+compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/jar/v0.0.1 FuzzJarDecodeEntryDirectMapAndRaw FuzzJarDecodeEntryDirectMapAndRaw
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/intoto/v0.0.1 FuzzIntotoCreateProposedEntry FuzzIntotoCreateProposedEntry_v001
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/intoto/v0.0.1 FuzzIntotoUnmarshalAndCanonicalize FuzzIntotoUnmarshalAndCanonicalize_v001
+compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/intoto/v0.0.1 FuzzIntotoDecodeEntryDirectMapAndRaw FuzzIntotoDecodeEntryDirectMapAndRaw
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/intoto/v0.0.2 FuzzIntotoCreateProposedEntry FuzzIntotoCreateProposedEntry_v002
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/intoto/v0.0.2 FuzzIntotoUnmarshalAndCanonicalize FuzzIntotoUnmarshalAndCanonicalize_v002
+compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/intoto/v0.0.2 FuzzIntotoDecodeEntryDirectMapAndRaw FuzzIntotoDecodeEntryDirectMapAndRaw
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/tuf/v0.0.1 FuzzTufCreateProposedEntry FuzzTufCreateProposedEntry
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/tuf/v0.0.1 FuzzTufUnmarshalAndCanonicalize FuzzTufUnmarshalAndCanonicalize
+compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/tuf/v0.0.1 FuzzTufDecodeEntryDirectMapAndRaw FuzzTufDecodeEntryDirectMapAndRaw
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/rfc3161/v0.0.1 FuzzRfc3161CreateProposedEntry FuzzRfc3161CreateProposedEntry
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/rfc3161/v0.0.1 FuzzRfc3161UnmarshalAndCanonicalize FuzzRfc3161UnmarshalAndCanonicalize
+compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/rfc3161/v0.0.1 FuzzRfc3161DecodeEntryDirectMapAndRaw FuzzRfc3161DecodeEntryDirectMapAndRaw
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/rpm/v0.0.1 FuzzRpmCreateProposedEntry FuzzRpmCreateProposedEntry
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/rpm/v0.0.1 FuzzRpmUnmarshalAndCanonicalize FuzzRpmUnmarshalAndCanonicalize
+compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/rpm/v0.0.1 FuzzRpmDecodeEntryDirectMapAndRaw FuzzRpmDecodeEntryDirectMapAndRaw
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/helm/v0.0.1 FuzzHelmCreateProposedEntry FuzzHelmCreateProposedEntry
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/helm/v0.0.1 FuzzHelmUnmarshalAndCanonicalize FuzzHelmUnmarshalAndCanonicalize
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/helm/v0.0.1 FuzzHelmProvenanceUnmarshal FuzzHelmProvenanceUnmarshal
+compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/helm/v0.0.1 FuzzHelmDecodeEntryDirectMapAndRaw FuzzHelmDecodeEntryDirectMapAndRaw
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/rekord/v0.0.1 FuzzRekordCreateProposedEntry FuzzRekordCreateProposedEntry
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/rekord/v0.0.1 FuzzRekordUnmarshalAndCanonicalize FuzzRekordUnmarshalAndCanonicalize
+compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/rekord/v0.0.1 FuzzRekordDecodeEntryDirectMapAndRaw FuzzRekordDecodeEntryDirectMapAndRaw
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/dsse/v0.0.1 FuzzDSSECreateProposedEntry FuzzDSSECreateProposedEntry
 compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/dsse/v0.0.1 FuzzDSSEUnmarshalAndCanonicalize FuzzDSSEUnmarshalAndCanonicalize
+compile_native_go_fuzzer github.com/sigstore/rekor/pkg/types/dsse/v0.0.1 FuzzDSSEDecodeEntryDirectMapAndRaw FuzzDSSEDecodeEntryDirectMapAndRaw
 
 # Test 3rd party API that rekor/pkg/types/jar/v0.0.1 uses
 go mod edit -replace github.com/sassoftware/relic=$SRC/relic


### PR DESCRIPTION
mapstructure is convenient for clients who may not want to encode the specific type logic into their applications; however it is expensive (uses reflection and lots of allocations) - and the server-side code can do much, much better:

```
  | Type          | Benchmark                     | Operations/sec       | ns/op          | B/op         | allocs/op   |
  |---------------|-------------------------------|----------------------|----------------|--------------|-------------|
  | hashedrekord  | DecodeEntryMapstructure       | 87,224               | 12,456         | 3,536        | 130         |
  |               | DecodeEntryDirect             | 4,241,101 (+4,764%)  | 281.5 (-97.7%) | 184 (-94.8%) | 10 (-92.3%) |
  |               | DecodeEntryMapstructureMemory | 99,608               | 12,099         | 3,496        | 128         |
  |               | DecodeEntryDirectMemory       | 8,967,894 (+8,904%)  | 139.4 (-98.8%) | 144 (-95.9%) | 8 (-93.8%)  |
  | rekord        | DecodeEntryMapstructure       | 66,650               | 16,335         | 4,912        | 171         |
  |               | DecodeEntryDirect             | 1,998,006 (+2,897%)  | 605.4 (-96.3%) | 352 (-92.8%) | 18 (-89.5%) |
  |               | DecodeEntryMapstructureMemory | 75,574               | 16,184         | 4,784        | 165         |
  |               | DecodeEntryDirectMemory       | 5,949,034 (+7,773%)  | 197.4 (-98.8%) | 224 (-95.3%) | 12 (-92.7%) |
  | alpine        | DecodeEntryMapstructure       | 81,751               | 13,360         | 3,910        | 137         |
  |               | DecodeEntryDirect             | 3,805,863 (+4,555%)  | 317.0 (-97.6%) | 208 (-94.7%) | 10 (-92.7%) |
  |               | DecodeEntryMapstructureMemory | 90,792               | 13,049         | 3,870        | 135         |
  |               | DecodeEntryDirectMemory       | 8,341,514 (+9,087%)  | 145.5 (-98.9%) | 168 (-95.7%) | 8 (-94.1%)  |
  | jar           | DecodeEntryMapstructure       | 68,284               | 16,101         | 4,336        | 165         |
  |               | DecodeEntryDirect             | 3,131,325 (+4,485%)  | 385.4 (-97.6%) | 256 (-94.1%) | 13 (-92.1%) |
  |               | DecodeEntryMapstructureMemory | 72,627               | 15,869         | 4,272        | 162         |
  |               | DecodeEntryDirectMemory       | 7,179,967 (+9,785%)  | 167.9 (-98.9%) | 192 (-95.5%) | 10 (-93.8%) |
  | cose          | DecodeEntryMapstructure       | 67,878               | 15,771         | 4,888        | 160         |
  |               | DecodeEntryDirect             | 2,927,893 (+4,214%)  | 410.6 (-97.4%) | 296 (-93.9%) | 15 (-90.6%) |
  |               | DecodeEntryMapstructureMemory | 80,606               | 15,163         | 4,808        | 156         |
  |               | DecodeEntryDirectMemory       | 6,571,891 (+8,053%)  | 186.7 (-98.8%) | 216 (-95.5%) | 11 (-92.9%) |
  | dsse          | DecodeEntryMapstructure       | 52,696               | 21,506         | 6,184        | 203         |
  |               | DecodeEntryDirect             | 2,665,147 (+4,960%)  | 459.0 (-97.9%) | 328 (-94.7%) | 16 (-92.1%) |
  |               | DecodeEntryMapstructureMemory | 58,820               | 20,479         | 5,956        | 197         |
  |               | DecodeEntryDirectMemory       | 6,529,576 (+10,997%) | 184.7 (-99.1%) | 224 (-96.2%) | 11 (-94.4%) |
  | helm          | DecodeEntryMapstructure       | 81,764               | 13,241         | 3,896        | 138         |
  |               | DecodeEntryDirect             | 3,409,502 (+4,069%)  | 351.9 (-97.3%) | 200 (-94.9%) | 11 (-92.0%) |
  |               | DecodeEntryMapstructureMemory | 93,044               | 12,649         | 3,856        | 136         |
  |               | DecodeEntryDirectMemory       | 8,024,420 (+8,525%)  | 150.9 (-98.8%) | 160 (-95.9%) | 9 (-93.4%)  |
  | intoto v0.0.1 | DecodeEntryMapstructure       | 103,467              | 10,329         | 3,784        | 110         |
  |               | DecodeEntryDirect             | 3,034,082 (+2,833%)  | 396.7 (-96.2%) | 248 (-93.4%) | 13 (-88.2%) |
  |               | DecodeEntryMapstructureMemory | 120,357              | 9,823          | 3,704        | 106         |
  |               | DecodeEntryDirectMemory       | 8,313,902 (+6,805%)  | 163.0 (-98.3%) | 168 (-95.5%) | 9 (-91.5%)  |
  | intoto v0.0.2 | DecodeEntryMapstructure       | 39,009               | 29,362         | 10,742       | 292         |
  |               | DecodeEntryDirect             | 1,528,224 (+3,818%)  | 783.5 (-97.3%) | 552 (-94.9%) | 26 (-91.1%) |
  |               | DecodeEntryMapstructureMemory | 42,055               | 28,240         | 10,637       | 287         |
  |               | DecodeEntryDirectMemory       | 3,237,895 (+7,599%)  | 363.3 (-98.7%) | 448 (-95.8%) | 21 (-92.7%) |
  | rfc3161       | DecodeEntryMapstructure       | 318,961              | 3,735          | 784          | 38          |
  |               | DecodeEntryDirect             | 12,580,731 (+3,845%) | 95.64 (-97.4%) | 48 (-93.9%)  | 3 (-92.1%)  |
  |               | DecodeEntryMapstructureMemory | 319,934              | 3,661          | 784          | 38          |
  |               | DecodeEntryDirectMemory       | 27,762,674 (+8,579%) | 43.53 (-98.8%) | 48 (-93.9%)  | 3 (-92.1%)  |
  | rpm           | DecodeEntryMapstructure       | 70,752               | 15,532         | 4,534        | 152         |
  |               | DecodeEntryDirect             | 3,824,611 (+5,307%)  | 316.1 (-98.0%) | 208 (-95.4%) | 10 (-93.4%) |
  |               | DecodeEntryMapstructureMemory | 78,793               | 15,114         | 4,494        | 150         |
  |               | DecodeEntryDirectMemory       | 8,314,075 (+10,453%) | 143.8 (-99.0%) | 168 (-96.3%) | 8 (-94.7%)  |
  | tuf           | DecodeEntryMapstructure       | 400,794              | 3,015          | 1,816        | 39          |
  |               | DecodeEntryDirect             | 13,219,346 (+3,197%) | 90.99 (-97.0%) | 32 (-98.2%)  | 2 (-94.9%)  |
  |               | DecodeEntryMapstructureMemory | 395,832              | 2,982          | 1,816        | 39          |
  |               | DecodeEntryDirectMemory       | 32,530,498 (+8,119%) | 37.30 (-98.7%) | 32 (-98.2%)  | 2 (-94.9%)  |
```

this adds the benchmark tests, additional fuzzers, and type-specific calls.