### PR TITLE
Handle malformed COSE and DSSE entries

### DIFF
--- a/cmd/cleanup-index/main.go
+++ b/cmd/cleanup-index/main.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /*
-	cleanup-index checks what index entries are in the MySQL table and deletes those entries from the Redis databse.
+	cleanup-index checks what index entries are in the MySQL table and deletes those entries from the Redis database.
 	It does not go the other way
 
 	To run:

--- a/pkg/pki/minisign/minisign_test.go
+++ b/pkg/pki/minisign/minisign_test.go
@@ -391,7 +391,7 @@ func TestVerifySignature(t *testing.T) {
 		}
 
 		if err := s.Verify(dataFile, k); (err == nil) != tc.verified {
-			t.Errorf("%v: unexpected result in verifying sigature: %v", tc.caseDesc, err)
+			t.Errorf("%v: unexpected result in verifying signature: %v", tc.caseDesc, err)
 		}
 	}
 

--- a/pkg/pki/pgp/pgp_test.go
+++ b/pkg/pki/pgp/pgp_test.go
@@ -354,7 +354,7 @@ func TestEmailAddresses(t *testing.T) {
 
 	var k PublicKey
 	if len(k.Subjects()) != 0 {
-		t.Errorf("Subjects for unitialized key should give empty slice")
+		t.Errorf("Subjects for uninitialized key should give empty slice")
 	}
 	tests := []test{
 		{caseDesc: "Valid armored public key", inputFile: "testdata/valid_armored_public.pgp", subjects: []string{}, keys: 2},
@@ -447,7 +447,7 @@ func TestVerifySignature(t *testing.T) {
 		}
 
 		if err := s.Verify(dataFile, k); (err == nil) != tc.verified {
-			t.Errorf("%v: unexpected result in verifying sigature: %v", tc.caseDesc, err)
+			t.Errorf("%v: unexpected result in verifying signature: %v", tc.caseDesc, err)
 		}
 	}
 

--- a/pkg/pki/tuf/tuf_test.go
+++ b/pkg/pki/tuf/tuf_test.go
@@ -229,7 +229,7 @@ func TestVerifySignature(t *testing.T) {
 		}
 
 		if err := s.Verify(nil, k); (err == nil) != tc.verified {
-			t.Errorf("%v: unexpected result in verifying sigature: %v", tc.caseDesc, err)
+			t.Errorf("%v: unexpected result in verifying signature: %v", tc.caseDesc, err)
 		}
 	}
 

--- a/pkg/types/dsse/v0.0.1/entry.go
+++ b/pkg/types/dsse/v0.0.1/entry.go
@@ -292,6 +292,9 @@ func (v *V001Entry) Unmarshal(pe models.ProposedEntry) error {
 	}
 
 	env := &dsse.Envelope{}
+	if dsseObj.ProposedContent.Envelope == nil {
+		return errors.New("proposed content envelope is missing")
+	}
 	if err := json.Unmarshal([]byte(*dsseObj.ProposedContent.Envelope), env); err != nil {
 		return err
 	}
@@ -374,7 +377,7 @@ func (v *V001Entry) Canonicalize(_ context.Context) ([]byte, error) {
 	}
 
 	for _, s := range canonicalEntry.Signatures {
-		if s.Signature == nil {
+		if s == nil || s.Signature == nil {
 			return nil, errors.New("canonical entry missing required signature")
 		}
 	}

--- a/pkg/types/dsse/v0.0.1/entry_test.go
+++ b/pkg/types/dsse/v0.0.1/entry_test.go
@@ -253,6 +253,15 @@ func TestV001Entry_Unmarshal(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "missing envelope with verifiers",
+			it: &models.DSSEV001Schema{
+				ProposedContent: &models.DSSEV001SchemaProposedContent{
+					Verifiers: []strfmt.Base64{[]byte("verifier")},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			env:  envelope(t, key, []byte(validPayload)),
 			name: "valid",
 			it: &models.DSSEV001Schema{
@@ -623,5 +632,11 @@ func TestCanonicalizeHandlesInvalidInput(t *testing.T) {
 	_, err := v.Canonicalize(context.TODO())
 	if err == nil {
 		t.Fatalf("expected error canonicalizing invalid input")
+	}
+
+	v.DSSEObj.Signatures = []*models.DSSEV001SchemaSignaturesItems0{nil}
+	_, err = v.Canonicalize(context.TODO())
+	if err == nil {
+		t.Fatalf("expected error canonicalizing nil signature")
 	}
 }


### PR DESCRIPTION
This adds graceful handling of dereferencing a number of pointers where the content may be user-controlled.

Also took care of a few spelling errors too.

Fixes GHSA-273p-m2cw-6833

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
