### PR TITLE
Run liveness checks on uncrowded 2112 port

### DIFF
--- a/cmd/rekor-server/app/serve.go
+++ b/cmd/rekor-server/app/serve.go
@@ -131,10 +131,13 @@ var serveCmd = &cobra.Command{
 		api.ConfigureAPI(treeID)
 		server.ConfigureAPI()
 
-		http.Handle("/metrics", promhttp.Handler())
+		utilMux := http.NewServeMux()
+		utilMux.Handle("/metrics", promhttp.Handler())
+		utilHandler := middleware.Heartbeat("/ping")(utilMux)
 		go func() {
 			srv := &http.Server{
 				Addr:         ":2112",
+				Handler:      utilHandler,
 				ReadTimeout:  10 * time.Second,
 				WriteTimeout: 10 * time.Second,
 			}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,8 @@ services:
       trillian-log-server:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/ping"]
+      # health check is on the util port
+      test: ["CMD", "curl", "-f", "http://localhost:2112/ping"]
       interval: 10s
       timeout: 3s
       retries: 15


### PR DESCRIPTION
- Readiness should still run on 3000

#### Summary
This might help with liveness checks that are being blocked by an overloaded port 3000 if we end up with a high volume of regular requests and the pod because starved.

Also move off the default global servermux and use an explicit one for utils (metrics, ping)

Readiness and Liveness still both hit `ping` just on different ports. It's possible they should have different names to prevent confusion.

Locally testing this, there are no (but practically probably just fewer) healthz related resets compared to running on 3000, when overloading the local instance running with docker compose.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
