### PR TITLE
use interruptable context to elegantly handle signals in rekor-cli

### DIFF
--- a/cmd/rekor-cli/app/format/wrap.go
+++ b/cmd/rekor-cli/app/format/wrap.go
@@ -29,11 +29,11 @@ import (
 
 type CobraCmd func(cmd *cobra.Command, args []string)
 
-type formatCmd func(args []string) (interface{}, error)
+type formatCmd func(cmd *cobra.Command, args []string) (interface{}, error)
 
 func WrapCmd(f formatCmd) CobraCmd {
-	return func(_ *cobra.Command, args []string) {
-		obj, err := f(args)
+	return func(cmd *cobra.Command, args []string) {
+		obj, err := f(cmd, args)
 		if err != nil {
 			log.CliLogger.Fatal(err)
 		}

--- a/cmd/rekor-cli/app/log_proof.go
+++ b/cmd/rekor-cli/app/log_proof.go
@@ -72,7 +72,7 @@ var logProofCmd = &cobra.Command{
 		}
 		return nil
 	},
-	Run: format.WrapCmd(func(_ []string) (interface{}, error) {
+	Run: format.WrapCmd(func(cmd *cobra.Command, _ []string) (interface{}, error) {
 		rekorClient, err := client.GetRekorClient(viper.GetString("rekor_server"), client.WithUserAgent(UserAgent()), client.WithRetryCount(viper.GetUint("retry")), client.WithLogger(log.CliLogger))
 		if err != nil {
 			return nil, err
@@ -82,7 +82,7 @@ var logProofCmd = &cobra.Command{
 		lastSize := int64(viper.GetUint64("last-size"))
 		treeID := viper.GetString("tree-id")
 
-		params := tlog.NewGetLogProofParams()
+		params := tlog.NewGetLogProofParamsWithContext(cmd.Context())
 		params.FirstSize = &firstSize
 		params.LastSize = lastSize
 		params.TreeID = &treeID

--- a/cmd/rekor-cli/app/root.go
+++ b/cmd/rekor-cli/app/root.go
@@ -16,9 +16,12 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -53,7 +56,9 @@ var rootCmd = &cobra.Command{
 
 // Execute runs the base CLI
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		log.CliLogger.Fatal(err)
 	}
 }

--- a/cmd/rekor-cli/app/search.go
+++ b/cmd/rekor-cli/app/search.go
@@ -96,14 +96,14 @@ var searchCmd = &cobra.Command{
 			os.Exit(1)
 		}
 	},
-	Run: format.WrapCmd(func(_ []string) (interface{}, error) {
+	Run: format.WrapCmd(func(cmd *cobra.Command, _ []string) (interface{}, error) {
 		log := log.CliLogger
 		rekorClient, err := client.GetRekorClient(viper.GetString("rekor_server"), client.WithUserAgent(UserAgent()), client.WithRetryCount(viper.GetUint("retry")), client.WithLogger(log))
 		if err != nil {
 			return nil, err
 		}
 
-		params := index.NewSearchIndexParams()
+		params := index.NewSearchIndexParamsWithContext(cmd.Context())
 		params.SetTimeout(viper.GetDuration("timeout"))
 		params.Query = &models.SearchIndex{}
 

--- a/pkg/pki/tuf/e2e_test.go
+++ b/pkg/pki/tuf/e2e_test.go
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package tuf
 

--- a/pkg/pki/tuf/tuf_e2e_test.go
+++ b/pkg/pki/tuf/tuf_e2e_test.go
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package tuf
 

--- a/pkg/pki/x509/e2e_test.go
+++ b/pkg/pki/x509/e2e_test.go
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 //go:build e2e
-// +build e2e
 
 package x509
 

--- a/pkg/types/alpine/e2e.go
+++ b/pkg/types/alpine/e2e.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 //
 // Copyright 2021 The Sigstore Authors.
 //
@@ -15,6 +12,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+//go:build e2e
 
 package alpine
 


### PR DESCRIPTION
also cleans up some left-over build tags which aren't compliant with new compilers.