### PR TITLE
docs(cli): add usage examples to rekor-cli commands

### DIFF
--- a/cmd/rekor-cli/app/get.go
+++ b/cmd/rekor-cli/app/get.go
@@ -70,7 +70,9 @@ func (g *getCmdOutput) String() string {
 
 // getCmd represents the get command
 var getCmd = &cobra.Command{
-	Use:   "get",
+	Use: "get",
+	Example: `  rekor-cli get --uuid <entry-uuid>
+  rekor-cli get --log-index 0`,
 	Short: "Rekor get command",
 	Long:  `Get information regarding entries in the transparency log`,
 	PreRun: func(cmd *cobra.Command, _ []string) {

--- a/cmd/rekor-cli/app/log_info.go
+++ b/cmd/rekor-cli/app/log_info.go
@@ -60,9 +60,10 @@ TreeID:                 %s
 
 // logInfoCmd represents the current information about the transparency log
 var logInfoCmd = &cobra.Command{
-	Use:   "loginfo",
-	Short: "Rekor loginfo command",
-	Long:  `Prints info about the transparency log`,
+	Use:     "loginfo",
+	Example: `  rekor-cli loginfo`,
+	Short:   "Rekor loginfo command",
+	Long:    `Prints info about the transparency log`,
 	Run: format.WrapCmd(func(cmd *cobra.Command, _ []string) (interface{}, error) {
 		serverURL := viper.GetString("rekor_server")
 		ctx := cmd.Context()

--- a/cmd/rekor-cli/app/log_proof.go
+++ b/cmd/rekor-cli/app/log_proof.go
@@ -50,7 +50,9 @@ func (l *logProofOutput) String() string {
 
 // logProof represents the consistency proof
 var logProofCmd = &cobra.Command{
-	Use:   "logproof",
+	Use: "logproof",
+	Example: `  rekor-cli logproof --last-size 10
+  rekor-cli logproof --first-size 5 --last-size 10`,
 	Short: "Rekor logproof command",
 	Long:  `Prints information required to compute the consistency proof of the transparency log`,
 	PreRunE: func(cmd *cobra.Command, _ []string) error {

--- a/cmd/rekor-cli/app/search.go
+++ b/cmd/rekor-cli/app/search.go
@@ -82,7 +82,11 @@ func validateSearchPFlags() error {
 
 // searchCmd represents the get command
 var searchCmd = &cobra.Command{
-	Use:   "search",
+	Use: "search",
+	Example: `  rekor-cli search --artifact <path-or-url>
+  rekor-cli search --public-key <path> --pki-format=x509
+  rekor-cli search --email <email>
+  rekor-cli search --sha <sha256>`,
 	Short: "Rekor search command",
 	Long:  `Searches the Rekor index to find entries by sha, artifact,  public key, or e-mail`,
 	PreRun: func(cmd *cobra.Command, _ []string) {

--- a/cmd/rekor-cli/app/upload.go
+++ b/cmd/rekor-cli/app/upload.go
@@ -56,8 +56,9 @@ func (u *uploadCmdOutput) String() string {
 
 // uploadCmd represents the upload command
 var uploadCmd = &cobra.Command{
-	Use:   "upload",
-	Short: "Upload an artifact to Rekor",
+	Use:     "upload",
+	Example: `  rekor-cli upload --artifact <path-or-url> --signature <path> --public-key <path>`,
+	Short:   "Upload an artifact to Rekor",
 	PreRunE: func(cmd *cobra.Command, _ []string) error {
 		// these are bound here so that they are not overwritten by other commands
 		if err := viper.BindPFlags(cmd.Flags()); err != nil {

--- a/cmd/rekor-cli/app/verify.go
+++ b/cmd/rekor-cli/app/verify.go
@@ -83,7 +83,9 @@ func (v *verifyCmdOutput) String() string {
 
 // verifyCmd represents the get command
 var verifyCmd = &cobra.Command{
-	Use:   "verify",
+	Use: "verify",
+	Example: `  rekor-cli verify --uuid <entry-uuid>
+  rekor-cli verify --artifact <path> --signature <path> --public-key <path>`,
 	Short: "Rekor verify command",
 	Long:  `Verifies an entry exists in the transparency log through an inclusion proof`,
 	PreRunE: func(cmd *cobra.Command, _ []string) error {


### PR DESCRIPTION
The `rekor-cli` `get`, `search`, `upload`, `verify`, `loginfo` and `logproof` commands had no `Example` field, so `rekor-cli <cmd> --help` printed the flags with no indication of how to actually invoke the command.

This adds concrete usage examples (using the real flags) to each command, so the help output is actionable. For example:

```
$ rekor-cli get --help
...
Examples:
  rekor-cli get --uuid <entry-uuid>
  rekor-cli get --log-index 0
```

No behaviour change, help text only.