### PR TITLE
add defensive check to ensure tid is in config ahead of getting client

### DIFF
--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -747,6 +747,12 @@ func retrieveLogEntry(ctx context.Context, entryUUID string) (models.LogEntry, e
 func retrieveUUIDFromTree(ctx context.Context, uuid string, tid int64) (models.LogEntry, error) {
 	log.ContextLogger(ctx).Debugf("Retrieving log entry %v from tree %d", uuid, tid)
 
+	// Reject tree IDs not in the configured shard set before they reach the
+	// Trillian client cache or backend.
+	if _, err := api.logRanges.GetLogRangeByTreeID(tid); err != nil {
+		return models.LogEntry{}, ErrNotFound
+	}
+
 	hashValue, err := hex.DecodeString(uuid)
 	if err != nil {
 		return models.LogEntry{}, &types.InputValidationError{Err: fmt.Errorf("parsing UUID: %w", err)}
@@ -754,7 +760,7 @@ func retrieveUUIDFromTree(ctx context.Context, uuid string, tid int64) (models.L
 
 	tc, err := api.trillianClientManager.GetTrillianClient(tid)
 	if err != nil {
-		return nil, fmt.Errorf("getting log client for tree %d: %w", tid, err)
+		return models.LogEntry{}, fmt.Errorf("getting log client for tree %d: %w", tid, err)
 	}
 	log.ContextLogger(ctx).Debugf("Attempting to retrieve UUID %v from TreeID %v", uuid, tid)
 

--- a/pkg/api/entries_test.go
+++ b/pkg/api/entries_test.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sigstore/rekor/pkg/sharding"
+	"github.com/sigstore/rekor/pkg/signer"
+)
+
+// TestRetrieveUUIDFromTree_UnconfiguredTreeID tests that retrieveUUIDFromTree returns ErrNotFound when the tree ID is not in the configured shard set.
+// This ensures that the API correctly rejects requests for tree IDs that are not configured, preventing unnecessary calls to the Trillian client manager and backend.
+func TestRetrieveUUIDFromTree_UnconfiguredTreeID(t *testing.T) {
+	ranges, err := sharding.NewLogRanges(context.Background(), "", 1, signer.SigningConfig{SigningSchemeOrKeyPath: "memory"})
+	if err != nil {
+		t.Fatalf("Failed to create LogRanges: %v", err)
+	}
+
+	api = &API{
+		logRanges: ranges,
+		// explicitly nil. if validation fails, using this manager will panic.
+		trillianClientManager: nil,
+	}
+
+	validUUID := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+	_, err = retrieveUUIDFromTree(context.Background(), validUUID, 999)
+
+	if err != ErrNotFound {
+		t.Errorf("Expected ErrNotFound, got: %v", err)
+	}
+}

--- a/pkg/api/entries_test.go
+++ b/pkg/api/entries_test.go
@@ -1,3 +1,18 @@
+//
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package api
 
 import (


### PR DESCRIPTION
we know in the configuration which tree IDs are expected to be in trillian so there's no reason to establish a client when we can check locally