### PR TITLE
Support restricting kinds on insertion

### DIFF
--- a/cmd/rekor-server/app/root.go
+++ b/cmd/rekor-server/app/root.go
@@ -27,6 +27,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/sigstore/rekor/pkg/api"
 	"github.com/sigstore/rekor/pkg/log"
+	"github.com/sigstore/rekor/pkg/types"
 	cose "github.com/sigstore/rekor/pkg/types/cose/v0.0.1"
 	intoto001 "github.com/sigstore/rekor/pkg/types/intoto/v0.0.1"
 	intoto002 "github.com/sigstore/rekor/pkg/types/intoto/v0.0.2"
@@ -135,6 +136,11 @@ Memory and file-based signers should only be used for testing.`)
 	rootCmd.PersistentFlags().Int("max_attestation_size", 100*1024, "max size for attestation storage, in bytes")
 
 	rootCmd.PersistentFlags().StringSlice("enabled_api_endpoints", operationIDs, "list of API endpoints to enable using operationId from openapi.yaml")
+
+	rootCmd.PersistentFlags().StringSlice("enabled_entry_types", types.ListSupportedKinds(),
+		"comma-separated list of entry type kinds to enable on the server (e.g. rekord,intoto,dsse,hashedrekord). "+
+			"If unset (default), all types compiled into the binary are enabled. Any kind specified here must be compiled "+
+			"into the binary; unknown kinds will cause startup to fail.")
 
 	rootCmd.PersistentFlags().Uint64("max_request_body_size", 0, "maximum size for HTTP request body, in bytes; set to 0 for unlimited")
 	rootCmd.PersistentFlags().Uint64("max_jar_metadata_size", 1048576, "maximum permitted size for jar META-INF/ files, in bytes; set to 0 for unlimited")

--- a/cmd/rekor-server/app/serve.go
+++ b/cmd/rekor-server/app/serve.go
@@ -17,7 +17,10 @@ package app
 
 import (
 	"flag"
+	"fmt"
 	"net/http"
+	"sort"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/profiler"
@@ -32,6 +35,7 @@ import (
 	"github.com/sigstore/rekor/pkg/generated/restapi"
 	"github.com/sigstore/rekor/pkg/generated/restapi/operations"
 	"github.com/sigstore/rekor/pkg/log"
+	"github.com/sigstore/rekor/pkg/types"
 	"github.com/sigstore/rekor/pkg/types/alpine"
 	alpine_v001 "github.com/sigstore/rekor/pkg/types/alpine/v0.0.1"
 	"github.com/sigstore/rekor/pkg/types/cose"
@@ -100,11 +104,9 @@ var serveCmd = &cobra.Command{
 				log.Logger.Error(err)
 			}
 		}()
-		//TODO: make this a config option for server to load via viper field
-		//TODO: add command line option to print versions supported in binary
-
-		// these trigger loading of package and therefore init() methods to run
-		pluggableTypeMap := map[string][]string{
+		// These trigger loading of the package and therefore init() methods to run,
+		// which registers each type's constructor in types.TypeMap.
+		entryTypeMap := map[string][]string{
 			rekord.KIND:       {rekord_v001.APIVERSION},
 			rpm.KIND:          {rpm_v001.APIVERSION},
 			jar.KIND:          {jar_v001.APIVERSION},
@@ -117,9 +119,20 @@ var serveCmd = &cobra.Command{
 			hashedrekord.KIND: {hashedrekord_v001.APIVERSION},
 			dsse.KIND:         {dsse_v001.APIVERSION},
 		}
-		for k, v := range pluggableTypeMap {
-			log.Logger.Infof("Loading support for pluggable type '%v'", k)
-			log.Logger.Infof("Loading version '%v' for pluggable type '%v'", v, k)
+
+		// Using --enabled_entry_types, restrict which kinds the server will
+		// accept for new submissions. By default, support every type compiled
+		// into the binary.
+		requestedTypes := viper.GetStringSlice("enabled_entry_types")
+		enabledTypes, err := filterEntryTypes(entryTypeMap, requestedTypes)
+		if err != nil {
+			log.Logger.Fatalf("invalid --enabled_entry_types flag: %v", err)
+		}
+		types.SetAllowedKindsForSubmission(enabledTypes)
+
+		for _, k := range enabledTypes {
+			log.Logger.Infof("Loading support for entry type '%v'", k)
+			log.Logger.Infof("Loading version '%v' for entry type '%v'", entryTypeMap[k], k)
 		}
 
 		server.Host = viper.GetString("rekor_server.address")
@@ -149,4 +162,30 @@ var serveCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(serveCmd)
+}
+
+// filterEntryTypes filters the list of compiled-in entry types
+// down to the set requested via the --enabled_entry_types flag.
+// If any requested type is not present, an error is returned.
+// Note that filtering only affects the write path, not the read paths.
+func filterEntryTypes(allTypes map[string][]string, requestedTypes []string) ([]string, error) {
+	enabled := make(map[string]struct{})
+	for _, kind := range requestedTypes {
+		_, ok := allTypes[kind]
+		if !ok {
+			known := make([]string, 0, len(allTypes))
+			for k := range allTypes {
+				known = append(known, k)
+			}
+			sort.Strings(known)
+			return nil, fmt.Errorf("unknown entry type %q; compiled-in types are: %s",
+				kind, strings.Join(known, ", "))
+		}
+		enabled[kind] = struct{}{}
+	}
+	enabledKinds := make([]string, 0, len(enabled))
+	for k := range enabled {
+		enabledKinds = append(enabledKinds, k)
+	}
+	return enabledKinds, nil
 }

--- a/cmd/rekor-server/app/serve_test.go
+++ b/cmd/rekor-server/app/serve_test.go
@@ -1,0 +1,132 @@
+//
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestFilterEntryTypes_EmptyRequestedReturnsNothing(t *testing.T) {
+	t.Parallel()
+	allEntries := map[string][]string{
+		"rekord":       {"0.0.1"},
+		"intoto":       {"0.0.1", "0.0.2"},
+		"hashedrekord": {"0.0.1"},
+	}
+
+	got, err := filterEntryTypes(allEntries, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("nil requested should return no entries")
+	}
+
+	got, err = filterEntryTypes(allEntries, []string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("empty slice requested should return no entries")
+	}
+}
+
+func TestFilterEntryTypes_SubsetPreservesVersions(t *testing.T) {
+	t.Parallel()
+	allEntries := map[string][]string{
+		"rekord":       {"0.0.1"},
+		"intoto":       {"0.0.1", "0.0.2"},
+		"hashedrekord": {"0.0.1"},
+	}
+
+	got, err := filterEntryTypes(allEntries, []string{"rekord", "intoto"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []string{"rekord", "intoto"}
+	sort.Strings(got)
+	sort.Strings(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("subset filter mismatch\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestFilterEntryTypes_UnknownKindErrors(t *testing.T) {
+	t.Parallel()
+	allEntries := map[string][]string{
+		"rekord": {"0.0.1"},
+		"intoto": {"0.0.1", "0.0.2"},
+	}
+
+	_, err := filterEntryTypes(allEntries, []string{"rekord", "doesnotexist"})
+	if err == nil {
+		t.Fatal("expected error for unknown kind, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, `"doesnotexist"`) {
+		t.Errorf("error should quote the bad kind, got: %v", err)
+	}
+	for _, want := range []string{"rekord", "intoto"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error should list known kind %q, got: %v", want, err)
+		}
+	}
+}
+
+func TestFilterEntryTypes_KnownKindsListedSorted(t *testing.T) {
+	t.Parallel()
+	allEntries := map[string][]string{
+		"zeta":  {"0.0.1"},
+		"alpha": {"0.0.1"},
+		"mu":    {"0.0.1"},
+	}
+
+	_, err := filterEntryTypes(allEntries, []string{"bogus"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	a, m, z := strings.Index(msg, "alpha"), strings.Index(msg, "mu"), strings.Index(msg, "zeta")
+	if a == -1 || m == -1 || z == -1 {
+		t.Fatalf("error message missing kinds: %s", msg)
+	}
+	if a >= m || m >= z {
+		t.Errorf("expected sorted order alpha < mu < zeta in error, got: %s", msg)
+	}
+}
+
+func TestFilterEntryTypes_DuplicatesAreIdempotent(t *testing.T) {
+	t.Parallel()
+	allEntries := map[string][]string{
+		"rekord": {"0.0.1"},
+		"intoto": {"0.0.1", "0.0.2"},
+	}
+
+	got, err := filterEntryTypes(allEntries, []string{"rekord", "rekord", "intoto"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"rekord", "intoto"}
+	sort.Strings(got)
+	sort.Strings(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("duplicate kinds should de-dupe\n got: %v\nwant: %v", got, want)
+	}
+}

--- a/pkg/types/entries.go
+++ b/pkg/types/entries.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"sync/atomic"
 
 	"github.com/cyberphone/json-canonicalization/go/src/webpki.org/jsoncanonicalizer"
 	"github.com/go-openapi/strfmt"
@@ -60,6 +61,30 @@ type ProposedEntryIterator interface {
 // EntryFactory describes a factory function that can generate structs for a specific versioned type
 type EntryFactory func() EntryImpl
 
+// allowedKindsForSubmission restricts the set of kinds that CreateVersionedEntry
+// will accept.
+// This restriction only applies to the insertion path. Read paths are unaffected
+// so that entries written to the log under a previous configuration are still readable.
+var allowedKindsForSubmission atomic.Pointer[map[string]struct{}]
+
+// SetAllowedKindsForSubmission configures the set of kinds that CreateVersionedEntry
+// will accept.
+func SetAllowedKindsForSubmission(kinds []string) {
+	m := make(map[string]struct{}, len(kinds))
+	for _, k := range kinds {
+		m[k] = struct{}{}
+	}
+	allowedKindsForSubmission.Store(&m)
+}
+
+// isKindAllowedForSubmission reports whether the given kind may be inserted
+// into the log via CreateVersionedEntry.
+func isKindAllowedForSubmission(kind string) bool {
+	m := allowedKindsForSubmission.Load()
+	_, ok := (*m)[kind]
+	return ok
+}
+
 func NewProposedEntry(ctx context.Context, kind, version string, props ArtifactProperties) (models.ProposedEntry, error) {
 	if tf, found := TypeMap.Load(kind); found {
 		t := tf.(func() TypeImpl)()
@@ -80,6 +105,9 @@ func CreateVersionedEntry(pe models.ProposedEntry) (EntryImpl, error) {
 		return nil, err
 	}
 	kind := pe.Kind()
+	if !isKindAllowedForSubmission(kind) {
+		return nil, fmt.Errorf("entry kind '%v' is not enabled for submission on this server", kind)
+	}
 	if tf, found := TypeMap.Load(kind); found {
 		if !tf.(func() TypeImpl)().IsSupportedVersion(ei.APIVersion()) {
 			return nil, fmt.Errorf("entry kind '%v' does not support inserting entries of version '%v'", kind, ei.APIVersion())

--- a/pkg/types/entries_test.go
+++ b/pkg/types/entries_test.go
@@ -1,0 +1,149 @@
+//
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+
+	"github.com/sigstore/rekor/pkg/generated/models"
+	pkitypes "github.com/sigstore/rekor/pkg/pki/pkitypes"
+)
+
+func TestIsKindAllowedForSubmission_NilAllowsNone(t *testing.T) {
+	SetAllowedKindsForSubmission(nil)
+	for _, kind := range []string{"rekord", "intoto", "anything-at-all", ""} {
+		if isKindAllowedForSubmission(kind) {
+			t.Errorf("with no allowlist configured, kind %q should not be allowed", kind)
+		}
+	}
+}
+
+func TestIsKindAllowedForSubmission_EmptySliceAllowsNone(t *testing.T) {
+	SetAllowedKindsForSubmission([]string{})
+	for _, kind := range []string{"rekord", "intoto", "anything-at-all", ""} {
+		if isKindAllowedForSubmission(kind) {
+			t.Errorf("with no allowlist configured, kind %q should not be allowed", kind)
+		}
+	}
+}
+
+func TestIsKindAllowedForSubmission_RestrictsToConfiguredSet(t *testing.T) {
+	SetAllowedKindsForSubmission([]string{"rekord", "intoto"})
+	if !isKindAllowedForSubmission("rekord") {
+		t.Error("rekord should be allowed")
+	}
+	if !isKindAllowedForSubmission("intoto") {
+		t.Error("intoto should be allowed")
+	}
+	if isKindAllowedForSubmission("hashedrekord") {
+		t.Error("hashedrekord should NOT be allowed")
+	}
+}
+
+const fakeKind = "test-fake-kind"
+
+type fakeProposedEntry struct{}
+
+func (fakeProposedEntry) Kind() string                                               { return fakeKind }
+func (fakeProposedEntry) SetKind(string)                                             {}
+func (fakeProposedEntry) Validate(_ strfmt.Registry) error                           { return nil }
+func (fakeProposedEntry) ContextValidate(_ context.Context, _ strfmt.Registry) error { return nil }
+
+type fakeType struct{}
+
+func (fakeType) CreateProposedEntry(_ context.Context, _ string, _ ArtifactProperties) (models.ProposedEntry, error) {
+	return fakeProposedEntry{}, nil
+}
+func (fakeType) DefaultVersion() string           { return "0.0.1" }
+func (fakeType) SupportedVersions() []string      { return []string{"0.0.1"} }
+func (fakeType) IsSupportedVersion(v string) bool { return v == "0.0.1" }
+func (fakeType) UnmarshalEntry(_ models.ProposedEntry) (EntryImpl, error) {
+	return fakeEntryImpl{}, nil
+}
+
+type fakeEntryImpl struct{}
+
+func (fakeEntryImpl) APIVersion() string           { return "0.0.1" }
+func (fakeEntryImpl) IndexKeys() ([]string, error) { return nil, nil }
+func (fakeEntryImpl) Canonicalize(_ context.Context) ([]byte, error) {
+	return []byte(`{}`), nil
+}
+func (fakeEntryImpl) Unmarshal(_ models.ProposedEntry) error { return nil }
+func (fakeEntryImpl) CreateFromArtifactProperties(_ context.Context, _ ArtifactProperties) (models.ProposedEntry, error) {
+	return fakeProposedEntry{}, nil
+}
+func (fakeEntryImpl) Verifiers() ([]pkitypes.PublicKey, error) { return nil, nil }
+func (fakeEntryImpl) ArtifactHash() (string, error)            { return "sha256:00", nil }
+func (fakeEntryImpl) Insertable() (bool, error)                { return true, nil }
+
+func registerFakeType(t *testing.T) {
+	t.Helper()
+	TypeMap.Store(fakeKind, func() TypeImpl { return fakeType{} })
+	t.Cleanup(func() { TypeMap.Delete(fakeKind) })
+}
+
+func TestCreateVersionedEntry_DoesNotAllowWhenAllowlistUnset(t *testing.T) {
+	registerFakeType(t)
+	SetAllowedKindsForSubmission(nil)
+
+	_, err := CreateVersionedEntry(fakeProposedEntry{})
+	if err == nil {
+		t.Fatal("expected submission to be rejected when kind is not allowlisted")
+	}
+	if !strings.Contains(err.Error(), "not enabled for submission") {
+		t.Errorf("error should clearly attribute rejection to the allowlist, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), fakeKind) {
+		t.Errorf("error should name the rejected kind, got: %v", err)
+	}
+}
+
+func TestCreateVersionedEntry_AllowsWhenKindInAllowlist(t *testing.T) {
+	registerFakeType(t)
+	SetAllowedKindsForSubmission([]string{fakeKind})
+
+	if _, err := CreateVersionedEntry(fakeProposedEntry{}); err != nil {
+		t.Errorf("expected submission to succeed when kind is allowlisted, got: %v", err)
+	}
+}
+
+func TestCreateVersionedEntry_RejectsWhenKindNotInAllowlist(t *testing.T) {
+	registerFakeType(t)
+	SetAllowedKindsForSubmission([]string{"some-other-kind"})
+
+	_, err := CreateVersionedEntry(fakeProposedEntry{})
+	if err == nil {
+		t.Fatal("expected submission to be rejected when kind is not allowlisted")
+	}
+	if !strings.Contains(err.Error(), "not enabled for submission") {
+		t.Errorf("error should clearly attribute rejection to the allowlist, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), fakeKind) {
+		t.Errorf("error should name the rejected kind, got: %v", err)
+	}
+}
+
+func TestUnmarshalEntry_DoesNotApplyToReadPath(t *testing.T) {
+	registerFakeType(t)
+	SetAllowedKindsForSubmission([]string{fakeKind})
+	if _, err := UnmarshalEntry(fakeProposedEntry{}); err != nil {
+		t.Errorf("UnmarshalEntry must remain unaffected by submission allowlist; got: %v", err)
+	}
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -73,11 +73,21 @@ func (rt *RekorType) IsSupportedVersion(proposedVersion string) bool {
 	return slices.Contains(rt.SupportedVersions(), proposedVersion)
 }
 
+// ListSupportedKinds returns all loaded entry kinds
+func ListSupportedKinds() []string {
+	var l []string
+	TypeMap.Range(func(k, _ any) bool {
+		l = append(l, k.(string))
+		return true
+	})
+	return l
+}
+
 // ListImplementedTypes returns a list of all type strings currently known to
 // be implemented
 func ListImplementedTypes() []string {
 	retVal := []string{}
-	TypeMap.Range(func(k interface{}, v interface{}) bool {
+	TypeMap.Range(func(k, v any) bool {
 		tf := v.(func() TypeImpl)
 		for _, verStr := range tf().SupportedVersions() {
 			retVal = append(retVal, fmt.Sprintf("%v:%v", k.(string), verStr))


### PR DESCRIPTION
This adds a server flag to restrict the set of kinds that the server will support for insertion. Note that this does not affect the read path, meaning previously inserted entries are still readable.

This will be used in the public instance to limit the set of kinds to the ones that are actively used to minimize the API attack surface.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
