### PR TITLE
optimize performance of regex operations

### DIFF
--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -57,12 +57,13 @@ func errorMsg(message string, code int) *models.Error {
 	}
 }
 
+var re = regexp.MustCompile("^(.*)Params$")
+
 func handleRekorAPIError(params interface{}, code int, err error, message string, fields ...interface{}) middleware.Responder {
 	if message == "" {
 		message = http.StatusText(code)
 	}
 
-	re := regexp.MustCompile("^(.*)Params$")
 	typeStr := fmt.Sprintf("%T", params)
 	handler := re.FindStringSubmatch(typeStr)[1]
 

--- a/pkg/types/hashedrekord/v0.0.1/entry.go
+++ b/pkg/types/hashedrekord/v0.0.1/entry.go
@@ -28,7 +28,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/asaskevich/govalidator"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 
@@ -170,17 +169,23 @@ func (v *V001Entry) validate() (pki.Signature, pki.PublicKey, error) {
 	if hash == nil {
 		return nil, nil, &types.InputValidationError{Err: errors.New("missing hash")}
 	}
-	if !govalidator.IsHash(swag.StringValue(hash.Value), swag.StringValue(hash.Algorithm)) {
-		return nil, nil, &types.InputValidationError{Err: errors.New("invalid value for hash")}
-	}
 
 	var alg crypto.Hash
 	switch swag.StringValue(hash.Algorithm) {
 	case models.HashedrekordV001SchemaDataHashAlgorithmSha384:
+		if len(*hash.Value) != crypto.SHA384.Size()*2 {
+			return nil, nil, &types.InputValidationError{Err: errors.New("invalid value for hash")}
+		}
 		alg = crypto.SHA384
 	case models.HashedrekordV001SchemaDataHashAlgorithmSha512:
+		if len(*hash.Value) != crypto.SHA512.Size()*2 {
+			return nil, nil, &types.InputValidationError{Err: errors.New("invalid value for hash")}
+		}
 		alg = crypto.SHA512
 	default:
+		if len(*hash.Value) != crypto.SHA256.Size()*2 {
+			return nil, nil, &types.InputValidationError{Err: errors.New("invalid value for hash")}
+		}
 		alg = crypto.SHA256
 	}
 

--- a/pkg/types/rekord/v0.0.1/entry.go
+++ b/pkg/types/rekord/v0.0.1/entry.go
@@ -18,6 +18,7 @@ package rekord
 import (
 	"bytes"
 	"context"
+	"crypto"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -28,7 +29,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/asaskevich/govalidator"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 
@@ -235,7 +235,11 @@ func (v V001Entry) validate() error {
 
 	hash := data.Hash
 	if hash != nil {
-		if !govalidator.IsHash(swag.StringValue(hash.Value), swag.StringValue(hash.Algorithm)) {
+		// Rekord v0.0.1 schema enumerates sha256; enforce length accordingly.
+		if hash.Value == nil || len(*hash.Value) != crypto.SHA256.Size()*2 {
+			return errors.New("invalid value for hash")
+		}
+		if _, err := hex.DecodeString(*hash.Value); err != nil {
 			return errors.New("invalid value for hash")
 		}
 	} else if len(data.Content) == 0 {

--- a/pkg/types/rpm/v0.0.1/entry.go
+++ b/pkg/types/rpm/v0.0.1/entry.go
@@ -298,8 +298,7 @@ func (v V001Entry) validate() error {
 	hash := pkg.Hash
 	if hash != nil {
 		// Only sha256 is supported for rpm v0.0.1; enforce length accordingly.
-		var want = crypto.SHA256
-		if hash.Value == nil || len(*hash.Value) != want.Size()*2 {
+		if hash.Value == nil || len(*hash.Value) != crypto.SHA256.Size()*2 {
 			return errors.New("invalid value for hash")
 		}
 		if _, err := hex.DecodeString(*hash.Value); err != nil {


### PR DESCRIPTION
profiling Rekor yielded that we were doing a lot of regex allocations in the hot path; this change optimizes those down with pretty big results:

```sh
goos: darwin
goarch: arm64
pkg: github.com/sigstore/rekor/pkg/types/hashedrekord/v0.0.1
cpu: Apple M4 Pro
BenchmarkHashValidation/Old/SHA256-14             171613              5854 ns/op           18185 B/op        173 allocs/op
BenchmarkHashValidation/New/SHA256-14           36960652                31.70 ns/op           32 B/op          1 allocs/op
BenchmarkHashValidation/Old/SHA384-14             143301              9013 ns/op           29637 B/op        239 allocs/op
BenchmarkHashValidation/New/SHA384-14           29359563                41.33 ns/op           48 B/op          1 allocs/op
BenchmarkHashValidation/Old/SHA512-14             113379             10810 ns/op           34810 B/op        303 allocs/op
BenchmarkHashValidation/New/SHA512-14           22802001                51.42 ns/op           64 B/op          1 allocs/op
PASS
ok      github.com/sigstore/rekor/pkg/types/hashedrekord/v0.0.1 7.834s
```
