### PR TITLE
Validate tree ID against configured shards in retrieveUUIDFromTree

### DIFF
--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -747,6 +747,11 @@ func retrieveLogEntry(ctx context.Context, entryUUID string) (models.LogEntry, e
 func retrieveUUIDFromTree(ctx context.Context, uuid string, tid int64) (models.LogEntry, error) {
 	log.ContextLogger(ctx).Debugf("Retrieving log entry %v from tree %d", uuid, tid)
 
+	// Validate that the tree ID is one of our configured shards; no need to proceed otherwise
+	if _, err := api.logRanges.GetLogRangeByTreeID(tid); err != nil {
+		return nil, ErrNotFound
+	}
+
 	hashValue, err := hex.DecodeString(uuid)
 	if err != nil {
 		return models.LogEntry{}, &types.InputValidationError{Err: fmt.Errorf("parsing UUID: %w", err)}

--- a/pkg/api/entries_test.go
+++ b/pkg/api/entries_test.go
@@ -1,0 +1,42 @@
+//
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sigstore/rekor/pkg/sharding"
+)
+
+func TestRetrieveUUIDFromTree_RejectsUnconfiguredTreeID(t *testing.T) {
+	// Set up a minimal API with a single configured shard (tree ID 100).
+	api = &API{
+		logRanges: sharding.NewLogRangesForTesting(100),
+	}
+
+	// Use an unconfigured tree ID (999). The UUID content doesn't matter
+	// because the tree ID check should reject the request before any
+	// Trillian call is made.
+	_, err := retrieveUUIDFromTree(context.Background(), "abcd1234", 999)
+	if err == nil {
+		t.Fatal("expected error for unconfigured tree ID, got nil")
+	}
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got: %v", err)
+	}
+}

--- a/pkg/sharding/ranges.go
+++ b/pkg/sharding/ranges.go
@@ -271,3 +271,9 @@ func (l *LogRanges) PublicKey(treeID string) (string, error) {
 	}
 	return "", fmt.Errorf("%d is not a valid tree ID and doesn't have an associated public key", tid)
 }
+
+// NewLogRangesForTesting creates a LogRanges with the given active tree ID
+// and no inactive shards, without initializing signers. For use in tests only.
+func NewLogRangesForTesting(activeTreeID int64) *LogRanges {
+	return &LogRanges{active: LogRange{TreeID: activeTreeID}}
+}


### PR DESCRIPTION
`retrieveUUIDFromTree` accepted any tree ID extracted from a client-supplied entryUUID and forwarded it directly to Trillian without checking that it belonged to a configured Rekor shard. If this was used on a shared Trillian backend, this allowed callers to probe leaf hash existence in co-tenant trees (distinguishable via 404 vs 500 responses) and caused unbounded growth of the Trillian client cache from attacker-chosen tree IDs.

Add a `GetLogRangeByTreeID` check at the top of `retrieveUUIDFromTree`, mirroring the existing validation in `GetConsistencyProof` (tlog.go:106-108). Requests referencing unknown tree IDs now return `ErrNotFound` before any Trillian RPC is issued.