### PR TITLE
return correct errors in rare failure situations

### DIFF
--- a/pkg/sharding/ranges.go
+++ b/pkg/sharding/ranges.go
@@ -110,7 +110,7 @@ func (l *LogRanges) CompleteInitialization(ctx context.Context, tcm *trilliancli
 		}
 		resp := logClient.GetLatest(ctx, 0)
 		if resp.Err != nil {
-			return nil, fmt.Errorf("getting signed log root for tree %d: %w", r.TreeID, err)
+			return nil, fmt.Errorf("getting signed log root for tree %d: %w", r.TreeID, resp.Err)
 		}
 		var root types.LogRootV1
 		if err := root.UnmarshalBinary(resp.GetLatestResult.SignedLogRoot.LogRoot); err != nil {

--- a/pkg/trillianclient/trillian_client.go
+++ b/pkg/trillianclient/trillian_client.go
@@ -231,8 +231,8 @@ func (t *TrillianClient) GetLeafAndProofByIndex(ctx context.Context, index int64
 	root, err := unmarshalLogRoot(rootResp.GetLatestResult.SignedLogRoot.LogRoot)
 	if err != nil {
 		return &Response{
-			Status: status.Code(rootResp.Err),
-			Err:    rootResp.Err,
+			Status: status.Code(err),
+			Err:    err,
 		}
 	}
 
@@ -307,8 +307,8 @@ func (t *TrillianClient) getProofByHash(ctx context.Context, hashValue []byte) *
 	root, err := unmarshalLogRoot(rootResp.GetLatestResult.SignedLogRoot.LogRoot)
 	if err != nil {
 		return &Response{
-			Status: status.Code(rootResp.Err),
-			Err:    rootResp.Err,
+			Status: status.Code(err),
+			Err:    err,
 		}
 	}
 


### PR DESCRIPTION
while analyzing the codebase, I noticed in three situations that we would return an incorrect err which would make debugging more challenging. this returns the correct err in each situation.