### PR TITLE
log: remove zap & go-chi dependecy from pkg/types

### DIFF
--- a/pkg/internal/log/logger.go
+++ b/pkg/internal/log/logger.go
@@ -1,0 +1,36 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+type LoggerImpl interface {
+	Error(...any)
+	Errorf(string, ...any)
+	Panic(...any)
+	Info(...any)
+	Infof(string, ...any)
+}
+
+var Logger LoggerImpl = &discardLogger{}
+
+type discardLogger struct{}
+
+func (l *discardLogger) Panic(err ...any) {
+	panic(err)
+}
+func (l *discardLogger) Error(...any)          {}
+func (l *discardLogger) Errorf(string, ...any) {}
+func (l *discardLogger) Infof(string, ...any)  {}
+func (l *discardLogger) Info(...any)           {}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -21,6 +21,7 @@ import (
 	"log"
 
 	"github.com/go-chi/chi/v5/middleware"
+	internallog "github.com/sigstore/rekor/pkg/internal/log"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -54,6 +55,7 @@ func ConfigureLogger(logType, traceStrPrefix string) {
 		log.Fatalln("createLogger", err)
 	}
 	Logger = logger.Sugar()
+	internallog.Logger = Logger
 
 	if traceStrPrefix != "" {
 		traceStringPrefix = traceStrPrefix

--- a/pkg/types/dsse/v0.0.1/entry.go
+++ b/pkg/types/dsse/v0.0.1/entry.go
@@ -30,14 +30,12 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/in-toto/in-toto-golang/in_toto"
-	"github.com/secure-systems-lab/go-securesystemslib/dsse"
-
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag/conv"
-
+	"github.com/in-toto/in-toto-golang/in_toto"
+	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 	"github.com/sigstore/rekor/pkg/generated/models"
-	"github.com/sigstore/rekor/pkg/log"
+	"github.com/sigstore/rekor/pkg/internal/log"
 	"github.com/sigstore/rekor/pkg/pki"
 	"github.com/sigstore/rekor/pkg/pki/x509"
 	"github.com/sigstore/rekor/pkg/types"

--- a/pkg/types/hashedrekord/v0.0.1/entry.go
+++ b/pkg/types/hashedrekord/v0.0.1/entry.go
@@ -33,7 +33,7 @@ import (
 	"github.com/go-openapi/swag/conv"
 
 	"github.com/sigstore/rekor/pkg/generated/models"
-	"github.com/sigstore/rekor/pkg/log"
+	"github.com/sigstore/rekor/pkg/internal/log"
 	"github.com/sigstore/rekor/pkg/pki"
 	"github.com/sigstore/rekor/pkg/pki/x509"
 	"github.com/sigstore/rekor/pkg/types"

--- a/pkg/types/intoto/intoto.go
+++ b/pkg/types/intoto/intoto.go
@@ -22,7 +22,7 @@ import (
 	"slices"
 
 	"github.com/sigstore/rekor/pkg/generated/models"
-	"github.com/sigstore/rekor/pkg/log"
+	"github.com/sigstore/rekor/pkg/internal/log"
 	"github.com/sigstore/rekor/pkg/types"
 )
 
@@ -82,12 +82,12 @@ func (it *BaseIntotoType) CreateProposedEntry(ctx context.Context, version strin
 			}
 			ei, err := it.VersionedUnmarshal(nil, v)
 			if err != nil {
-				log.ContextLogger(ctx).Errorf("fetching Intoto version (%v) implementation: %w", v, err)
+				log.Logger.Errorf("fetching Intoto version (%v) implementation: %w", v, err)
 				continue
 			}
 			versionedPE, err := ei.CreateFromArtifactProperties(ctx, props)
 			if err != nil {
-				log.ContextLogger(ctx).Errorf("error creating Intoto entry of version (%v): %w", v, err)
+				log.Logger.Errorf("error creating Intoto entry of version (%v): %w", v, err)
 				continue
 			}
 			next.next = &ProposedIntotoEntryIterator{versionedPE, nil}

--- a/pkg/types/intoto/v0.0.2/entry.go
+++ b/pkg/types/intoto/v0.0.2/entry.go
@@ -38,7 +38,7 @@ import (
 	"github.com/go-openapi/swag/conv"
 
 	"github.com/sigstore/rekor/pkg/generated/models"
-	"github.com/sigstore/rekor/pkg/log"
+	"github.com/sigstore/rekor/pkg/internal/log"
 	"github.com/sigstore/rekor/pkg/pki"
 	"github.com/sigstore/rekor/pkg/pki/x509"
 	"github.com/sigstore/rekor/pkg/types"

--- a/pkg/types/versionmap.go
+++ b/pkg/types/versionmap.go
@@ -20,7 +20,7 @@ import (
 	"sync"
 
 	"github.com/blang/semver"
-	"github.com/sigstore/rekor/pkg/log"
+	"github.com/sigstore/rekor/pkg/internal/log"
 )
 
 // VersionEntryFactoryMap defines a map-like interface to find the correct implementation for a version string


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
Rekor currently depends on Uber’s Zap logging framework (with go-chi middleware integration). It’s unclear to me why this particular stack was introduced, as other Sigstore projects don’t seem to use it.

However, this dependency leaks into library packages such as those under `pkg/types`, which are meant to be reused by other projects like `sigstore-go` when running TLog verification. This adds an unnecessary heavy dependency and also causes out-of-place log output in importing applications.

This PR fixes that by adding a lightweight, dependency-free internal logger (`pkg/internal/log`) as the default for these library packages. The internal logger is silent by default, which is suitable for libraries. Any user of Zap or the Rekor CLI utilities can continue to configure logging via `pkg/log` without any code or behavior changes(Rekor CLI still gets all the same logs as before). If an importing application wants to capture logs from Rekor libs, it can configure the `pkg/log` package as before.

Dependency footprint change for `sigstore-go/verifier`:
```
112 files changed, 34 insertions(+), 14361 deletions(-)
```

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
