### PR TITLE
feat: add checkpointing into the backfill so we can resume from the l…

### DIFF
--- a/tests/backfill-test.sh
+++ b/tests/backfill-test.sh
@@ -50,7 +50,18 @@ remove_keys() {
     set +e
 }
 
+clear_checkpoint() {
+    local checkpoint_key=${1:-default}
+    if [ "$INDEX_BACKEND" == "redis" ] ; then
+        redis_cli DEL "backfill/checkpoint/$checkpoint_key" 2>/dev/null || true
+    else
+        mysql_cli -e "DELETE FROM BackfillCheckpoint WHERE CheckpointKey='$checkpoint_key';" 2>/dev/null || true
+    fi
+}
+
 check_all_entries() {
+    local expected_redis=${1:-21}  # 20 index keys + 1 checkpoint key
+    local expected_mysql=${2:-26}
     set -e
     for artifact in "${!expected_artifacts[@]}" ; do
         local expected_uuids="${expected_artifacts[$artifact]}"
@@ -113,10 +124,10 @@ check_all_entries() {
     local expected_size
     local actual_size
     if [ "${INDEX_BACKEND}" == "redis" ] ; then
-        expected_size=20
+        expected_size=$expected_redis
         actual_size=$(redis_cli DBSIZE)
     else
-        expected_size=26
+        expected_size=$expected_mysql
         actual_size=$(mysql_cli -NB -e "SELECT COUNT(*) FROM EntryIndex;")
     fi
     if [ $expected_size -ne $actual_size ] ; then
@@ -174,6 +185,9 @@ echo
 echo "##### Scenario 2: backfill last half of entries #####"
 echo
 
+# Clear checkpoint since we're modifying the index
+clear_checkpoint
+
 remove_keys $(seq 6 12)
 
 # searching for artifact 0-5 should succeed, but searching for later artifacts should fail
@@ -189,6 +203,9 @@ echo "Scenario 2: SUCCESS"
 echo
 echo "##### Scenario 3: backfill sparse entries #####"
 echo
+
+# Clear checkpoint since we're modifying the index
+clear_checkpoint
 
 remove_keys $(seq 2 2 12)
 
@@ -212,3 +229,134 @@ run_backfill $end_index
 check_all_entries
 
 echo "Scenario 4: SUCCESS"
+
+echo
+echo "##### Scenario 5: checkpoint and resume #####"
+echo
+
+# Start fresh, make sure we have a clean index
+if [ "$INDEX_BACKEND" == "redis" ] ; then
+    redis_cli FLUSHALL
+else
+    mysql_cli -e "DELETE FROM EntryIndex; DELETE FROM BackfillCheckpoint;" 2>/dev/null || true
+fi
+
+echo "Initial backfill from 0 to $end_index with checkpointing"
+set -e
+if [ "$INDEX_BACKEND" == "redis" ] ; then
+    go run cmd/backfill-index/main.go --rekor-address $REKOR_ADDRESS \
+        --redis-hostname $REDIS_HOST --redis-port $REDIS_PORT --redis-password $REDIS_PASSWORD \
+        --concurrency 5 --start 0 --end $end_index \
+        --checkpoint-interval 2
+else
+    go run cmd/backfill-index/main.go --rekor-address $REKOR_ADDRESS \
+        --mysql-dsn "${MYSQL_USER}:${MYSQL_PASSWORD}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/${MYSQL_DB}" \
+        --concurrency 5 --start 0 --end $end_index \
+        --checkpoint-interval 2
+fi
+set +e
+
+# Capture initial checkpoint value for later
+initial_checkpoint=$end_index
+
+echo "Adding more entries to the log..."
+for i in $(seq 13 20) ; do
+    minisign -GW -p $testdir/mini${i}.pub -s $testdir/mini${i}.key
+    echo test${i} > $testdir/blob${i}
+    minisign -S -s $testdir/mini${i}.key -m $testdir/blob${i}
+    rekor_out=$(rekor-cli --rekor_server $REKOR_ADDRESS upload \
+        --artifact $testdir/blob${i} \
+        --pki-format=minisign \
+        --public-key $testdir/mini${i}.pub \
+        --signature $testdir/blob${i}.minisig \
+        --format json)
+    uuid=$(echo $rekor_out | jq -r .Location | cut -d '/' -f 6)
+    expected_keys["$testdir/mini${i}.pub"]=$uuid
+    expected_artifacts["$testdir/blob${i}"]=$uuid
+done
+
+set -e
+loginfo=$(rekor-cli --rekor_server $REKOR_ADDRESS loginfo --format=json)
+let new_end_index=$(echo $loginfo | jq .ActiveTreeSize)-1
+set +e
+
+echo "New entries added, log now has indices 0-$new_end_index"
+
+echo "Running backfill from 0 to $new_end_index (should resume from checkpoint)"
+if [ "$INDEX_BACKEND" == "redis" ] ; then
+    go run cmd/backfill-index/main.go --rekor-address $REKOR_ADDRESS \
+        --redis-hostname $REDIS_HOST --redis-port $REDIS_PORT --redis-password $REDIS_PASSWORD \
+        --concurrency 5 --start 0 --end $new_end_index \
+        --checkpoint-interval 2 2>&1 | tee /tmp/backfill-resume.log
+else
+    go run cmd/backfill-index/main.go --rekor-address $REKOR_ADDRESS \
+        --mysql-dsn "${MYSQL_USER}:${MYSQL_PASSWORD}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/${MYSQL_DB}" \
+        --concurrency 5 --start 0 --end $new_end_index \
+        --checkpoint-interval 2 2>&1 | tee /tmp/backfill-resume.log
+fi
+
+if ! grep -q "Resuming from checkpoint: last completed index $initial_checkpoint" /tmp/backfill-resume.log ; then
+    echo "Scenario 5: FAILED - Did not resume from checkpoint"
+    cat /tmp/backfill-resume.log
+    exit 1
+fi
+echo "Verified: Backfill resumed from checkpoint index $initial_checkpoint"
+
+# Verify all entries are indexed and checkpoint is at the end
+# After adding 8 new entries (13-20), total is 21 entries:
+#   Redis: 20 index + 16 new index + 1 checkpoint = 37 keys
+#   MySQL: 26 + (8 entries × 2 rows) = 42 rows
+check_all_entries 37 42
+
+if [ "$INDEX_BACKEND" == "redis" ] ; then
+    checkpoint_data=$(redis_cli GET "backfill/checkpoint/default")
+    final_checkpoint=$(echo $checkpoint_data | jq -r .last_completed_index)
+else
+    final_checkpoint=$(mysql_cli -NB -e "SELECT LastCompletedIndex FROM BackfillCheckpoint WHERE CheckpointKey='default'")
+fi
+
+if [ "$final_checkpoint" != "$new_end_index" ] ; then
+    echo "Scenario 5: FAILED - Checkpoint should be at end index $new_end_index, got $final_checkpoint"
+    exit 1
+fi
+echo "Checkpoint at index $final_checkpoint (end of log)"
+
+echo "Testing --reset-checkpoint flag"
+reset_end_index=5
+if [ "$INDEX_BACKEND" == "redis" ] ; then
+    go run cmd/backfill-index/main.go --rekor-address $REKOR_ADDRESS \
+        --redis-hostname $REDIS_HOST --redis-port $REDIS_PORT --redis-password $REDIS_PASSWORD \
+        --concurrency 5 --start 0 --end $reset_end_index \
+        --checkpoint-interval 2 --reset-checkpoint 2>&1 | tee /tmp/backfill-reset.log
+else
+    go run cmd/backfill-index/main.go --rekor-address $REKOR_ADDRESS \
+        --mysql-dsn "${MYSQL_USER}:${MYSQL_PASSWORD}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/${MYSQL_DB}" \
+        --concurrency 5 --start 0 --end $reset_end_index \
+        --checkpoint-interval 2 --reset-checkpoint 2>&1 | tee /tmp/backfill-reset.log
+fi
+
+if grep -q "Resuming from checkpoint" /tmp/backfill-reset.log ; then
+    echo "Scenario 5: FAILED - Reset flag did not clear checkpoint"
+    exit 1
+fi
+if ! grep -q "Checkpoint reset - starting fresh" /tmp/backfill-reset.log ; then
+    echo "Scenario 5: FAILED - Did not see checkpoint reset message"
+    exit 1
+fi
+
+if [ "$INDEX_BACKEND" == "redis" ] ; then
+    checkpoint_data=$(redis_cli GET "backfill/checkpoint/default")
+    reset_checkpoint=$(echo $checkpoint_data | jq -r .last_completed_index)
+else
+    reset_checkpoint=$(mysql_cli -NB -e "SELECT LastCompletedIndex FROM BackfillCheckpoint WHERE CheckpointKey='default'")
+fi
+
+if [ "$reset_checkpoint" != "$reset_end_index" ] ; then
+    echo "Scenario 5: FAILED - Checkpoint should be at end index $reset_end_index, got $reset_checkpoint"
+    exit 1
+fi
+echo "Checkpoint reset and at index $reset_checkpoint (end of range)"
+
+check_all_entries 37 42
+
+echo "Scenario 5: SUCCESS"


### PR DESCRIPTION
…ast completed, contiguous index

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

Closes #2279 

#### Summary

This pull request adds support for checkpointing the progress of the backfill process, allowing the process to resume from the last known, contiguous index.  This addresses the issue of the backfill reprocessing information from the beginning each time it runs.

#### Release Note

Added support for checkpointing progress during the backfill operation, rerunning the backfill will resume from the last known, contiguous index instead of starting at the beginning.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
