### PR TITLE
add nil pointer check to resolve fuzzing crash

### DIFF
--- a/pkg/types/alpine/alpine.go
+++ b/pkg/types/alpine/alpine.go
@@ -55,6 +55,10 @@ func (bat *BaseAlpineType) UnmarshalEntry(pe models.ProposedEntry) (types.EntryI
 		return nil, errors.New("cannot unmarshal non-Alpine types")
 	}
 
+	if apk.APIVersion == nil {
+		return nil, errors.New("api version cannot be nil")
+	}
+
 	return bat.VersionedUnmarshal(apk, *apk.APIVersion)
 }
 

--- a/pkg/types/alpine/alpine_test.go
+++ b/pkg/types/alpine/alpine_test.go
@@ -71,8 +71,15 @@ func TestAlpineType(t *testing.T) {
 		t.Error("valid semver range was not added to SemVerToFacFnMap")
 	}
 
-	u.Alpine.APIVersion = conv.Pointer("2.0.1")
+	u.Alpine.APIVersion = nil
 	brt := New()
+
+	// nil api version should return error, not panic
+	if _, err := brt.UnmarshalEntry(&u.Alpine); err == nil {
+		t.Error("unexpected success in Unmarshal for nil api version")
+	}
+
+	u.Alpine.APIVersion = conv.Pointer("2.0.1")
 
 	// version requested matches implementation in map
 	if _, err := brt.UnmarshalEntry(&u.Alpine); err != nil {

--- a/pkg/types/cose/cose.go
+++ b/pkg/types/cose/cose.go
@@ -55,6 +55,10 @@ func (it BaseCOSEType) UnmarshalEntry(pe models.ProposedEntry) (types.EntryImpl,
 		return nil, errors.New("cannot unmarshal non-COSE types")
 	}
 
+	if in.APIVersion == nil {
+		return nil, errors.New("api version cannot be nil")
+	}
+
 	return it.VersionedUnmarshal(in, *in.APIVersion)
 }
 

--- a/pkg/types/cose/cose_test.go
+++ b/pkg/types/cose/cose_test.go
@@ -72,8 +72,15 @@ func TestCOSEType(t *testing.T) {
 		t.Error("valid semver range was not added to SemVerToFacFnMap")
 	}
 
-	u.Cose.APIVersion = conv.Pointer("2.0.1")
+	u.Cose.APIVersion = nil
 	brt := New()
+
+	// nil api version should return error, not panic
+	if _, err := brt.UnmarshalEntry(&u.Cose); err == nil {
+		t.Error("unexpected success in Unmarshal for nil api version")
+	}
+
+	u.Cose.APIVersion = conv.Pointer("2.0.1")
 
 	// version requested matches implementation in map
 	if _, err := brt.UnmarshalEntry(&u.Cose); err != nil {

--- a/pkg/types/dsse/dsse.go
+++ b/pkg/types/dsse/dsse.go
@@ -55,6 +55,10 @@ func (it BaseDSSEType) UnmarshalEntry(pe models.ProposedEntry) (types.EntryImpl,
 		return nil, errors.New("cannot unmarshal non-DSSE types")
 	}
 
+	if in.APIVersion == nil {
+		return nil, errors.New("api version cannot be nil")
+	}
+
 	return it.VersionedUnmarshal(in, *in.APIVersion)
 }
 

--- a/pkg/types/dsse/dsse_test.go
+++ b/pkg/types/dsse/dsse_test.go
@@ -68,8 +68,15 @@ func TestDSSEType(t *testing.T) {
 		t.Error("valid semver range was not added to SemVerToFacFnMap")
 	}
 
-	u.DSSE.APIVersion = conv.Pointer("2.0.1")
+	u.DSSE.APIVersion = nil
 	brt := New()
+
+	// nil api version should return error, not panic
+	if _, err := brt.UnmarshalEntry(&u.DSSE); err == nil {
+		t.Error("unexpected success in Unmarshal for nil api version")
+	}
+
+	u.DSSE.APIVersion = conv.Pointer("2.0.1")
 
 	// version requested matches implementation in map
 	if _, err := brt.UnmarshalEntry(&u.DSSE); err != nil {

--- a/pkg/types/hashedrekord/hashedrekord.go
+++ b/pkg/types/hashedrekord/hashedrekord.go
@@ -55,6 +55,10 @@ func (rt BaseRekordType) UnmarshalEntry(pe models.ProposedEntry) (types.EntryImp
 		return nil, fmt.Errorf("cannot unmarshal non-hashed Rekord types: %s", pe.Kind())
 	}
 
+	if rekord.APIVersion == nil {
+		return nil, errors.New("api version cannot be nil")
+	}
+
 	return rt.VersionedUnmarshal(rekord, *rekord.APIVersion)
 }
 

--- a/pkg/types/hashedrekord/hashedrekord_test.go
+++ b/pkg/types/hashedrekord/hashedrekord_test.go
@@ -71,8 +71,15 @@ func TestRekordType(t *testing.T) {
 		t.Error("valid semver range was not added to SemVerToFacFnMap")
 	}
 
-	u.Hashedrekord.APIVersion = conv.Pointer("2.0.1")
+	u.Hashedrekord.APIVersion = nil
 	brt := New()
+
+	// nil api version should return error, not panic
+	if _, err := brt.UnmarshalEntry(&u.Hashedrekord); err == nil {
+		t.Error("unexpected success in Unmarshal for nil api version")
+	}
+
+	u.Hashedrekord.APIVersion = conv.Pointer("2.0.1")
 
 	// version requested matches implementation in map
 	if _, err := brt.UnmarshalEntry(&u.Hashedrekord); err != nil {

--- a/pkg/types/helm/helm.go
+++ b/pkg/types/helm/helm.go
@@ -55,6 +55,10 @@ func (it BaseHelmType) UnmarshalEntry(pe models.ProposedEntry) (types.EntryImpl,
 		return nil, errors.New("cannot unmarshal non-Rekord types")
 	}
 
+	if in.APIVersion == nil {
+		return nil, errors.New("api version cannot be nil")
+	}
+
 	return it.VersionedUnmarshal(in, *in.APIVersion)
 }
 

--- a/pkg/types/helm/helm_test.go
+++ b/pkg/types/helm/helm_test.go
@@ -67,8 +67,15 @@ func TestHelmType(t *testing.T) {
 		t.Error("valid semver range was not added to SemVerToFacFnMap")
 	}
 
-	u.Helm.APIVersion = conv.Pointer("2.0.1")
+	u.Helm.APIVersion = nil
 	brt := New()
+
+	// nil api version should return error, not panic
+	if _, err := brt.UnmarshalEntry(&u.Helm); err == nil {
+		t.Error("unexpected success in Unmarshal for nil api version")
+	}
+
+	u.Helm.APIVersion = conv.Pointer("2.0.1")
 
 	// version requested matches implementation in map
 	if _, err := brt.UnmarshalEntry(&u.Helm); err != nil {

--- a/pkg/types/intoto/intoto.go
+++ b/pkg/types/intoto/intoto.go
@@ -57,6 +57,10 @@ func (it BaseIntotoType) UnmarshalEntry(pe models.ProposedEntry) (types.EntryImp
 		return nil, errors.New("cannot unmarshal non-Rekord types")
 	}
 
+	if in.APIVersion == nil {
+		return nil, errors.New("api version cannot be nil")
+	}
+
 	return it.VersionedUnmarshal(in, *in.APIVersion)
 }
 

--- a/pkg/types/intoto/intoto_test.go
+++ b/pkg/types/intoto/intoto_test.go
@@ -67,8 +67,15 @@ func TestIntotoType(t *testing.T) {
 		t.Error("valid semver range was not added to SemVerToFacFnMap")
 	}
 
-	u.Intoto.APIVersion = conv.Pointer("2.0.1")
+	u.Intoto.APIVersion = nil
 	brt := New()
+
+	// nil api version should return error, not panic
+	if _, err := brt.UnmarshalEntry(&u.Intoto); err == nil {
+		t.Error("unexpected success in Unmarshal for nil api version")
+	}
+
+	u.Intoto.APIVersion = conv.Pointer("2.0.1")
 
 	// version requested matches implementation in map
 	if _, err := brt.UnmarshalEntry(&u.Intoto); err != nil {

--- a/pkg/types/jar/jar.go
+++ b/pkg/types/jar/jar.go
@@ -55,6 +55,10 @@ func (bjt *BaseJARType) UnmarshalEntry(pe models.ProposedEntry) (types.EntryImpl
 		return nil, errors.New("cannot unmarshal non-JAR types")
 	}
 
+	if jar.APIVersion == nil {
+		return nil, errors.New("api version cannot be nil")
+	}
+
 	return bjt.VersionedUnmarshal(jar, *jar.APIVersion)
 }
 

--- a/pkg/types/jar/jar_test.go
+++ b/pkg/types/jar/jar_test.go
@@ -66,8 +66,15 @@ func TestJARType(t *testing.T) {
 		t.Error("valid semver range was not added to SemVerToFacFnMap")
 	}
 
-	u.Jar.APIVersion = conv.Pointer("2.0.1")
+	u.Jar.APIVersion = nil
 	brt := New()
+
+	// nil api version should return error, not panic
+	if _, err := brt.UnmarshalEntry(&u.Jar); err == nil {
+		t.Error("unexpected success in Unmarshal for nil api version")
+	}
+
+	u.Jar.APIVersion = conv.Pointer("2.0.1")
 
 	// version requested matches implementation in map
 	if _, err := brt.UnmarshalEntry(&u.Jar); err != nil {

--- a/pkg/types/rekord/rekord.go
+++ b/pkg/types/rekord/rekord.go
@@ -55,6 +55,10 @@ func (rt BaseRekordType) UnmarshalEntry(pe models.ProposedEntry) (types.EntryImp
 		return nil, errors.New("cannot unmarshal non-Rekord types")
 	}
 
+	if rekord.APIVersion == nil {
+		return nil, errors.New("api version cannot be nil")
+	}
+
 	return rt.VersionedUnmarshal(rekord, *rekord.APIVersion)
 }
 

--- a/pkg/types/rekord/rekord_test.go
+++ b/pkg/types/rekord/rekord_test.go
@@ -67,8 +67,15 @@ func TestRekordType(t *testing.T) {
 		t.Error("valid semver range was not added to SemVerToFacFnMap")
 	}
 
-	u.Rekord.APIVersion = conv.Pointer("2.0.1")
+	u.Rekord.APIVersion = nil
 	brt := New()
+
+	// nil api version should return error, not panic
+	if _, err := brt.UnmarshalEntry(&u.Rekord); err == nil {
+		t.Error("unexpected success in Unmarshal for nil api version")
+	}
+
+	u.Rekord.APIVersion = conv.Pointer("2.0.1")
 
 	// version requested matches implementation in map
 	if _, err := brt.UnmarshalEntry(&u.Rekord); err != nil {

--- a/pkg/types/rfc3161/rfc3161.go
+++ b/pkg/types/rfc3161/rfc3161.go
@@ -55,6 +55,10 @@ func (btt BaseTimestampType) UnmarshalEntry(pe models.ProposedEntry) (types.Entr
 		return nil, errors.New("cannot unmarshal non-Timestamp types")
 	}
 
+	if rfc3161.APIVersion == nil {
+		return nil, errors.New("api version cannot be nil")
+	}
+
 	return btt.VersionedUnmarshal(rfc3161, *rfc3161.APIVersion)
 }
 

--- a/pkg/types/rfc3161/rfc3161_test.go
+++ b/pkg/types/rfc3161/rfc3161_test.go
@@ -67,8 +67,15 @@ func TestRfc3161Type(t *testing.T) {
 		t.Error("valid semver range was not added to SemVerToFacFnMap")
 	}
 
-	u.Rfc3161.APIVersion = conv.Pointer("2.0.1")
+	u.Rfc3161.APIVersion = nil
 	brt := New()
+
+	// nil api version should return error, not panic
+	if _, err := brt.UnmarshalEntry(&u.Rfc3161); err == nil {
+		t.Error("unexpected success in Unmarshal for nil api version")
+	}
+
+	u.Rfc3161.APIVersion = conv.Pointer("2.0.1")
 
 	// version requested matches implementation in map
 	if _, err := brt.UnmarshalEntry(&u.Rfc3161); err != nil {

--- a/pkg/types/rpm/rpm.go
+++ b/pkg/types/rpm/rpm.go
@@ -55,6 +55,10 @@ func (brt *BaseRPMType) UnmarshalEntry(pe models.ProposedEntry) (types.EntryImpl
 		return nil, errors.New("cannot unmarshal non-RPM types")
 	}
 
+	if rpm.APIVersion == nil {
+		return nil, errors.New("api version cannot be nil")
+	}
+
 	return brt.VersionedUnmarshal(rpm, *rpm.APIVersion)
 }
 

--- a/pkg/types/rpm/rpm_test.go
+++ b/pkg/types/rpm/rpm_test.go
@@ -67,8 +67,15 @@ func TestRPMType(t *testing.T) {
 		t.Error("valid semver range was not added to SemVerToFacFnMap")
 	}
 
-	u.Rpm.APIVersion = conv.Pointer("2.0.1")
+	u.Rpm.APIVersion = nil
 	brt := New()
+
+	// nil api version should return error, not panic
+	if _, err := brt.UnmarshalEntry(&u.Rpm); err == nil {
+		t.Error("unexpected success in Unmarshal for nil api version")
+	}
+
+	u.Rpm.APIVersion = conv.Pointer("2.0.1")
 
 	// version requested matches implementation in map
 	if _, err := brt.UnmarshalEntry(&u.Rpm); err != nil {

--- a/pkg/types/tuf/tuf.go
+++ b/pkg/types/tuf/tuf.go
@@ -56,6 +56,10 @@ func (btt BaseTufType) UnmarshalEntry(pe models.ProposedEntry) (types.EntryImpl,
 		return nil, fmt.Errorf("cannot unmarshal non-tuf types %+v", pe)
 	}
 
+	if tuf.APIVersion == nil {
+		return nil, errors.New("api version cannot be nil")
+	}
+
 	return btt.VersionedUnmarshal(tuf, *tuf.APIVersion)
 }
 

--- a/pkg/types/tuf/tuf_test.go
+++ b/pkg/types/tuf/tuf_test.go
@@ -67,8 +67,15 @@ func TestTufType(t *testing.T) {
 		t.Error("valid semver range was not added to SemVerToFacFnMap")
 	}
 
-	u.TUF.APIVersion = conv.Pointer("2.0.1")
+	u.TUF.APIVersion = nil
 	brt := New()
+
+	// nil api version should return error, not panic
+	if _, err := brt.UnmarshalEntry(&u.TUF); err == nil {
+		t.Error("unexpected success in Unmarshal for nil api version")
+	}
+
+	u.TUF.APIVersion = conv.Pointer("2.0.1")
 
 	// version requested matches implementation in map
 	if _, err := brt.UnmarshalEntry(&u.TUF); err != nil {


### PR DESCRIPTION
this is not exploitable through the REST endpoints b/c we validate input, but it's possible for someone calling the API directly to cause an nil pointer dereference.