### PR TITLE
process type contents serially

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 
 	"github.com/sigstore/rekor/pkg/generated/models"
-	"github.com/sigstore/rekor/pkg/log"
 	"golang.org/x/exp/slices"
 )
 
@@ -86,19 +85,4 @@ func ListImplementedTypes() []string {
 		return true
 	})
 	return retVal
-}
-
-type errCloser interface {
-	CloseWithError(error) error
-}
-
-func PipeCloser(errClosers ...errCloser) func(err error) error {
-	return func(err error) error {
-		for _, p := range errClosers {
-			if err := p.CloseWithError(err); err != nil {
-				log.Logger.Error(fmt.Errorf("error closing pipe: %w", err))
-			}
-		}
-		return err
-	}
 }


### PR DESCRIPTION
We're still seeing spurious testing failures due to pipes being closed, and similar to #2578 the errgroup/goroutine pattern wasn't removed from all types. this finishes the job.

#vc4a