### PR TITLE
pkg: remove viper config from spec definitions

### DIFF
--- a/cmd/rekor-server/app/root.go
+++ b/cmd/rekor-server/app/root.go
@@ -27,6 +27,9 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/sigstore/rekor/pkg/api"
 	"github.com/sigstore/rekor/pkg/log"
+	cose "github.com/sigstore/rekor/pkg/types/cose/v0.0.1"
+	intoto001 "github.com/sigstore/rekor/pkg/types/intoto/v0.0.1"
+	intoto002 "github.com/sigstore/rekor/pkg/types/intoto/v0.0.2"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -214,4 +217,9 @@ func initConfig() {
 	if err := viper.ReadInConfig(); err == nil {
 		log.Logger.Infof("Using config file: %s", viper.ConfigFileUsed())
 	}
+
+	maxSize := viper.GetInt("max_attestation_size")
+	intoto001.SetMaxAttestationSize(maxSize)
+	intoto002.SetMaxAttestationSize(maxSize)
+	cose.SetMaxAttestationSize(maxSize)
 }

--- a/pkg/types/cose/v0.0.1/entry.go
+++ b/pkg/types/cose/v0.0.1/entry.go
@@ -34,7 +34,6 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag/conv"
 	"github.com/in-toto/in-toto-golang/in_toto"
-	"github.com/spf13/viper"
 	gocose "github.com/veraison/go-cose"
 
 	"github.com/sigstore/rekor/pkg/generated/models"
@@ -57,6 +56,12 @@ func init() {
 	if err := cose.VersionMap.SetEntryFactory(APIVERSION, NewEntry); err != nil {
 		log.Logger.Panic(err)
 	}
+}
+
+var maxAttestationSize = 100 * 1024
+
+func SetMaxAttestationSize(limit int) {
+	maxAttestationSize = limit
 }
 
 type V001Entry struct {
@@ -368,8 +373,8 @@ func DecodeEntry(input any, output *models.CoseV001Schema) error {
 // into attestation storage
 func (v *V001Entry) AttestationKeyValue() (string, []byte) {
 	storageSize := len(v.CoseObj.Message)
-	if storageSize > viper.GetInt("max_attestation_size") {
-		log.Logger.Infof("Skipping attestation storage, size %d is greater than max %d", storageSize, viper.GetInt("max_attestation_size"))
+	if storageSize > maxAttestationSize {
+		log.Logger.Infof("Skipping attestation storage, size %d is greater than max %d", storageSize, maxAttestationSize)
 		return "", nil
 	}
 

--- a/pkg/types/cose/v0.0.1/entry_test.go
+++ b/pkg/types/cose/v0.0.1/entry_test.go
@@ -27,7 +27,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"math/big"
-	"os"
 	"reflect"
 	"testing"
 
@@ -37,7 +36,6 @@ import (
 	"github.com/sigstore/rekor/pkg/pki/identity"
 	sigx509 "github.com/sigstore/rekor/pkg/pki/x509"
 	"github.com/sigstore/rekor/pkg/types"
-	"github.com/spf13/viper"
 	gocose "github.com/veraison/go-cose"
 	"go.uber.org/goleak"
 )
@@ -541,6 +539,8 @@ func TestV001Entry_Attestation(t *testing.T) {
 	}
 
 	t.Run("no storage", func(t *testing.T) {
+		SetMaxAttestationSize(0)
+
 		v := &V001Entry{
 			CoseObj: models.CoseV001Schema{},
 		}
@@ -557,10 +557,7 @@ func TestV001Entry_Attestation(t *testing.T) {
 	})
 
 	t.Run("with storage", func(t *testing.T) {
-		// Need to trick viper to update config so we can return
-		// an attestation
-		os.Setenv("MAX_ATTESTATION_SIZE", "1048576")
-		viper.AutomaticEnv()
+		SetMaxAttestationSize(1048576)
 
 		msgHash := sha256.Sum256(msg)
 		wantKey := fmt.Sprintf("sha256:%s",

--- a/pkg/types/intoto/v0.0.1/entry.go
+++ b/pkg/types/intoto/v0.0.1/entry.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
-	"github.com/spf13/viper"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag/conv"
@@ -54,6 +53,12 @@ func init() {
 	if err := intoto.VersionMap.SetEntryFactory(APIVERSION, NewEntry); err != nil {
 		log.Logger.Panic(err)
 	}
+}
+
+var maxAttestationSize = 100 * 1024
+
+func SetMaxAttestationSize(limit int) {
+	maxAttestationSize = limit
 }
 
 type V001Entry struct {
@@ -350,8 +355,8 @@ func (v *V001Entry) AttestationKey() string {
 // AttestationKeyValue returns both the key and value to be persisted into attestation storage
 func (v *V001Entry) AttestationKeyValue() (string, []byte) {
 	storageSize := base64.StdEncoding.DecodedLen(len(v.env.Payload))
-	if storageSize > viper.GetInt("max_attestation_size") {
-		log.Logger.Infof("Skipping attestation storage, size %d is greater than max %d", storageSize, viper.GetInt("max_attestation_size"))
+	if storageSize > maxAttestationSize {
+		log.Logger.Infof("Skipping attestation storage, size %d is greater than max %d", storageSize, maxAttestationSize)
 		return "", nil
 	}
 	attBytes, _ := base64.StdEncoding.DecodeString(v.env.Payload)

--- a/pkg/types/intoto/v0.0.2/entry.go
+++ b/pkg/types/intoto/v0.0.2/entry.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
-	"github.com/spf13/viper"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag/conv"
@@ -55,6 +54,12 @@ func init() {
 	if err := intoto.VersionMap.SetEntryFactory(APIVERSION, NewEntry); err != nil {
 		log.Logger.Panic(err)
 	}
+}
+
+var maxAttestationSize = 100 * 1024
+
+func SetMaxAttestationSize(limit int) {
+	maxAttestationSize = limit
 }
 
 type V002Entry struct {
@@ -392,8 +397,8 @@ func (v *V002Entry) AttestationKey() string {
 // AttestationKeyValue returns both the key and value to be persisted into attestation storage
 func (v *V002Entry) AttestationKeyValue() (string, []byte) {
 	storageSize := base64.StdEncoding.DecodedLen(len(v.env.Payload))
-	if storageSize > viper.GetInt("max_attestation_size") {
-		log.Logger.Infof("Skipping attestation storage, size %d is greater than max %d", storageSize, viper.GetInt("max_attestation_size"))
+	if storageSize > maxAttestationSize {
+		log.Logger.Infof("Skipping attestation storage, size %d is greater than max %d", storageSize, maxAttestationSize)
 		return "", nil
 	}
 	attBytes, err := base64.StdEncoding.DecodeString(v.env.Payload)


### PR DESCRIPTION


<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

CLI config reading routines from Viper should not be included in spec definition types under pkg because
    - this creates unnecessarily huge dependency
    - it creates an unexpected reconfiguration/attack method to applications importing the types.

Instead, read viper config in Rekor CLI and pass to the types packages to reconfigure them. The default size limit remains unchanged.

Optionally, I could instead create a `limits` pkg with no dependencies that spec types import for shared implementation. In that case, let me know where you want that pkg defined.

Footprint reduction to `sigstore-go/verifier` from this change:
```
 218 files changed, 33 insertions(+), 35989 deletions(-)
```

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
