### PR TITLE
Fix internal error detail leakage in 500 responses

### DIFF
--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -195,7 +195,7 @@ func GetLogEntryByIndexHandler(params entries.GetLogEntryByIndexParams) middlewa
 		if errors.Is(err, ErrNotFound) {
 			return handleRekorAPIError(params, http.StatusNotFound, fmt.Errorf("grpc error: %w", err), "")
 		}
-		return handleRekorAPIError(params, http.StatusInternalServerError, err, err.Error())
+		return handleRekorAPIError(params, http.StatusInternalServerError, err, trillianCommunicationError)
 	}
 	return entries.NewGetLogEntryByIndexOK().WithPayload(logEntry)
 }
@@ -655,7 +655,7 @@ func SearchLogQueryHandler(params entries.SearchLogQueryParams) middleware.Respo
 				}
 				logEntry, err := logEntryFromLeaf(httpReqCtx, leafResp.Leaf, leafResp.SignedLogRoot, leafResp.Proof, shard, api.logRanges, api.cachedCheckpoints)
 				if err != nil {
-					return handleRekorAPIError(params, http.StatusInternalServerError, err, err.Error())
+					return handleRekorAPIError(params, http.StatusInternalServerError, err, trillianUnexpectedResult)
 				}
 				resultPayload = append(resultPayload, logEntry)
 			}
@@ -666,7 +666,7 @@ func SearchLogQueryHandler(params entries.SearchLogQueryParams) middleware.Respo
 		for _, logIndex := range params.Entry.LogIndexes {
 			logEntry, err := retrieveLogEntryByIndex(httpReqCtx, int(conv.Value(logIndex)))
 			if err != nil && !errors.Is(err, ErrNotFound) {
-				return handleRekorAPIError(params, http.StatusInternalServerError, err, err.Error())
+				return handleRekorAPIError(params, http.StatusInternalServerError, err, trillianCommunicationError)
 			} else if err == nil {
 				resultPayload = append(resultPayload, logEntry)
 			}


### PR DESCRIPTION
Replace `err.Error()` with generic constants in three `handleRekorAPIError` calls in `entries.go` that were exposing internal error details (gRPC status text, hostnames, file paths) to unauthenticated callers via 500 response bodies

Detailed errors are still logged server-side; only the user-facing message changes