### PR TITLE
Add support for a custom TLS config for clients

### DIFF
--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -15,6 +15,7 @@
 package client
 
 import (
+	"crypto/tls"
 	"net/http"
 	"time"
 
@@ -30,6 +31,7 @@ type options struct {
 	RetryWaitMin        time.Duration
 	RetryWaitMax        time.Duration
 	InsecureTLS         bool
+	TLSConfig           *tls.Config
 	Logger              interface{}
 	NoDisableKeepalives bool
 	Headers             map[string][]string
@@ -95,6 +97,13 @@ func WithLogger(logger interface{}) Option {
 func WithInsecureTLS(enabled bool) Option {
 	return func(o *options) {
 		o.InsecureTLS = enabled
+	}
+}
+
+// WithTLSConfig sets the TLS config.
+func WithTLSConfig(tlsConfig *tls.Config) Option {
+	return func(o *options) {
+		o.TLSConfig = tlsConfig
 	}
 }
 

--- a/pkg/client/rekor_client.go
+++ b/pkg/client/rekor_client.go
@@ -44,6 +44,8 @@ func GetRekorClient(rekorServerURL string, opts ...Option) (*client.Rekor, error
 	if o.InsecureTLS {
 		/* #nosec G402 */
 		defaultTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	} else if o.TLSConfig != nil {
+		defaultTransport.TLSClientConfig = o.TLSConfig
 	}
 	retryableClient.HTTPClient = &http.Client{
 		Transport: defaultTransport,


### PR DESCRIPTION
Add the ability to set a custom CA or insecure TLS connection in the clients to support connecting to log servers running at an HTTPS instance with a self-signed CA chain.

Relates to https://github.com/sigstore/rekor-monitor/issues/847

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
