### PR TITLE
Return clear HTTP 413 when request body exceeds max_request_body_size

### DIFF
--- a/pkg/generated/restapi/configure_rekor_server.go
+++ b/pkg/generated/restapi/configure_rekor_server.go
@@ -341,6 +341,14 @@ func wrapMetrics(handler http.Handler) http.Handler {
 
 func logAndServeError(w http.ResponseWriter, r *http.Request, err error) {
 	ctx := r.Context()
+	// If the request body exceeded max_request_body_size, surface a clear
+	// 413 Request Entity Too Large that names the limit instead of letting the
+	// MaxBytesReader error fall through to an opaque 500. The conversion happens
+	// before logging so the request is logged as the client error it is.
+	if maxBytesErr := asMaxBytesError(err); maxBytesErr != nil {
+		err = errors.New(http.StatusRequestEntityTooLarge,
+			"request body exceeds max_request_body_size limit of %d bytes", maxBytesErr.Limit)
+	}
 	if apiErr, ok := err.(errors.Error); ok {
 		code := apiErr.Code()
 		if code >= http.StatusBadRequest && code < http.StatusInternalServerError {
@@ -351,21 +359,53 @@ func logAndServeError(w http.ResponseWriter, r *http.Request, err error) {
 	} else {
 		log.ContextLogger(ctx).Error(err)
 	}
-	if compErr, ok := err.(*errors.CompositeError); ok {
-		// iterate over composite error looking for something more specific
-		for _, embeddedErr := range compErr.Errors {
-			var maxBytesError *http.MaxBytesError
-			if parseErr, ok := embeddedErr.(*errors.ParseError); ok && go_errors.As(parseErr.Reason, &maxBytesError) {
-				err = errors.New(http.StatusRequestEntityTooLarge, "Request Entity Too Large")
-				break
-			}
-		}
-	}
 	requestFields := map[string]interface{}{}
 	if decodeErr := mapstructure.Decode(r, &requestFields); decodeErr == nil {
 		log.ContextLogger(ctx).Debug(requestFields)
 	}
 	errors.ServeError(w, r, err)
+}
+
+// asMaxBytesError reports whether err was caused by the request body exceeding
+// the http.MaxBytesReader limit set by the maxBodySize middleware, returning the
+// underlying *http.MaxBytesError (which carries the configured Limit) if so.
+//
+// The error can reach here in a few shapes. A bare *http.MaxBytesError, or one
+// nested anywhere that unwraps (for example a CompositeError, which implements
+// Unwrap), is caught by errors.As. go-openapi consumers instead wrap the read
+// failure in a *errors.ParseError, whose Reason holds the original error but is
+// not reachable through errors.As because ParseError does not implement Unwrap;
+// that case is handled explicitly, both when the ParseError is the top-level
+// error and when it is a member of a CompositeError.
+func asMaxBytesError(err error) *http.MaxBytesError {
+	var maxBytesError *http.MaxBytesError
+	if go_errors.As(err, &maxBytesError) {
+		return maxBytesError
+	}
+	if mbErr := maxBytesFromParseError(err); mbErr != nil {
+		return mbErr
+	}
+	var compErr *errors.CompositeError
+	if go_errors.As(err, &compErr) {
+		for _, embeddedErr := range compErr.Errors {
+			if mbErr := maxBytesFromParseError(embeddedErr); mbErr != nil {
+				return mbErr
+			}
+		}
+	}
+	return nil
+}
+
+// maxBytesFromParseError returns the *http.MaxBytesError held in a
+// *errors.ParseError's Reason, or nil if err is not such a ParseError. This is
+// needed because ParseError does not implement Unwrap, so errors.As cannot reach
+// its Reason on its own.
+func maxBytesFromParseError(err error) *http.MaxBytesError {
+	var maxBytesError *http.MaxBytesError
+	if parseErr, ok := err.(*errors.ParseError); ok && go_errors.As(parseErr.Reason, &maxBytesError) {
+		return maxBytesError
+	}
+	return nil
 }
 
 //go:embed rekorHomePage.html

--- a/pkg/generated/restapi/configure_rekor_server_test.go
+++ b/pkg/generated/restapi/configure_rekor_server_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright © 2025 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package restapi
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-openapi/errors"
+)
+
+// readBodyHandler reads the whole request body and, if the read fails, routes
+// the error through logAndServeError exactly like the go-openapi runtime does
+// when a consumer fails to read an oversized body. This lets the test exercise
+// the full middleware + error-handling path without standing up the API server.
+func readBodyHandler(wrapReason func(error) error) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := io.ReadAll(r.Body); err != nil {
+			if wrapReason != nil {
+				err = wrapReason(err)
+			}
+			logAndServeError(w, r, err)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func TestMaxBodySizeReturns413(t *testing.T) {
+	const limit = 1024
+
+	cases := []struct {
+		name string
+		// wrapReason mirrors how the read error is wrapped before it reaches
+		// logAndServeError. nil means the bare *http.MaxBytesError is passed.
+		wrapReason func(error) error
+	}{
+		{
+			name:       "bare MaxBytesError",
+			wrapReason: nil,
+		},
+		{
+			name: "wrapped in ParseError (go-openapi consumer shape)",
+			wrapReason: func(reason error) error {
+				return errors.NewParseError("body", "", "", reason)
+			},
+		},
+		{
+			name: "wrapped in CompositeError of ParseError",
+			wrapReason: func(reason error) error {
+				return &errors.CompositeError{
+					Errors: []error{errors.NewParseError("body", "", "", reason)},
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := maxBodySize(limit, readBodyHandler(tc.wrapReason))
+
+			body := strings.NewReader(strings.Repeat("a", limit*4))
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/log/entries", body)
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusRequestEntityTooLarge {
+				t.Fatalf("expected status %d, got %d (body: %q)",
+					http.StatusRequestEntityTooLarge, rec.Code, rec.Body.String())
+			}
+			// The message must name the configured limit so operators and
+			// clients can see why the request was rejected (issue #2808).
+			if want := fmt.Sprintf("%d", limit); !strings.Contains(rec.Body.String(), want) {
+				t.Errorf("expected response body to name the limit %q, got %q", want, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), "max_request_body_size") {
+				t.Errorf("expected response body to reference max_request_body_size, got %q", rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestMaxBodySizeUnderLimitPasses guards against false positives: a request
+// within the limit must not be turned into a 413.
+func TestMaxBodySizeUnderLimitPasses(t *testing.T) {
+	const limit = 1024
+	handler := maxBodySize(limit, readBodyHandler(nil))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/log/entries", strings.NewReader("small body"))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d for under-limit body, got %d", http.StatusOK, rec.Code)
+	}
+}
+
+// TestAsMaxBytesError checks the detection helper directly across the shapes the
+// error can take, including a non-matching error that must not be misclassified.
+func TestAsMaxBytesError(t *testing.T) {
+	mbErr := &http.MaxBytesError{Limit: 42}
+
+	t.Run("bare", func(t *testing.T) {
+		if got := asMaxBytesError(mbErr); got == nil || got.Limit != 42 {
+			t.Fatalf("expected MaxBytesError with limit 42, got %v", got)
+		}
+	})
+
+	t.Run("parse error reason", func(t *testing.T) {
+		err := errors.NewParseError("body", "", "", mbErr)
+		if got := asMaxBytesError(err); got == nil || got.Limit != 42 {
+			t.Fatalf("expected MaxBytesError with limit 42, got %v", got)
+		}
+	})
+
+	t.Run("composite of parse error", func(t *testing.T) {
+		err := &errors.CompositeError{Errors: []error{errors.NewParseError("body", "", "", mbErr)}}
+		if got := asMaxBytesError(err); got == nil || got.Limit != 42 {
+			t.Fatalf("expected MaxBytesError with limit 42, got %v", got)
+		}
+	})
+
+	t.Run("unrelated error is not matched", func(t *testing.T) {
+		if got := asMaxBytesError(fmt.Errorf("some other failure")); got != nil {
+			t.Fatalf("expected nil for unrelated error, got %v", got)
+		}
+	})
+}


### PR DESCRIPTION
#### Summary

Fixes #2808.

When `max_request_body_size` is configured, the `maxBodySize` middleware in `pkg/generated/restapi/configure_rekor_server.go` wraps the request body with `http.MaxBytesReader`. Once the limit is exceeded the read fails, but the way that failure was surfaced to clients depended entirely on how the error happened to be wrapped before it reached `logAndServeError`:

- a bare `*http.MaxBytesError` fell through to an opaque `500` with body `http: request body too large`
- a top-level `*errors.ParseError` produced a `400` that leaked the same internal `http: request body too large` text
- only a `CompositeError` holding a `ParseError` was converted to `413`, and even then the message was a generic `Request Entity Too Large` that never named the limit

That is why the reporter (uploading with cosign against the public instance) saw only a generic `giving up after N attempt(s)` retry failure with no hint that the body size limit was the cause, and why the limit itself was effectively undiscoverable.

This change detects the underlying `*http.MaxBytesError` across all of those shapes through a single helper (`asMaxBytesError`) and responds with `413 Request Entity Too Large`, including the configured limit in bytes (read straight from `MaxBytesError.Limit`) so operators and clients can see exactly why the request was rejected. `*errors.ParseError` is handled explicitly because it does not implement `Unwrap`, so `errors.As` cannot reach its `Reason` on its own; everything else (bare error, or one nested in a `CompositeError`, which does unwrap) is caught by `errors.As`. The detailed error is still logged server-side, and it is now logged at warn rather than error since it is a client error.

This edit is in the hand-maintained region of `configure_rekor_server.go` (the file carries the go-swagger `This file is safe to edit. Once it exists it will not be overwritten` marker, and the prior 413 handling lived in this same region).

How to verify:

```
go test ./pkg/generated/restapi/ -run 'TestMaxBodySize|TestAsMaxBytesError' -v
```

Behaviour for an over-limit body with the fix applied:

- before: `500 {"code":500,"message":"http: request body too large"}` (or a `400` leaking the same text, depending on the consumer)
- after: `413 {"code":413,"message":"request body exceeds max_request_body_size limit of 1024 bytes"}`

The new tests cover each error shape, an under-limit request (must stay a success, not a false-positive 413), and the detection helper directly.

#### Release Note

Rekor now returns a clear `413 Request Entity Too Large` response that names the configured byte limit when a request body exceeds `max_request_body_size`, instead of an opaque `500`/`400` with no explanation. The detailed error continues to be logged server-side only.

#### Documentation

None.
