### PR TITLE
Return the file error instead of the URL error for a missing artifact path

### DIFF
--- a/cmd/rekor-cli/app/pflags.go
+++ b/cmd/rekor-cli/app/pflags.go
@@ -280,12 +280,23 @@ func validateSHAValue(v string) error {
 
 // validateFileOrURL ensures the provided string is either a valid file path that can be opened or a valid URL
 func validateFileOrURL(v string) error {
-	valGen := pflagValueFuncMap[fileFlag]
-	if valGen().Set(v) == nil {
+	fileErr := pflagValueFuncMap[fileFlag]().Set(v)
+	if fileErr == nil {
 		return nil
 	}
-	valGen = pflagValueFuncMap[urlFlag]
-	return valGen().Set(v)
+	urlErr := pflagValueFuncMap[urlFlag]().Set(v)
+	if urlErr == nil {
+		return nil
+	}
+	// Neither a readable file nor a valid URL. Return the error for whichever
+	// the input was most likely intended to be, so the message is actionable:
+	// a value with an http(s) scheme is treated as a URL, anything else as a
+	// file path. Previously the file error (e.g. "no such file or directory")
+	// was always masked by the "is not a valid url" error.
+	if strings.HasPrefix(v, "http://") || strings.HasPrefix(v, "https://") {
+		return urlErr
+	}
+	return fileErr
 }
 
 // validateID ensures the ID is either an EntryID (TreeID + UUID) or a UUID

--- a/cmd/rekor-cli/app/pflags_test.go
+++ b/cmd/rekor-cli/app/pflags_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -923,6 +924,37 @@ func TestParseTypeFlag(t *testing.T) {
 	for _, tc := range tests {
 		if _, _, err := ParseTypeFlag(tc.typeStr); (err == nil) != tc.expectSuccess {
 			t.Fatalf("unexpected error parsing type flag in '%v': %v", tc.caseDesc, err)
+		}
+	}
+}
+
+func TestValidateFileOrURL(t *testing.T) {
+	tests := []struct {
+		caseDesc  string
+		value     string
+		expectErr bool
+		errSubstr string
+	}{
+		{caseDesc: "valid local file", value: "tests/test_file.txt", expectErr: false},
+		{caseDesc: "valid https url", value: "https://example.com/artifact", expectErr: false},
+		{caseDesc: "missing file reports the file error, not the url error", value: "tests/not_a_file", expectErr: true, errSubstr: "not_a_file"},
+		{caseDesc: "malformed http url reports the url error", value: "http://", expectErr: true, errSubstr: "is not a valid url"},
+	}
+	for _, tc := range tests {
+		err := validateFileOrURL(tc.value)
+		if tc.expectErr {
+			if err == nil {
+				t.Errorf("%s: expected an error, got nil", tc.caseDesc)
+				continue
+			}
+			if tc.errSubstr != "" && !strings.Contains(err.Error(), tc.errSubstr) {
+				t.Errorf("%s: expected error containing %q, got %q", tc.caseDesc, tc.errSubstr, err.Error())
+			}
+			if !strings.HasPrefix(tc.value, "http") && strings.Contains(err.Error(), "is not a valid url") {
+				t.Errorf("%s: file error was masked by the url error: %q", tc.caseDesc, err.Error())
+			}
+		} else if err != nil {
+			t.Errorf("%s: expected no error, got %q", tc.caseDesc, err.Error())
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the misleading error reported in #2138. When `--artifact` (or `--entry`) is given a path to a file that does not exist, `rekor-cli` prints:

```
'tests/not_a_file' is not a valid url
```

instead of the real reason (`stat tests/not_a_file: no such file or directory`).

## Cause

`validateFileOrURL` validated the value as a file, and on failure fell through to URL validation and returned **only the URL error**, masking the file error:

```go
valGen := pflagValueFuncMap[fileFlag]
if valGen().Set(v) == nil {
    return nil
}
valGen = pflagValueFuncMap[urlFlag]
return valGen().Set(v)   // file error is lost
```

This matches the maintainer's note on the issue that the message is incorrectly printed when the argument does not exist.

## Change

If the value is neither a readable file nor a valid URL, return the error for whichever it was most likely intended to be: values with an `http(s)://` scheme return the URL error, everything else returns the file error. Valid-file and valid-URL inputs behave exactly as before.

Scope note: this addresses the confirmed missing-file case. The issue also mentioned the error appearing for an existing file, which the maintainer could not reproduce, so that is intentionally left out of scope.

## Testing

Adds `TestValidateFileOrURL` covering a valid file, a valid https URL, a missing file (asserts the file error is surfaced and not masked), and a malformed http URL. `go test ./cmd/rekor-cli/app/...` and `go vet` pass.