### PR TITLE
alpine: enforce maximum signature decompression size

### DIFF
--- a/pkg/types/alpine/apk.go
+++ b/pkg/types/alpine/apk.go
@@ -106,15 +106,17 @@ func (p *Package) Unmarshal(pkgReader io.Reader) error {
 
 	// GZIP headers/footers are left unmodified; Tar footers are removed on first two archives
 	// signature.tar.gz | control.tar.gz | data.tar.gz
+	maxBufSize := viper.GetUint64("max_apk_metadata_size")
+	if maxBufSize == 0 {
+		maxBufSize = 20 * 1024 * 1024
+	}
 	sigBuf := bytes.Buffer{}
-	for {
-		_, err := io.CopyN(&sigBuf, gzipReader, 1024)
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			return fmt.Errorf("reading signature.tar.gz: %w", err)
-		}
+	if _, err := io.Copy(&sigBuf, io.LimitReader(gzipReader, int64(maxBufSize)+1)); err != nil {
+		return fmt.Errorf("reading signature.tar.gz: %w", err)
+	}
+	if sigBuf.Len() > int(maxBufSize) {
+		return fmt.Errorf("decompressed size (%d) for signature.tar.gz exceeds max allowed size %d",
+			sigBuf.Len(), maxBufSize)
 	}
 
 	// the SHA1 sum used in the signature is over the entire file control.tar.gz so we need to

--- a/pkg/types/alpine/apk_test.go
+++ b/pkg/types/alpine/apk_test.go
@@ -16,6 +16,7 @@
 package alpine
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -30,6 +31,7 @@ func TestAlpinePackage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not open archive %v", err)
 	}
+	defer inputArchive.Close()
 
 	p := Package{}
 	err = p.Unmarshal(inputArchive)
@@ -41,6 +43,7 @@ func TestAlpinePackage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not open archive %v", err)
 	}
+	defer pubKey.Close()
 
 	pub, err := x509.NewPublicKey(pubKey)
 	if err != nil {
@@ -53,12 +56,16 @@ func TestAlpinePackage(t *testing.T) {
 }
 
 func TestAlpineMetadataSize(t *testing.T) {
+	origVal := viper.Get("max_apk_metadata_size")
+	defer viper.Set("max_apk_metadata_size", origVal)
+
 	viper.Set("max_apk_metadata_size", 10)
 
 	inputArchive, err := os.Open("tests/test_alpine.apk")
 	if err != nil {
 		t.Fatalf("could not open archive %v", err)
 	}
+	defer inputArchive.Close()
 
 	p := Package{}
 	err = p.Unmarshal(inputArchive)
@@ -67,5 +74,65 @@ func TestAlpineMetadataSize(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "exceeds max allowed size 10") {
 		t.Fatalf("unexpected error %v", err)
+	}
+}
+
+func TestAlpineMetadataSizeDefault(t *testing.T) {
+	origVal := viper.Get("max_apk_metadata_size")
+	defer viper.Set("max_apk_metadata_size", origVal)
+
+	viper.Set("max_apk_metadata_size", 0)
+
+	inputArchive, err := os.Open("tests/test_alpine.apk")
+	if err != nil {
+		t.Fatalf("could not open archive %v", err)
+	}
+	defer inputArchive.Close()
+
+	p := Package{}
+	err = p.Unmarshal(inputArchive)
+	if err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+}
+
+func TestAlpineMetadataSizeBoundary(t *testing.T) {
+	origVal := viper.Get("max_apk_metadata_size")
+	defer viper.Set("max_apk_metadata_size", origVal)
+
+	// The signature.tar.gz decompressed size in test_alpine.apk is exactly 1024 bytes.
+	boundary := 1024
+
+	// 1. Verify that max_apk_metadata_size = 1024 succeeds
+	viper.Set("max_apk_metadata_size", uint64(boundary))
+	inputArchive, err := os.Open("tests/test_alpine.apk")
+	if err != nil {
+		t.Fatalf("could not open archive %v", err)
+	}
+	p := Package{}
+	err = p.Unmarshal(inputArchive)
+	inputArchive.Close()
+	if err != nil {
+		t.Fatalf("expected success at size %d, got err: %v", boundary, err)
+	}
+
+	// 2. Verify that max_apk_metadata_size = 1023 fails
+	viper.Set("max_apk_metadata_size", uint64(boundary-1))
+	inputArchive, err = os.Open("tests/test_alpine.apk")
+	if err != nil {
+		t.Fatalf("could not open archive %v", err)
+	}
+	defer inputArchive.Close()
+
+	p = Package{}
+	err = p.Unmarshal(inputArchive)
+	if err == nil {
+		t.Fatalf("expected failure at size %d", boundary-1)
+	}
+
+	// Decompressed size (1024) exceeds max allowed size (1023)
+	expectedErr := fmt.Sprintf("decompressed size (%d) for signature.tar.gz exceeds max allowed size %d", boundary, boundary-1)
+	if !strings.Contains(err.Error(), expectedErr) {
+		t.Fatalf("expected error containing %q, got %q", expectedErr, err.Error())
 	}
 }

--- a/pkg/types/entries.go
+++ b/pkg/types/entries.go
@@ -81,6 +81,9 @@ func SetAllowedKindsForSubmission(kinds []string) {
 // into the log via CreateVersionedEntry.
 func isKindAllowedForSubmission(kind string) bool {
 	m := allowedKindsForSubmission.Load()
+	if m == nil {
+		return true
+	}
 	_, ok := (*m)[kind]
 	return ok
 }


### PR DESCRIPTION
Enforce maximum decompression size validation during Alpine package unmarshalling to prevent decompressed size exhaustion.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
