### PR TITLE
restapi: include inactiveShards in the homepage total count

### DIFF
--- a/pkg/generated/restapi/rekorHomePage.html
+++ b/pkg/generated/restapi/rekorHomePage.html
@@ -34,7 +34,14 @@ const url = '/api/v1/log/';
 function update() {
   fetch(url, {headers: {'Accept': 'application/json'}}).then((resp) => {
     resp.json().then((j) => {
-      let count = j.treeSize;
+      // Total across the active shard plus any inactive shards; otherwise
+      // the page under-reports after a shard rotation.
+      let count = Number(j.treeSize) || 0;
+      if (Array.isArray(j.inactiveShards)) {
+        for (const shard of j.inactiveShards) {
+          count += Number(shard.treeSize) || 0;
+        }
+      }
       document.getElementById('count').innerText = count;
     }).catch(console.error);
   }).catch(console.error);


### PR DESCRIPTION
## Summary

The HTML homepage at `/` reads `j.treeSize` from `/api/v1/log/` to display "Currently storing N items" but ignores `j.inactiveShards`. After a shard rotation the total count is the sum of the active tree plus every inactive shard, so the page under-reports by the size of all previous shards.

Sum the inactive shards' `treeSize` values into the displayed count, defensively guarding against a missing or non-array `inactiveShards` field.

Fixes #2281

Signed-off-by: Ali <alliasgher123@gmail.com>