### PR TITLE
optimize DSSE memory and cpu while parsing and verifying envs

### DIFF
--- a/pkg/types/dsse/v0.0.1/benchmark_test.go
+++ b/pkg/types/dsse/v0.0.1/benchmark_test.go
@@ -16,11 +16,31 @@
 package dsse
 
 import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	cryptox509 "crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
 	"testing"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag/conv"
+	"github.com/in-toto/in-toto-golang/in_toto"
+	ssldsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
 	"github.com/sigstore/rekor/pkg/generated/models"
+	rekorx509 "github.com/sigstore/rekor/pkg/pki/x509"
 	"github.com/sigstore/rekor/pkg/types"
+	"github.com/sigstore/sigstore/pkg/signature"
+	sigdsse "github.com/sigstore/sigstore/pkg/signature/dsse"
 )
 
 // Sample test data for benchmarking - using proper base64 signatures that match the regex
@@ -100,4 +120,271 @@ func BenchmarkDecodeEntryDirectMemory(b *testing.B) {
 			b.Fatalf("DecodeEntryDirect failed: %v", err)
 		}
 	}
+}
+
+var benchmarkUnmarshalEntrySink *V001Entry
+
+func BenchmarkV001EntryUnmarshal(b *testing.B) {
+	for _, payloadSize := range []int{256 * 1024, 1024 * 1024, 32 * 1024 * 1024} {
+		payloadSize := payloadSize
+		b.Run(strconv.Itoa(payloadSize)+"B", func(b *testing.B) {
+			pe := benchmarkProposedEntry(b, payloadSize)
+
+			b.Run("BeforeVerifyAndDecode", func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					entry := &V001Entry{}
+					if err := benchmarkUnmarshalBefore(entry, pe); err != nil {
+						b.Fatalf("benchmarkUnmarshalBefore failed: %v", err)
+					}
+					benchmarkUnmarshalEntrySink = entry
+				}
+			})
+
+			b.Run("AfterVerifyAndDecode", func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					entry := &V001Entry{}
+					if err := entry.Unmarshal(pe); err != nil {
+						b.Fatalf("Unmarshal failed: %v", err)
+					}
+					benchmarkUnmarshalEntrySink = entry
+				}
+			})
+		})
+	}
+}
+
+func benchmarkProposedEntry(tb testing.TB, payloadSize int) models.ProposedEntry {
+	tb.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	der, err := cryptox509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	pub := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
+
+	payload, err := json.Marshal(map[string]any{
+		"_type": "https://in-toto.io/Statement/v0.1",
+		"subject": []map[string]any{
+			{
+				"name": "artifact.tar.gz",
+				"digest": map[string]string{
+					"sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				},
+			},
+		},
+		"predicateType": "https://slsa.dev/provenance/v0.2",
+		"predicate": map[string]any{
+			"materials": []map[string]any{
+				{
+					"uri": "git+https://github.com/sigstore/rekor",
+					"digest": map[string]string{
+						"sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+					},
+				},
+			},
+			"buildConfig": string(bytes.Repeat([]byte("x"), payloadSize)),
+		},
+	})
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	env := benchmarkEnvelope(tb, key, payload)
+	return &models.DSSE{
+		APIVersion: conv.Pointer(APIVERSION),
+		Spec: &models.DSSEV001Schema{
+			ProposedContent: createRekorEnvelope(env, [][]byte{pub}),
+		},
+	}
+}
+
+func benchmarkEnvelope(tb testing.TB, key *ecdsa.PrivateKey, payload []byte) *ssldsse.Envelope {
+	tb.Helper()
+
+	s, err := signature.LoadECDSASigner(key, crypto.SHA256)
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	signer, err := ssldsse.NewEnvelopeSigner(&sigdsse.SignerAdapter{SignatureSigner: s})
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	env, err := signer.SignPayload(context.Background(), in_toto.PayloadType, payload)
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	return env
+}
+
+func benchmarkUnmarshalBefore(v *V001Entry, pe models.ProposedEntry) error {
+	it, ok := pe.(*models.DSSE)
+	if !ok {
+		return errors.New("cannot unmarshal non DSSE v0.0.1 type")
+	}
+
+	dsseObj := &models.DSSEV001Schema{}
+	if err := DecodeEntry(it.Spec, dsseObj); err != nil {
+		return err
+	}
+
+	if err := dsseObj.Validate(strfmt.Default); err != nil {
+		return err
+	}
+
+	if dsseObj.ProposedContent == nil {
+		if dsseObj.EnvelopeHash == nil || dsseObj.PayloadHash == nil || len(dsseObj.Signatures) == 0 {
+			return errors.New("either proposedContent or envelopeHash, payloadHash, and signatures must be present")
+		}
+		v.DSSEObj = *dsseObj
+		return nil
+	}
+
+	if dsseObj.EnvelopeHash != nil || dsseObj.PayloadHash != nil || len(dsseObj.Signatures) != 0 {
+		return errors.New("either proposedContent or envelopeHash, payloadHash, and signatures must be present but not both")
+	}
+
+	env := &ssldsse.Envelope{}
+	if dsseObj.ProposedContent.Envelope == nil {
+		return errors.New("proposed content envelope is missing")
+	}
+	if err := json.Unmarshal([]byte(*dsseObj.ProposedContent.Envelope), env); err != nil {
+		return err
+	}
+
+	if len(env.Signatures) == 0 {
+		return errors.New("DSSE envelope must contain 1 or more signatures")
+	}
+
+	allPubKeyBytes := make([][]byte, 0, len(dsseObj.ProposedContent.Verifiers))
+	for _, publicKey := range dsseObj.ProposedContent.Verifiers {
+		if publicKey == nil {
+			return errors.New("an invalid null verifier was provided in ProposedContent")
+		}
+		allPubKeyBytes = append(allPubKeyBytes, publicKey)
+	}
+
+	sigToKeyMap, decodedPayload, err := benchmarkVerifyEnvelopeBefore(allPubKeyBytes, env)
+	if err != nil {
+		return err
+	}
+
+	sortedSigs := make([]string, 0, len(sigToKeyMap))
+	for sig := range sigToKeyMap {
+		sortedSigs = append(sortedSigs, sig)
+	}
+	sort.Strings(sortedSigs)
+
+	for i, sig := range sortedSigs {
+		key := sigToKeyMap[sig]
+		canonicalizedKey, err := key.CanonicalValue()
+		if err != nil {
+			return err
+		}
+		b64CanonicalizedKey := strfmt.Base64(canonicalizedKey)
+		dsseObj.Signatures = append(dsseObj.Signatures, &models.DSSEV001SchemaSignaturesItems0{
+			Signature: &sortedSigs[i],
+			Verifier:  &b64CanonicalizedKey,
+		})
+	}
+
+	if env.PayloadType == in_toto.PayloadType {
+		var extract indexKeyExtract
+		if err := json.Unmarshal(decodedPayload, &extract); err == nil {
+			for _, s := range extract.Subject {
+				for alg, ds := range s.Digest {
+					v.extractedIndexKeys = append(v.extractedIndexKeys, alg+":"+ds)
+				}
+			}
+			if extract.Predicate != nil {
+				var materials materialsExtract
+				if err := json.Unmarshal(extract.Predicate, &materials); err == nil {
+					for _, m := range materials.Materials {
+						for alg, ds := range m.Digest {
+							v.extractedIndexKeys = append(v.extractedIndexKeys, alg+":"+ds)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	payloadHash := sha256.Sum256(decodedPayload)
+	dsseObj.PayloadHash = &models.DSSEV001SchemaPayloadHash{
+		Algorithm: conv.Pointer(models.DSSEV001SchemaPayloadHashAlgorithmSha256),
+		Value:     conv.Pointer(fmt.Sprintf("%x", payloadHash[:])),
+	}
+
+	envelopeHash := sha256.Sum256([]byte(*dsseObj.ProposedContent.Envelope))
+	dsseObj.EnvelopeHash = &models.DSSEV001SchemaEnvelopeHash{
+		Algorithm: conv.Pointer(models.DSSEV001SchemaEnvelopeHashAlgorithmSha256),
+		Value:     conv.Pointer(fmt.Sprintf("%x", envelopeHash[:])),
+	}
+
+	v.DSSEObj = *dsseObj
+	v.env = env
+	v.isInsertable = true
+	v.env.Payload = ""
+	v.DSSEObj.ProposedContent = nil
+
+	return nil
+}
+
+func benchmarkVerifyEnvelopeBefore(allPubKeyBytes [][]byte, env *ssldsse.Envelope) (map[string]*rekorx509.PublicKey, []byte, error) {
+	verifierBySig := make(map[string]*rekorx509.PublicKey)
+	allSigs := make(map[string]struct{}, len(env.Signatures))
+	for _, sig := range env.Signatures {
+		allSigs[sig.Sig] = struct{}{}
+	}
+
+	for _, pubKeyBytes := range allPubKeyBytes {
+		if len(allSigs) == 0 {
+			break
+		}
+
+		key, err := rekorx509.NewPublicKey(bytes.NewReader(pubKeyBytes))
+		if err != nil {
+			return nil, nil, fmt.Errorf("could not parse public key as x509: %w", err)
+		}
+
+		vfr, err := signature.LoadVerifier(key.CryptoPubKey(), crypto.SHA256)
+		if err != nil {
+			return nil, nil, fmt.Errorf("could not load verifier: %w", err)
+		}
+
+		dsseVfr, err := ssldsse.NewEnvelopeVerifier(&sigdsse.VerifierAdapter{SignatureVerifier: vfr})
+		if err != nil {
+			return nil, nil, fmt.Errorf("could not use public key as a dsse verifier: %w", err)
+		}
+
+		accepted, err := dsseVfr.Verify(context.Background(), env)
+		if err != nil {
+			return nil, nil, fmt.Errorf("could not verify envelope: %w", err)
+		}
+
+		for _, accept := range accepted {
+			delete(allSigs, accept.Sig.Sig)
+			verifierBySig[accept.Sig.Sig] = key
+		}
+	}
+
+	if len(allSigs) > 0 {
+		return nil, nil, errors.New("all signatures must have a key that verifies it")
+	}
+
+	decodedPayload, err := env.DecodeB64Payload()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return verifierBySig, decodedPayload, nil
 }

--- a/pkg/types/dsse/v0.0.1/entry.go
+++ b/pkg/types/dsse/v0.0.1/entry.go
@@ -311,8 +311,6 @@ func (v *V001Entry) Unmarshal(pe models.ProposedEntry) error {
 		})
 	}
 
-
-
 	// extraction of index keys - done here so we can clear the huge strings from memory
 	if env.PayloadType == in_toto.PayloadType {
 		var extract indexKeyExtract

--- a/pkg/types/dsse/v0.0.1/entry.go
+++ b/pkg/types/dsse/v0.0.1/entry.go
@@ -285,7 +285,7 @@ func (v *V001Entry) Unmarshal(pe models.ProposedEntry) error {
 		allPubKeyBytes = append(allPubKeyBytes, publicKey)
 	}
 
-	sigToKeyMap, err := verifyEnvelope(allPubKeyBytes, env)
+	sigToKeyMap, decodedPayload, err := verifyEnvelope(allPubKeyBytes, env)
 	if err != nil {
 		return err
 	}
@@ -311,11 +311,7 @@ func (v *V001Entry) Unmarshal(pe models.ProposedEntry) error {
 		})
 	}
 
-	decodedPayload, err := env.DecodeB64Payload()
-	if err != nil {
-		// this shouldn't happen because failure would have occurred in verifyEnvelope call above
-		return err
-	}
+
 
 	// extraction of index keys - done here so we can clear the huge strings from memory
 	if env.PayloadType == in_toto.PayloadType {
@@ -442,7 +438,7 @@ func (v V001Entry) CreateFromArtifactProperties(_ context.Context, props types.A
 		}
 	}
 
-	keysBySig, err := verifyEnvelope(allPubKeyBytes, env)
+	keysBySig, _, err := verifyEnvelope(allPubKeyBytes, env)
 	if err != nil {
 		return nil, err
 	}
@@ -464,7 +460,7 @@ func (v V001Entry) CreateFromArtifactProperties(_ context.Context, props types.A
 // verifyEnvelope takes in an array of possible key bytes and attempts to parse them as x509 public keys.
 // it then uses these to verify the envelope and makes sure that every signature on the envelope is verified.
 // it returns a map of verifiers indexed by the signature the verifier corresponds to.
-func verifyEnvelope(allPubKeyBytes [][]byte, env *dsse.Envelope) (map[string]*x509.PublicKey, error) {
+func verifyEnvelope(allPubKeyBytes [][]byte, env *dsse.Envelope) (map[string]*x509.PublicKey, []byte, error) {
 	// generate a fake id for these keys so we can get back to the key bytes and match them to their corresponding signature
 	verifierBySig := make(map[string]*x509.PublicKey)
 	allSigs := make(map[string]struct{})
@@ -472,28 +468,33 @@ func verifyEnvelope(allPubKeyBytes [][]byte, env *dsse.Envelope) (map[string]*x5
 		allSigs[sig.Sig] = struct{}{}
 	}
 
+	var verifiedPayload []byte
 	for _, pubKeyBytes := range allPubKeyBytes {
 		if len(allSigs) == 0 {
 			break // if all signatures have been verified, do not attempt anymore
 		}
 		key, err := x509.NewPublicKey(bytes.NewReader(pubKeyBytes))
 		if err != nil {
-			return nil, fmt.Errorf("could not parse public key as x509: %w", err)
+			return nil, nil, fmt.Errorf("could not parse public key as x509: %w", err)
 		}
 
 		vfr, err := signature.LoadVerifier(key.CryptoPubKey(), crypto.SHA256)
 		if err != nil {
-			return nil, fmt.Errorf("could not load verifier: %w", err)
+			return nil, nil, fmt.Errorf("could not load verifier: %w", err)
 		}
 
 		dsseVfr, err := dsse.NewEnvelopeVerifier(&sigdsse.VerifierAdapter{SignatureVerifier: vfr})
 		if err != nil {
-			return nil, fmt.Errorf("could not use public key as a dsse verifier: %w", err)
+			return nil, nil, fmt.Errorf("could not use public key as a dsse verifier: %w", err)
 		}
 
-		accepted, err := dsseVfr.Verify(context.Background(), env)
+		accepted, payload, err := dsseVfr.VerifyAndDecode(context.Background(), env)
 		if err != nil {
-			return nil, fmt.Errorf("could not verify envelope: %w", err)
+			return nil, nil, fmt.Errorf("could not verify envelope: %w", err)
+		}
+
+		if len(accepted) > 0 {
+			verifiedPayload = payload
 		}
 
 		for _, accept := range accepted {
@@ -503,10 +504,10 @@ func verifyEnvelope(allPubKeyBytes [][]byte, env *dsse.Envelope) (map[string]*x5
 	}
 
 	if len(allSigs) > 0 {
-		return nil, errors.New("all signatures must have a key that verifies it")
+		return nil, nil, errors.New("all signatures must have a key that verifies it")
 	}
 
-	return verifierBySig, nil
+	return verifierBySig, verifiedPayload, nil
 }
 
 func (v V001Entry) Verifiers() ([]pkitypes.PublicKey, error) {


### PR DESCRIPTION
Leverages the improvements from https://github.com/sigstore/sigstore/pull/2326 and https://github.com/secure-systems-lab/go-securesystemslib/commit/e06bffc452b39d9a142602af3464162900088221

The VerifyAndDecode integration consistently reduces CPU by about 3-4.5%, memory by about 12.5%, and allocations by 4-34 allocs/op, with the absolute memory savings growing significantly as envelope size increases - details from attached benchmarks:

| DSSE payload | Metric | Before | After | Improvement |
| --- | --- | ---: | ---: | ---: |
| 256 KB | CPU (`ns/op`) | 2,820,916 | 2,695,087 | 4.46% faster |
| 256 KB | Memory (`B/op`) | 2,150,049 | 1,879,442 | 12.59% lower |
| 256 KB | Allocs (`allocs/op`) | 163 | 159 | 4 fewer, 2.45% lower |
| 1 MB | CPU (`ns/op`) | 10,671,560 | 10,325,926 | 3.24% faster |
| 1 MB | Memory (`B/op`) | 8,442,506 | 7,384,813 | 12.53% lower |
| 1 MB | Allocs (`allocs/op`) | 165 | 160 | 5 fewer, 3.03% lower |
| 32 MB | CPU (`ns/op`) | 344,043,500 | 333,368,486 | 3.10% faster |
| 32 MB | Memory (`B/op`) | 268,500,349 | 234,935,832 | 12.50% lower |
| 32 MB | Allocs (`allocs/op`) | 197 | 163 | 34 fewer, 17.26% lower |