### PR TITLE
return 499 if client disconnects instead of 500

### DIFF
--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -785,6 +785,11 @@ func retrieveUUIDFromTree(ctx context.Context, uuid string, tid int64) (models.L
 
 	case codes.NotFound:
 		return models.LogEntry{}, ErrNotFound
+	case codes.Canceled:
+		// If the client disconnected, trillian will return Canceled — surface
+		// that up the stack rather than logging it as an unexpected error.
+		// handleRekorAPIError rewrites this to a 499 response.
+		return models.LogEntry{}, ctx.Err()
 	default:
 		log.ContextLogger(ctx).Errorf("Unexpected response code while attempting to retrieve UUID %v from TreeID %v: %v", uuid, tid, resp.Status)
 		return models.LogEntry{}, errors.New("unexpected error")

--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -16,6 +16,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -34,6 +35,7 @@ import (
 const (
 	trillianCommunicationError     = "unexpected error communicating with transparency log"
 	trillianUnexpectedResult       = "unexpected result from transparency log"
+	clientDisconnected             = "client disconnected during request"
 	validationError                = "error processing entry: %v"
 	failedToGenerateCanonicalEntry = "error generating canonicalized entry"
 	entryAlreadyExists             = "an equivalent entry already exists in the transparency log with UUID %v"
@@ -69,6 +71,15 @@ func handleRekorAPIError(params interface{}, code int, err error, message string
 
 	logMsg := func(r *http.Request, inputs ...interface{}) {
 		ctx := r.Context()
+		// If the client disconnected before we could respond, rewrite the
+		// status to 499 (nginx-style "client closed request") so that the
+		// response, request log, and metrics all agree that this wasn't a
+		// server-side error we could have prevented. Also replace the
+		// client-facing message so the JSON body reflects the true cause.
+		if code >= 500 && ctx.Err() == context.Canceled {
+			code = 499
+			message = clientDisconnected
+		}
 		fields := append([]interface{}{"handler", handler, "statusCode", code, "clientMessage", message}, fields...)
 		if code >= 500 {
 			fields = append(fields, inputs...)

--- a/pkg/api/error_test.go
+++ b/pkg/api/error_test.go
@@ -1,0 +1,68 @@
+//
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-openapi/runtime"
+	"github.com/sigstore/rekor/pkg/generated/restapi/operations/entries"
+)
+
+func TestHandleRekorAPIError_ClientCanceled(t *testing.T) {
+	// Case 1: When client context is NOT canceled, we expect a standard HTTP 500 response.
+	t.Run("Context not canceled returns 500", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/v1/log/entries?logIndex=1", nil)
+		params := entries.GetLogEntryByIndexParams{
+			HTTPRequest: req,
+			LogIndex:    1,
+		}
+
+		responder := handleRekorAPIError(params, http.StatusInternalServerError, errors.New("underlying error"), "some server error message")
+
+		recorder := httptest.NewRecorder()
+		responder.WriteResponse(recorder, runtime.JSONProducer())
+
+		if recorder.Code != http.StatusInternalServerError {
+			t.Errorf("Expected status code %d, got %d", http.StatusInternalServerError, recorder.Code)
+		}
+	})
+
+	// Case 2: When client context IS canceled (simulating a disconnect), we expect HTTP 499.
+	t.Run("Context canceled returns 499", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel the context to simulate client disconnect mid-flight
+
+		req := httptest.NewRequest("GET", "/api/v1/log/entries?logIndex=1", nil).WithContext(ctx)
+		params := entries.GetLogEntryByIndexParams{
+			HTTPRequest: req,
+			LogIndex:    1,
+		}
+
+		responder := handleRekorAPIError(params, http.StatusInternalServerError, errors.New("underlying error"), "some server error message")
+
+		recorder := httptest.NewRecorder()
+		responder.WriteResponse(recorder, runtime.JSONProducer())
+
+		if recorder.Code != 499 {
+			t.Errorf("Expected status code 499, got %d", recorder.Code)
+		}
+	})
+}


### PR DESCRIPTION
If a client abruptly disconnects from the server, we currently log and return a 500 error; this swaps the behavior to a 499 response code which is the industry norm for this scenario.