### PR TITLE
raise error if decoding hash fails during inclusion proof

### DIFF
--- a/pkg/verify/verify.go
+++ b/pkg/verify/verify.go
@@ -145,7 +145,10 @@ func VerifyInclusion(ctx context.Context, e *models.LogEntryAnon) error {
 
 	hashes := [][]byte{}
 	for _, h := range e.Verification.InclusionProof.Hashes {
-		hb, _ := hex.DecodeString(h)
+		hb, err := hex.DecodeString(h)
+		if err != nil {
+			return err
+		}
 		hashes = append(hashes, hb)
 	}
 


### PR DESCRIPTION
if the decoding of a hexadecimal string were to fail, we should raise the error instead of squelching it and returning a proof failure (since the underlying value would be `nil`).