### PR TITLE
fix(trillianclient): strip dns:/// scheme from TLS ServerName in gRPC dial

### DIFF
--- a/pkg/trillianclient/manager.go
+++ b/pkg/trillianclient/manager.go
@@ -158,14 +158,19 @@ func CreateAndInitTree(ctx context.Context, config GRPCConfig) (*trillian.Tree, 
 	return t, nil
 }
 
+// cleanDialHostname strips gRPC resolver scheme prefixes (e.g. "dns:///")
+// from a hostname, returning the bare hostname suitable for TLS SNI and
+// certificate verification. The original address with its scheme must be
+// preserved for the grpc.NewClient target so the chosen resolver stays active.
+func cleanDialHostname(hostname string) string {
+	return strings.TrimPrefix(hostname, "dns:///")
+}
+
 func dial(hostname string, port uint16, tlsCACertFile string, useSystemTrustStore bool, serviceConfig string) (*grpc.ClientConn, error) {
-	// tlsServerName is the bare hostname used for TLS SNI and certificate
-	// verification. When hostname carries a gRPC resolver scheme (e.g.
-	// "dns:///host.svc"), the scheme must be stripped before it reaches the
-	// TLS stack — otherwise gRPC-go sets the x509 ServerName to the scheme
-	// string ("dns"), causing certificate verification to fail with
-	// `x509: certificate is valid for <SANs>, not dns`.
-	cleanHostname := strings.TrimPrefix(hostname, "dns:///")
+	// Strip gRPC resolver scheme before TLS: if hostname is e.g.
+	// "dns:///host.svc", passing it raw into tls.Config.ServerName causes
+	// x509 verification to fail with `certificate valid for host.svc, not dns`.
+	cleanHostname := cleanDialHostname(hostname)
 
 	var creds credentials.TransportCredentials
 	switch {

--- a/pkg/trillianclient/manager.go
+++ b/pkg/trillianclient/manager.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -158,12 +159,19 @@ func CreateAndInitTree(ctx context.Context, config GRPCConfig) (*trillian.Tree, 
 }
 
 func dial(hostname string, port uint16, tlsCACertFile string, useSystemTrustStore bool, serviceConfig string) (*grpc.ClientConn, error) {
-	// Set up and test connection to rpc server
+	// tlsServerName is the bare hostname used for TLS SNI and certificate
+	// verification. When hostname carries a gRPC resolver scheme (e.g.
+	// "dns:///host.svc"), the scheme must be stripped before it reaches the
+	// TLS stack — otherwise gRPC-go sets the x509 ServerName to the scheme
+	// string ("dns"), causing certificate verification to fail with
+	// `x509: certificate is valid for <SANs>, not dns`.
+	cleanHostname := strings.TrimPrefix(hostname, "dns:///")
+
 	var creds credentials.TransportCredentials
 	switch {
 	case useSystemTrustStore:
 		creds = credentials.NewTLS(&tls.Config{
-			ServerName: hostname,
+			ServerName: cleanHostname,
 			MinVersion: tls.VersionTLS12,
 		})
 	case tlsCACertFile != "":
@@ -176,7 +184,7 @@ func dial(hostname string, port uint16, tlsCACertFile string, useSystemTrustStor
 			return nil, fmt.Errorf("failed to append CA certificate to pool")
 		}
 		creds = credentials.NewTLS(&tls.Config{
-			ServerName: hostname,
+			ServerName: cleanHostname,
 			RootCAs:    certPool,
 			MinVersion: tls.VersionTLS12,
 		})
@@ -184,10 +192,17 @@ func dial(hostname string, port uint16, tlsCACertFile string, useSystemTrustStor
 		creds = insecure.NewCredentials()
 	}
 
-	opts := []grpc.DialOption{grpc.WithTransportCredentials(creds)}
+	opts := []grpc.DialOption{
+		grpc.WithTransportCredentials(creds),
+		grpc.WithAuthority(cleanHostname),
+	}
+
 	if serviceConfig != "" {
 		opts = append(opts, grpc.WithDefaultServiceConfig(serviceConfig))
 	}
+	// hostname (not cleanHostname) is intentional: the dns:/// scheme must
+	// reach grpc.NewClient so gRPC uses the DNS resolver for client-side
+	// load balancing. TLS and authority are handled separately above.
 	conn, err := grpc.NewClient(fmt.Sprintf("%s:%d", hostname, port), opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to RPC server: %w", err)

--- a/pkg/trillianclient/manager_test.go
+++ b/pkg/trillianclient/manager_test.go
@@ -1,0 +1,58 @@
+//
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trillianclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCleanDialHostname(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "dns:/// scheme is stripped",
+			input: "dns:///trillian-logserver.ns.svc",
+			want:  "trillian-logserver.ns.svc",
+		},
+		{
+			name:  "plain hostname is unchanged",
+			input: "trillian-logserver.ns.svc",
+			want:  "trillian-logserver.ns.svc",
+		},
+		{
+			name:  "localhost is unchanged",
+			input: "localhost",
+			want:  "localhost",
+		},
+		{
+			name:  "dns:/// with port is stripped correctly",
+			input: "dns:///trillian-logserver.ns.svc:8091",
+			want:  "trillian-logserver.ns.svc:8091",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cleanDialHostname(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -368,27 +368,38 @@ func TestDialE2E(t *testing.T) {
 
 	tests := []struct {
 		name          string
+		hostname      string
 		tlsCACert     string
 		useSystemTLS  bool
 		expectedError bool
 	}{
 		{
 			name:          "Connection with custom CA cert",
+			hostname:      "localhost",
 			tlsCACert:     serverCertPath,
 			useSystemTLS:  false,
 			expectedError: false,
 		},
 		{
 			name:          "Connection with system TLS",
+			hostname:      "localhost",
 			tlsCACert:     "",
 			useSystemTLS:  true,
 			expectedError: true,
 		},
 		{
 			name:          "Insecure connection attempt",
+			hostname:      "localhost",
 			tlsCACert:     "",
 			useSystemTLS:  false,
 			expectedError: true,
+		},
+		{
+			name:          "Connection with dns:/// scheme and custom CA cert",
+			hostname:      "dns:///localhost",
+			tlsCACert:     serverCertPath,
+			useSystemTLS:  false,
+			expectedError: false,
 		},
 	}
 
@@ -398,7 +409,7 @@ func TestDialE2E(t *testing.T) {
 			viper.Set("trillian_log_server.tls_ca_cert", tt.tlsCACert)
 			viper.Set("trillian_log_server.tls", tt.useSystemTLS)
 
-			conn, _ := trillianclient.TestDial("localhost", uint16(listener.Addr().(*net.TCPAddr).Port), tt.tlsCACert, tt.useSystemTLS)
+			conn, _ := trillianclient.TestDial(tt.hostname, uint16(listener.Addr().(*net.TCPAddr).Port), tt.tlsCACert, tt.useSystemTLS)
 			require.NotNil(t, conn)
 
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

When the Trillian gRPC address includes a `dns:///` resolver scheme (used to enable client-side `round_robin` load balancing with headless Kubernetes Services), the `dial()` function passes the raw address, scheme included, into `tls.Config.ServerName` and the gRPC channel authority

This breaks TLS: the x509 certificate verification matches SANs against `"dns"` (the URI scheme) instead of the actual hostname, failing with:

```
x509: certificate is valid for trillian-logserver.ns.svc, not dns
```

The fix strips the `dns:///` prefix into a `cleanHostname` for TLS `ServerName` and `grpc.WithAuthority()`, while preserving the full scheme in the `grpc.NewClient` target so the DNS resolver stays active

`strings.TrimPrefix` is a no-op when the prefix is absent, so callers passing plain hostnames are unaffected

Tested on an OpenShift cluster with internal TLS:
- before: every Trillian gRPC call fails with the x509 error above
- after: TLS handshake succeeds and round-robin load balancing works across all trillian-logserver pod IPs

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Fixed a bug where using the `dns:///` gRPC resolver scheme in the Trillian server address caused TLS certificate verification to fail. The URI scheme was incorrectly used as the TLS ServerName instead of the actual hostname. This affected deployments using client-side gRPC load balancing (`round_robin`) with TLS enabled.


#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->