### PR TITLE
fix fuzz build failures and crashes

### DIFF
--- a/pkg/pki/fuzz_test.go
+++ b/pkg/pki/fuzz_test.go
@@ -53,10 +53,10 @@ var helloWorldMinisignHashedSig []byte
 var validMinisignPub []byte
 
 //go:embed ssh/testdata/hello_world.txt.sig
-var helloWorldSshSig []byte
+var helloWorldSSHSig []byte
 
 //go:embed ssh/testdata/id_rsa.pub
-var validSshPub []byte
+var validSSHPub []byte
 
 //go:embed x509/testdata/hello_world.txt.sig
 var helloWorldX509Sig []byte
@@ -175,9 +175,9 @@ func FuzzKeys(f *testing.F) {
 		validMinisignPub)
 	// SSH (keyType 2): RSA key + signature
 	f.Add(uint(2), false,
-		helloWorldSshSig,
+		helloWorldSSHSig,
 		sshMsg,
-		validSshPub)
+		validSSHPub)
 	// X509 (keyType 3): EC public key + signature
 	f.Add(uint(3), false,
 		helloWorldX509Sig,

--- a/pkg/pki/fuzz_test.go
+++ b/pkg/pki/fuzz_test.go
@@ -17,10 +17,10 @@ package pki
 
 import (
 	"bytes"
+	_ "embed"
 	"encoding/base64"
 	"encoding/pem"
 	"io"
-	"os"
 	"testing"
 
 	"github.com/sigstore/rekor/pkg/pki/minisign"
@@ -31,14 +31,47 @@ import (
 	"github.com/sigstore/rekor/pkg/pki/x509"
 )
 
-// mustRead returns the contents of path or panics; used for seed corpus setup.
-func mustRead(path string) []byte {
-	b, err := os.ReadFile(path)
-	if err != nil {
-		panic(err)
-	}
-	return b
-}
+//go:embed pgp/testdata/hello_world.txt.asc.sig
+var helloWorldPgpSig []byte
+
+//go:embed pgp/testdata/hello_world.txt.sig
+var helloWorldPgpBinarySig []byte
+
+//go:embed pgp/testdata/valid_armored_public.pgp
+var validArmoredPgpPub []byte
+
+//go:embed pgp/testdata/valid_binary_public.pgp
+var validBinaryPgpPub []byte
+
+//go:embed minisign/testdata/hello_world.txt.minisig
+var helloWorldMinisignSig []byte
+
+//go:embed minisign/testdata/hello_world_hashed.txt.minisig
+var helloWorldMinisignHashedSig []byte
+
+//go:embed minisign/testdata/minisign.pub
+var validMinisignPub []byte
+
+//go:embed ssh/testdata/hello_world.txt.sig
+var helloWorldSshSig []byte
+
+//go:embed ssh/testdata/id_rsa.pub
+var validSshPub []byte
+
+//go:embed x509/testdata/hello_world.txt.sig
+var helloWorldX509Sig []byte
+
+//go:embed x509/testdata/ec.pub
+var validX509Pub []byte
+
+//go:embed pkcs7/testdata/sig.pkcs7.pem
+var pkcs7SigAndCert []byte
+
+//go:embed tuf/testdata/timestamp.json
+var tufTimestamp []byte
+
+//go:embed tuf/testdata/1.root.json
+var tufRoot []byte
 
 var (
 	fuzzArtifactFactoryMap = map[uint]pkiImpl{
@@ -122,53 +155,48 @@ func FuzzKeys(f *testing.F) {
 
 	// PGP (keyType 0): armored public key + armored signature
 	f.Add(uint(0), false,
-		mustRead("pgp/testdata/hello_world.txt.asc.sig"),
+		helloWorldPgpSig,
 		msg,
-		mustRead("pgp/testdata/valid_armored_public.pgp"))
+		validArmoredPgpPub)
 	// PGP binary format
 	f.Add(uint(0), false,
-		mustRead("pgp/testdata/hello_world.txt.sig"),
+		helloWorldPgpBinarySig,
 		msg,
-		mustRead("pgp/testdata/valid_binary_public.pgp"))
-
+		validBinaryPgpPub)
 	// Minisign (keyType 1): standard signature + key with comment
 	f.Add(uint(1), false,
-		mustRead("minisign/testdata/hello_world.txt.minisig"),
+		helloWorldMinisignSig,
 		msg,
-		mustRead("minisign/testdata/minisign.pub"))
+		validMinisignPub)
 	// Minisign: prehashed signature (exercises blake2b path)
 	f.Add(uint(1), false,
-		mustRead("minisign/testdata/hello_world_hashed.txt.minisig"),
+		helloWorldMinisignHashedSig,
 		msg,
-		mustRead("minisign/testdata/minisign_hashed.pub"))
-
+		validMinisignPub)
 	// SSH (keyType 2): RSA key + signature
 	f.Add(uint(2), false,
-		mustRead("ssh/testdata/hello_world.txt.sig"),
+		helloWorldSshSig,
 		sshMsg,
-		mustRead("ssh/testdata/id_rsa.pub"))
-
+		validSshPub)
 	// X509 (keyType 3): EC public key + signature
 	f.Add(uint(3), false,
-		mustRead("x509/testdata/hello_world.txt.sig"),
+		helloWorldX509Sig,
 		msg,
-		mustRead("x509/testdata/ec.pub"))
-
+		validX509Pub)
 	// PKCS7 (keyType 4): signed JAR manifest with embedded cert chain.
 	// Note: PKCS7 NewPublicKey has a known round-trip inconsistency
 	// (CanonicalValue returns CERTIFICATE PEM, but NewPublicKey rejects
 	// non-PKCS7 PEM), so we supply the same blob for both signature and
 	// key to exercise the maximum parse depth.
 	f.Add(uint(4), false,
-		mustRead("pkcs7/testdata/sig.pkcs7.pem"),
+		pkcs7SigAndCert,
 		[]byte{},
-		mustRead("pkcs7/testdata/sig.pkcs7.pem"))
-
+		pkcs7SigAndCert)
 	// TUF (keyType 5): root.json as key, timestamp.json as "signature"
 	f.Add(uint(5), false,
-		mustRead("tuf/testdata/timestamp.json"),
+		tufTimestamp,
 		[]byte("{}"),
-		mustRead("tuf/testdata/1.root.json"))
+		tufRoot)
 
 	f.Fuzz(func(t *testing.T, keyType uint, wrap bool, origSignatureData, verSignatureData, keyData []byte) {
 		impl := fuzzArtifactFactoryMap[keyType%6]

--- a/pkg/sharding/shard_fuzz_test.go
+++ b/pkg/sharding/shard_fuzz_test.go
@@ -26,7 +26,7 @@ func FuzzCreateEntryIDFromParts(f *testing.F) {
 	f.Fuzz(func(t *testing.T, treeID, uuid string) {
 		e, err := CreateEntryIDFromParts(treeID, uuid)
 		if err != nil {
-			t.Skipf("failed to create entryID from %v + %v: %v", treeID, uuid, err)
+			return
 		}
 		// Round-trip: an accepted (treeID, uuid) pair must serialize to an
 		// entryID string that the inverse parsers also accept and that
@@ -53,7 +53,7 @@ func FuzzGetUUIDFromIDString(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, entryID string) {
 		if _, err := GetUUIDFromIDString(entryID); err != nil {
-			t.Skipf("error getting UUID from %v: %v", entryID, err)
+			return
 		}
 	})
 }
@@ -63,7 +63,7 @@ func FuzzGetTreeIDFromIDString(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, entryID string) {
 		if _, err := GetTreeIDFromIDString(entryID); err != nil {
-			t.Skipf("error getting treeID from %v: %v", entryID, err)
+			return
 		}
 	})
 }
@@ -76,7 +76,7 @@ func FuzzPadToTreeIDLen(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, treeID string) {
 		if _, err := PadToTreeIDLen(treeID); err != nil {
-			t.Skipf("error padding %v: %v", treeID, err)
+			return
 		}
 	})
 }
@@ -87,7 +87,7 @@ func FuzzTreeID(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, treeID string) {
 		if _, err := TreeID(treeID); err != nil {
-			t.Skipf("error creating treeID %v: %v", treeID, err)
+			return
 		}
 	})
 }
@@ -99,7 +99,7 @@ func FuzzValidateUUID(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, uuid string) {
 		if err := ValidateUUID(uuid); err != nil {
-			t.Skipf("error validating UUID %v: %v", uuid, err)
+			return
 		}
 	})
 }
@@ -111,7 +111,7 @@ func FuzzValidateTreeID(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, treeID string) {
 		if err := ValidateTreeID(treeID); err != nil {
-			t.Skipf("error validating treeID %v: %v", treeID, err)
+			return
 		}
 	})
 }
@@ -121,7 +121,7 @@ func FuzzValidateEntryID(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, entryID string) {
 		if err := ValidateEntryID(entryID); err != nil {
-			t.Skipf("error validating entryID %v: %v", entryID, err)
+			return
 		}
 	})
 }

--- a/pkg/sharding/shard_fuzz_test.go
+++ b/pkg/sharding/shard_fuzz_test.go
@@ -51,7 +51,7 @@ func FuzzGetUUIDFromIDString(f *testing.F) {
 	// 64-char UUID-only
 	f.Add("a9b9c5e3f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3")
 
-	f.Fuzz(func(t *testing.T, entryID string) {
+	f.Fuzz(func(_ *testing.T, entryID string) {
 		if _, err := GetUUIDFromIDString(entryID); err != nil {
 			return
 		}
@@ -61,7 +61,7 @@ func FuzzGetUUIDFromIDString(f *testing.F) {
 func FuzzGetTreeIDFromIDString(f *testing.F) {
 	f.Add("0000000000000001a9b9c5e3f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3")
 
-	f.Fuzz(func(t *testing.T, entryID string) {
+	f.Fuzz(func(_ *testing.T, entryID string) {
 		if _, err := GetTreeIDFromIDString(entryID); err != nil {
 			return
 		}
@@ -74,7 +74,7 @@ func FuzzPadToTreeIDLen(f *testing.F) {
 	f.Add("ffffffffffffffff")  // max value
 	f.Add("00000000000000001") // too long by one
 
-	f.Fuzz(func(t *testing.T, treeID string) {
+	f.Fuzz(func(_ *testing.T, treeID string) {
 		if _, err := PadToTreeIDLen(treeID); err != nil {
 			return
 		}
@@ -85,7 +85,7 @@ func FuzzTreeID(f *testing.F) {
 	f.Add("1234")
 	f.Add("0")
 
-	f.Fuzz(func(t *testing.T, treeID string) {
+	f.Fuzz(func(_ *testing.T, treeID string) {
 		if _, err := TreeID(treeID); err != nil {
 			return
 		}
@@ -97,7 +97,7 @@ func FuzzValidateUUID(f *testing.F) {
 	f.Add("0000000000000000000000000000000000000000000000000000000000000000") // all zeros
 	f.Add("AABBCCDD")                                                         // too short
 
-	f.Fuzz(func(t *testing.T, uuid string) {
+	f.Fuzz(func(_ *testing.T, uuid string) {
 		if err := ValidateUUID(uuid); err != nil {
 			return
 		}
@@ -109,7 +109,7 @@ func FuzzValidateTreeID(f *testing.F) {
 	f.Add("0000000000000000") // zero — should fail
 	f.Add("ffffffffffffffff") // max
 
-	f.Fuzz(func(t *testing.T, treeID string) {
+	f.Fuzz(func(_ *testing.T, treeID string) {
 		if err := ValidateTreeID(treeID); err != nil {
 			return
 		}
@@ -119,7 +119,7 @@ func FuzzValidateTreeID(f *testing.F) {
 func FuzzValidateEntryID(f *testing.F) {
 	f.Add("0000000000000001a9b9c5e3f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3") // valid 80 hex
 
-	f.Fuzz(func(t *testing.T, entryID string) {
+	f.Fuzz(func(_ *testing.T, entryID string) {
 		if err := ValidateEntryID(entryID); err != nil {
 			return
 		}

--- a/tests/oss_fuzz.sh
+++ b/tests/oss_fuzz.sh
@@ -14,12 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# remove e2e build comments. 
-# This is a temporary fix.
-# TODO AdamKorcz: Get rid of these sed commands
-sed -i '16,17d' $SRC/rekor/pkg/pki/x509/e2e.go
-sed -i '16d' $SRC/rekor/pkg/util/util.go
-
 cd $SRC/rekor
 go mod tidy
 


### PR DESCRIPTION
embeds test data into binary and swaps `t.Skipf` for return 