### PR TITLE
Use bytes.Equal for inclusion proof root hash comparison

### DIFF
--- a/pkg/verify/verify.go
+++ b/pkg/verify/verify.go
@@ -126,7 +126,7 @@ func VerifyCheckpointSignature(e *models.LogEntryAnon, verifier signature.Verifi
 		return errors.New("decoding inclusion proof root has")
 	}
 
-	if !bytes.EqualFold(rootHash, sth.Hash) {
+	if !bytes.Equal(rootHash, sth.Hash) {
 		return fmt.Errorf("proof root hash does not match signed tree head, expected %s got %s",
 			*e.Verification.InclusionProof.RootHash,
 			hex.EncodeToString(sth.Hash))

--- a/pkg/verify/verify_test.go
+++ b/pkg/verify/verify_test.go
@@ -340,3 +340,39 @@ func TestCheckpoint(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckpointRootHashCaseFolding(t *testing.T) {
+	signer, _, err := signature.NewDefaultECDSASignerVerifier()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var rootHash [32]byte
+	for i := range rootHash {
+		rootHash[i] = byte(i) + 1
+	}
+	rootHash[0] = 'A'
+
+	scBytes, err := util.CreateAndSignCheckpoint(context.Background(), "rekor.localhost", 123, 42, rootHash[:], signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Same bytes except an ASCII letter in different case: not equal, but equal
+	// under case folding.
+	mismatch := rootHash
+	mismatch[0] = 'a'
+
+	e := models.LogEntryAnon{
+		Verification: &models.LogEntryAnonVerification{
+			InclusionProof: &models.InclusionProof{
+				RootHash:   conv.Pointer(hex.EncodeToString(mismatch[:])),
+				Checkpoint: conv.Pointer(string(scBytes)),
+			},
+		},
+	}
+
+	if err := VerifyCheckpointSignature(&e, signer); err == nil {
+		t.Fatal("VerifyCheckpointSignature accepted a root hash that does not match the signed tree head")
+	}
+}


### PR DESCRIPTION
#### Summary

VerifyCheckpointSignature compares the inclusion proof root hash to the signed tree head with `bytes.EqualFold` (`pkg/verify/verify.go`), which folds ASCII case, so two hashes differing only by letter case compare equal. The other root hash comparisons in this package use `bytes.Equal`.

Not exploitable through `VerifyLogEntry`, since `VerifyInclusion` independently pins the root hash to the entry body. Switch to `bytes.Equal` to match.

#### Release Note

Fixed `VerifyCheckpointSignature` to compare the inclusion proof root hash with exact byte equality.

#### Documentation

N/A
