### PR TITLE
pkg: separate pki types from implementations

### DIFF
--- a/pkg/pki/pkitypes/types.go
+++ b/pkg/pki/pkitypes/types.go
@@ -16,11 +16,25 @@
 package pki
 
 import (
-	pkitypes "github.com/sigstore/rekor/pkg/pki/pkitypes"
+	"io"
+
+	"github.com/sigstore/rekor/pkg/pki/identity"
+	sigsig "github.com/sigstore/sigstore/pkg/signature"
 )
 
 // PublicKey Generic object representing a public key (regardless of format & algorithm)
-type PublicKey = pkitypes.PublicKey
+type PublicKey interface {
+	CanonicalValue() ([]byte, error)
+	// Deprecated: EmailAddresses() will be deprecated in favor of Subjects() which will
+	// also return Subject URIs present in public keys.
+	EmailAddresses() []string
+	Subjects() []string
+	// Identities returns a list of typed keys and certificates.
+	Identities() ([]identity.Identity, error)
+}
 
 // Signature Generic object representing a signature (regardless of format & algorithm)
-type Signature = pkitypes.Signature
+type Signature interface {
+	CanonicalValue() ([]byte, error)
+	Verify(r io.Reader, k interface{}, opts ...sigsig.VerifyOption) error
+}

--- a/pkg/types/dsse/v0.0.1/entry.go
+++ b/pkg/types/dsse/v0.0.1/entry.go
@@ -36,7 +36,7 @@ import (
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/rekor/pkg/internal/log"
-	"github.com/sigstore/rekor/pkg/pki"
+	pkitypes "github.com/sigstore/rekor/pkg/pki/pkitypes"
 	"github.com/sigstore/rekor/pkg/pki/x509"
 	"github.com/sigstore/rekor/pkg/types"
 	dsseType "github.com/sigstore/rekor/pkg/types/dsse"
@@ -506,12 +506,12 @@ func verifyEnvelope(allPubKeyBytes [][]byte, env *dsse.Envelope) (map[string]*x5
 	return verifierBySig, nil
 }
 
-func (v V001Entry) Verifiers() ([]pki.PublicKey, error) {
+func (v V001Entry) Verifiers() ([]pkitypes.PublicKey, error) {
 	if len(v.DSSEObj.Signatures) == 0 {
 		return nil, errors.New("dsse v0.0.1 entry not initialized")
 	}
 
-	var keys []pki.PublicKey
+	var keys []pkitypes.PublicKey
 	for _, s := range v.DSSEObj.Signatures {
 		key, err := x509.NewPublicKey(bytes.NewReader(*s.Verifier))
 		if err != nil {

--- a/pkg/types/entries.go
+++ b/pkg/types/entries.go
@@ -27,7 +27,7 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/sigstore/rekor/pkg/generated/models"
-	"github.com/sigstore/rekor/pkg/pki"
+	pkitypes "github.com/sigstore/rekor/pkg/pki/pkitypes"
 )
 
 // EntryImpl specifies the behavior of a versioned type
@@ -37,9 +37,9 @@ type EntryImpl interface {
 	Canonicalize(ctx context.Context) ([]byte, error) // marshal the canonical entry to be put into the tlog
 	Unmarshal(e models.ProposedEntry) error           // unmarshal the abstract entry into the specific struct for this versioned type
 	CreateFromArtifactProperties(context.Context, ArtifactProperties) (models.ProposedEntry, error)
-	Verifiers() ([]pki.PublicKey, error) // list of keys or certificates that can verify an entry's signature
-	ArtifactHash() (string, error)       // hex-encoded artifact hash prefixed with hash name, e.g. sha256:abcdef
-	Insertable() (bool, error)           // denotes whether the entry that was unmarshalled has the writeOnly fields required to validate and insert into the log
+	Verifiers() ([]pkitypes.PublicKey, error) // list of keys or certificates that can verify an entry's signature
+	ArtifactHash() (string, error)            // hex-encoded artifact hash prefixed with hash name, e.g. sha256:abcdef
+	Insertable() (bool, error)                // denotes whether the entry that was unmarshalled has the writeOnly fields required to validate and insert into the log
 }
 
 // EntryWithAttestationImpl specifies the behavior of a versioned type that also stores attestations

--- a/pkg/types/hashedrekord/v0.0.1/entry.go
+++ b/pkg/types/hashedrekord/v0.0.1/entry.go
@@ -34,7 +34,7 @@ import (
 
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/rekor/pkg/internal/log"
-	"github.com/sigstore/rekor/pkg/pki"
+	pkitypes "github.com/sigstore/rekor/pkg/pki/pkitypes"
 	"github.com/sigstore/rekor/pkg/pki/x509"
 	"github.com/sigstore/rekor/pkg/types"
 	hashedrekord "github.com/sigstore/rekor/pkg/types/hashedrekord"
@@ -201,7 +201,7 @@ func (v *V001Entry) Canonicalize(_ context.Context) ([]byte, error) {
 }
 
 // validate performs cross-field validation for fields in object
-func (v *V001Entry) validate() (pki.Signature, pki.PublicKey, error) {
+func (v *V001Entry) validate() (pkitypes.Signature, pkitypes.PublicKey, error) {
 	sig := v.HashedRekordObj.Signature
 	if sig == nil {
 		return nil, nil, &types.InputValidationError{Err: errors.New("missing signature")}
@@ -281,7 +281,7 @@ func (v V001Entry) CreateFromArtifactProperties(_ context.Context, props types.A
 
 	var err error
 
-	if props.PKIFormat != string(pki.X509) {
+	if props.PKIFormat != "x509" {
 		return nil, errors.New("hashedrekord entries can only be created for artifacts signed with x509-based PKI")
 	}
 
@@ -330,7 +330,7 @@ func (v V001Entry) CreateFromArtifactProperties(_ context.Context, props types.A
 	return &returnVal, nil
 }
 
-func (v V001Entry) Verifiers() ([]pki.PublicKey, error) {
+func (v V001Entry) Verifiers() ([]pkitypes.PublicKey, error) {
 	if v.HashedRekordObj.Signature == nil || v.HashedRekordObj.Signature.PublicKey == nil || v.HashedRekordObj.Signature.PublicKey.Content == nil {
 		return nil, errors.New("hashedrekord v0.0.1 entry not initialized")
 	}
@@ -338,7 +338,7 @@ func (v V001Entry) Verifiers() ([]pki.PublicKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	return []pki.PublicKey{key}, nil
+	return []pkitypes.PublicKey{key}, nil
 }
 
 func (v V001Entry) ArtifactHash() (string, error) {

--- a/pkg/types/intoto/v0.0.1/entry.go
+++ b/pkg/types/intoto/v0.0.1/entry.go
@@ -37,7 +37,7 @@ import (
 
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/rekor/pkg/log"
-	"github.com/sigstore/rekor/pkg/pki"
+	pkitypes "github.com/sigstore/rekor/pkg/pki/pkitypes"
 	"github.com/sigstore/rekor/pkg/pki/x509"
 	"github.com/sigstore/rekor/pkg/types"
 	"github.com/sigstore/rekor/pkg/types/intoto"
@@ -63,7 +63,7 @@ func SetMaxAttestationSize(limit int) {
 
 type V001Entry struct {
 	IntotoObj models.IntotoV001Schema
-	keyObj    pki.PublicKey
+	keyObj    pkitypes.PublicKey
 	env       dsse.Envelope
 }
 
@@ -416,7 +416,7 @@ func (v V001Entry) CreateFromArtifactProperties(_ context.Context, props types.A
 	return &returnVal, nil
 }
 
-func (v V001Entry) Verifiers() ([]pki.PublicKey, error) {
+func (v V001Entry) Verifiers() ([]pkitypes.PublicKey, error) {
 	if v.IntotoObj.PublicKey == nil {
 		return nil, errors.New("intoto v0.0.1 entry not initialized")
 	}
@@ -424,7 +424,7 @@ func (v V001Entry) Verifiers() ([]pki.PublicKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	return []pki.PublicKey{key}, nil
+	return []pkitypes.PublicKey{key}, nil
 }
 
 func (v V001Entry) ArtifactHash() (string, error) {

--- a/pkg/types/intoto/v0.0.2/entry.go
+++ b/pkg/types/intoto/v0.0.2/entry.go
@@ -38,7 +38,7 @@ import (
 
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/rekor/pkg/internal/log"
-	"github.com/sigstore/rekor/pkg/pki"
+	pkitypes "github.com/sigstore/rekor/pkg/pki/pkitypes"
 	"github.com/sigstore/rekor/pkg/pki/x509"
 	"github.com/sigstore/rekor/pkg/types"
 	"github.com/sigstore/rekor/pkg/types/intoto"
@@ -582,7 +582,7 @@ func verifyEnvelope(allPubKeyBytes [][]byte, env *dsse.Envelope) (map[string]*x5
 	return verifierBySig, nil
 }
 
-func (v V002Entry) Verifiers() ([]pki.PublicKey, error) {
+func (v V002Entry) Verifiers() ([]pkitypes.PublicKey, error) {
 	if v.IntotoObj.Content == nil || v.IntotoObj.Content.Envelope == nil {
 		return nil, errors.New("intoto v0.0.2 entry not initialized")
 	}
@@ -592,7 +592,7 @@ func (v V002Entry) Verifiers() ([]pki.PublicKey, error) {
 		return nil, errors.New("no signatures found on intoto entry")
 	}
 
-	var keys []pki.PublicKey
+	var keys []pkitypes.PublicKey
 	for _, s := range v.IntotoObj.Content.Envelope.Signatures {
 		key, err := x509.NewPublicKey(bytes.NewReader(*s.PublicKey))
 		if err != nil {

--- a/pkg/types/test_util.go
+++ b/pkg/types/test_util.go
@@ -22,7 +22,7 @@ import (
 	"github.com/go-openapi/strfmt"
 
 	"github.com/sigstore/rekor/pkg/generated/models"
-	"github.com/sigstore/rekor/pkg/pki"
+	pkitypes "github.com/sigstore/rekor/pkg/pki/pkitypes"
 )
 
 type BaseUnmarshalTester struct{}
@@ -35,7 +35,7 @@ func (u BaseUnmarshalTester) ArtifactHash() (string, error) {
 	return "", nil
 }
 
-func (u BaseUnmarshalTester) Verifiers() ([]pki.PublicKey, error) {
+func (u BaseUnmarshalTester) Verifiers() ([]pkitypes.PublicKey, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

`pkg/pki` package defines both the interface types for `PublicKey` and `Signature`, linked to many external packages, and also all the implementations for pki via a static factory map.

This separates the types to separate packages so the packages that use them can be included without a big dependency chain. The types are aliased to the old pkg/pki package so that this change wouldn't break any backwards compatibility.

This could be cleaned up more in a further refactor when backwards compatibility is not an issue.

Footprint change for `sigstore-go/verifier` 
```
 80 files changed, 18 insertions(+), 13144 deletions(-)
```
Most notably, this drops the inclusion of `spf13/cobra` CLI framework and its dependencies that somehow is pulled in via x509tools dependency 🤯 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
