### PR TITLE
minimize duplicative JSON parsing while handling entries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ all: rekor-cli rekor-server ## Build all binaries (rekor-cli and rekor-server)
 
 include Makefile.swagger
 
-OPENAPIDEPS = openapi.yaml $(shell find pkg/types -iname "*.json")
+SWAGGER_TEMPLATE_DIR := hack/swagger-templates
+OPENAPIDEPS = openapi.yaml $(shell find pkg/types -iname "*.json") $(shell find $(SWAGGER_TEMPLATE_DIR) -iname "*.gotmpl")
 SRCS = $(shell find cmd -iname "*.go") $(shell find pkg -iname "*.go"|grep -v pkg/generated) pkg/generated/restapi/configure_rekor_server.go $(SWAGGER_GEN)
 TOOLS_DIR := hack/tools
 TOOLS_BIN_DIR := $(abspath $(TOOLS_DIR)/bin)
@@ -65,10 +66,10 @@ SERVER_LDFLAGS=$(REKOR_LDFLAGS)
 
 Makefile.swagger: $(SWAGGER) $(OPENAPIDEPS) ## Generate Swagger code and Makefile
 	$(SWAGGER) validate openapi.yaml
-	$(SWAGGER) generate client -f openapi.yaml -q -r COPYRIGHT.txt -t pkg/generated --additional-initialism=TUF --additional-initialism=DSSE
-	$(SWAGGER) generate server -f openapi.yaml -q -r COPYRIGHT.txt -t pkg/generated --exclude-main -A rekor_server --flag-strategy=pflag --default-produces application/json --additional-initialism=TUF --additional-initialism=DSSE
+	$(SWAGGER) generate client -f openapi.yaml -q -r COPYRIGHT.txt -t pkg/generated -T $(SWAGGER_TEMPLATE_DIR) --allow-template-override --additional-initialism=TUF --additional-initialism=DSSE
+	$(SWAGGER) generate server -f openapi.yaml -q -r COPYRIGHT.txt -t pkg/generated -T $(SWAGGER_TEMPLATE_DIR) --allow-template-override --exclude-main -A rekor_server --flag-strategy=pflag --default-produces application/json --additional-initialism=TUF --additional-initialism=DSSE
 	@echo "# This file is generated after swagger runs as part of the build; do not edit!" > Makefile.swagger
-	@echo "SWAGGER_GEN=`find pkg/generated/client pkg/generated/models pkg/generated/restapi -iname '*.go' | grep -v 'configure_rekor_server' | sort -d | tr '\n' ' ' | sed 's/ $$//'`" >> Makefile.swagger;
+	@echo "SWAGGER_GEN=`find pkg/generated/client pkg/generated/models pkg/generated/restapi -iname '*.go' ! -iname '*_test.go' | grep -v 'configure_rekor_server' | sort -d | tr '\n' ' ' | sed 's/ $$//'`" >> Makefile.swagger;
 
 lint: ## Run golangci-lint checks
 	$(GOBIN)/golangci-lint run -v ./...

--- a/hack/swagger-templates/serializers/basetypeserializer.gotmpl
+++ b/hack/swagger-templates/serializers/basetypeserializer.gotmpl
@@ -1,0 +1,118 @@
+{{ define "polymorphicSerializer" }}
+// Unmarshal{{ pascalize .Name }}Slice unmarshals polymorphic slices of {{ pascalize .Name }}
+func Unmarshal{{ pascalize .Name }}Slice(reader io.Reader, consumer runtime.Consumer) ([]{{ pascalize .Name }}, error) {
+  var elements []json.RawMessage
+  if err := consumer.Consume(reader, &elements); err != nil {
+    return nil, err
+  }
+
+  var result []{{ pascalize .Name }}
+  for _, element := range elements {
+    obj, err := unmarshal{{ pascalize .Name }}(element, consumer)
+    if err != nil {
+      return nil, err
+    }
+    result = append(result, obj)
+  }
+  return result, nil
+}
+
+// Unmarshal{{ pascalize .Name }} unmarshals polymorphic {{ pascalize .Name }}
+func Unmarshal{{ pascalize .Name }}(reader io.Reader, {{ if eq (pascalize .Name) "ProposedEntry" }}_{{ else }}consumer{{ end }} runtime.Consumer) ({{ pascalize .Name }}, error) {
+  {{- if eq (pascalize .Name) "ProposedEntry" }}
+  return fastUnmarshalTargeted{{ pascalize .Name }}Reader(reader)
+  {{- else }}
+  // we need to read this twice, so first into a buffer
+  data, err := io.ReadAll(reader)
+  if err != nil {
+    return nil, err
+  }
+  return unmarshal{{ pascalize .Name }}(data, consumer)
+  {{ end }}
+}
+
+{{ if eq (pascalize .Name) "ProposedEntry" }}
+type targeted{{ pascalize .Name }} struct {
+  {{ pascalize .DiscriminatorField }} string `json:{{ printf "%q" .DiscriminatorField }}`
+  APIVersion *string `json:"apiVersion"`
+  Spec any `json:"spec"`
+}
+
+func fastUnmarshalTargeted{{ pascalize .Name }}Reader(reader io.Reader) ({{ pascalize .Name }}, error) {
+  var parsed targeted{{ pascalize .Name }}
+  dec := json.NewDecoder(reader)
+  dec.UseNumber()
+
+  if err := dec.Decode(&parsed); err != nil {
+    return nil, err
+  }
+
+  if err := validate.RequiredString({{ printf "%q" .DiscriminatorField }}, "body", parsed.{{ pascalize .DiscriminatorField }}); err != nil {
+    return nil, err
+  }
+
+  switch parsed.{{ pascalize .DiscriminatorField }} {
+  {{- range $k, $v := .Discriminates }}
+  case {{ printf "%q" $k }}:
+    {{- if eq (upper (pascalize $.Name)) (upper $v) }}
+    return &{{ camelize $.Name }}{kindField: parsed.{{ pascalize $.DiscriminatorField }}}, nil
+    {{- else }}
+    return &{{ $v }}{APIVersion: parsed.APIVersion, Spec: parsed.Spec}, nil
+    {{- end }}
+  {{- end }}
+  default:
+    return nil, errors.New(422, "invalid {{ .DiscriminatorField }} value: %q", parsed.{{ pascalize .DiscriminatorField }})
+  }
+}
+
+func fastUnmarshalTargeted{{ pascalize .Name }}(data []byte) ({{ pascalize .Name }}, error) {
+  return fastUnmarshalTargeted{{ pascalize .Name }}Reader(bytes.NewReader(data))
+}
+{{ end }}
+
+func unmarshal{{ pascalize .Name }}(data []byte, {{ if eq (pascalize .Name) "ProposedEntry" }}_{{ else }}consumer{{ end }} runtime.Consumer) ({{ pascalize .Name }}, error) {
+  {{- if eq (pascalize .Name) "ProposedEntry" }}
+  return fastUnmarshalTargeted{{ pascalize .Name }}(data)
+  {{- end }}
+
+  {{- if ne (pascalize .Name) "ProposedEntry" }}
+  buf := bytes.NewBuffer(data)
+  {{ if .Discriminates }} buf2 := bytes.NewBuffer(data) {{ end }}
+
+  // the first time this is read is to fetch the value of the {{ .DiscriminatorField }} property.
+  var getType struct { {{ pascalize .DiscriminatorField }} string `json:{{ printf "%q" .DiscriminatorField }}` }
+  if err := consumer.Consume(buf, &getType); err != nil {
+    return nil, err
+  }
+
+  if err := validate.RequiredString({{ printf "%q" .DiscriminatorField }}, "body", getType.{{ pascalize .DiscriminatorField }}); err != nil {
+    return nil, err
+  }
+
+  // The value of {{ .DiscriminatorField }} is used to determine which type to create and unmarshal the data into
+  switch getType.{{ pascalize .DiscriminatorField }} {
+    {{- range $k, $v := .Discriminates }}
+    case {{ printf "%q" $k }}:
+      var result {{ if eq (upper (pascalize $.Name)) (upper $v) }}{{ camelize $.Name }}{{ else }}{{ $v }}{{ end }}
+      if err := consumer.Consume(buf2, &result); err != nil {
+        return nil, err
+      }
+      return &result, nil
+    {{- end }}
+  }
+  return nil, errors.New(422, "invalid {{ .DiscriminatorField }} value: %q", getType.{{ pascalize .DiscriminatorField }})
+  {{- end }}
+}
+{{- end }}
+
+{{ define "baseTypeSerializer" }}
+// Unmarshal{{ pascalize .Name }} unmarshals polymorphic {{ pascalize .Name }}
+func Unmarshal{{ pascalize .Name }}(reader io.Reader, consumer runtime.Consumer) ({{ pascalize .Name }}, error) {
+  return Unmarshal{{ pascalize .GoType }}(reader, consumer)
+}
+
+// Unmarshal{{ pascalize .Name }}Slice unmarshals polymorphic slices of {{ pascalize .Name }}
+func Unmarshal{{ pascalize .Name }}Slice(reader io.Reader, consumer runtime.Consumer) ([]{{ pascalize .Name }}, error) {
+  return Unmarshal{{ pascalize .GoType }}Slice(reader, consumer)
+}
+{{- end }}

--- a/pkg/generated/models/proposed_entry.go
+++ b/pkg/generated/models/proposed_entry.go
@@ -78,107 +78,65 @@ func UnmarshalProposedEntrySlice(reader io.Reader, consumer runtime.Consumer) ([
 }
 
 // UnmarshalProposedEntry unmarshals polymorphic ProposedEntry
-func UnmarshalProposedEntry(reader io.Reader, consumer runtime.Consumer) (ProposedEntry, error) {
-	// we need to read this twice, so first into a buffer
-	data, err := io.ReadAll(reader)
-	if err != nil {
-		return nil, err
-	}
-	return unmarshalProposedEntry(data, consumer)
+func UnmarshalProposedEntry(reader io.Reader, _ runtime.Consumer) (ProposedEntry, error) {
+	return fastUnmarshalTargetedProposedEntryReader(reader)
 }
 
-func unmarshalProposedEntry(data []byte, consumer runtime.Consumer) (ProposedEntry, error) {
-	buf := bytes.NewBuffer(data)
-	buf2 := bytes.NewBuffer(data)
+type targetedProposedEntry struct {
+	Kind       string  `json:"kind"`
+	APIVersion *string `json:"apiVersion"`
+	Spec       any     `json:"spec"`
+}
 
-	// the first time this is read is to fetch the value of the kind property.
-	var getType struct {
-		Kind string `json:"kind"`
-	}
-	if err := consumer.Consume(buf, &getType); err != nil {
+func fastUnmarshalTargetedProposedEntryReader(reader io.Reader) (ProposedEntry, error) {
+	var parsed targetedProposedEntry
+	dec := json.NewDecoder(reader)
+	dec.UseNumber()
+
+	if err := dec.Decode(&parsed); err != nil {
 		return nil, err
 	}
 
-	if err := validate.RequiredString("kind", "body", getType.Kind); err != nil {
+	if err := validate.RequiredString("kind", "body", parsed.Kind); err != nil {
 		return nil, err
 	}
 
-	// The value of kind is used to determine which type to create and unmarshal the data into
-	switch getType.Kind {
+	switch parsed.Kind {
 	case "ProposedEntry":
-		var result proposedEntry
-		if err := consumer.Consume(buf2, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
+		return &proposedEntry{kindField: parsed.Kind}, nil
 	case "alpine":
-		var result Alpine
-		if err := consumer.Consume(buf2, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
+		return &Alpine{APIVersion: parsed.APIVersion, Spec: parsed.Spec}, nil
 	case "cose":
-		var result Cose
-		if err := consumer.Consume(buf2, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
+		return &Cose{APIVersion: parsed.APIVersion, Spec: parsed.Spec}, nil
 	case "dsse":
-		var result DSSE
-		if err := consumer.Consume(buf2, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
+		return &DSSE{APIVersion: parsed.APIVersion, Spec: parsed.Spec}, nil
 	case "hashedrekord":
-		var result Hashedrekord
-		if err := consumer.Consume(buf2, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
+		return &Hashedrekord{APIVersion: parsed.APIVersion, Spec: parsed.Spec}, nil
 	case "helm":
-		var result Helm
-		if err := consumer.Consume(buf2, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
+		return &Helm{APIVersion: parsed.APIVersion, Spec: parsed.Spec}, nil
 	case "intoto":
-		var result Intoto
-		if err := consumer.Consume(buf2, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
+		return &Intoto{APIVersion: parsed.APIVersion, Spec: parsed.Spec}, nil
 	case "jar":
-		var result Jar
-		if err := consumer.Consume(buf2, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
+		return &Jar{APIVersion: parsed.APIVersion, Spec: parsed.Spec}, nil
 	case "rekord":
-		var result Rekord
-		if err := consumer.Consume(buf2, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
+		return &Rekord{APIVersion: parsed.APIVersion, Spec: parsed.Spec}, nil
 	case "rfc3161":
-		var result Rfc3161
-		if err := consumer.Consume(buf2, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
+		return &Rfc3161{APIVersion: parsed.APIVersion, Spec: parsed.Spec}, nil
 	case "rpm":
-		var result Rpm
-		if err := consumer.Consume(buf2, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
+		return &Rpm{APIVersion: parsed.APIVersion, Spec: parsed.Spec}, nil
 	case "tuf":
-		var result TUF
-		if err := consumer.Consume(buf2, &result); err != nil {
-			return nil, err
-		}
-		return &result, nil
+		return &TUF{APIVersion: parsed.APIVersion, Spec: parsed.Spec}, nil
+	default:
+		return nil, errors.New(422, "invalid kind value: %q", parsed.Kind)
 	}
-	return nil, errors.New(422, "invalid kind value: %q", getType.Kind)
+}
+
+func fastUnmarshalTargetedProposedEntry(data []byte) (ProposedEntry, error) {
+	return fastUnmarshalTargetedProposedEntryReader(bytes.NewReader(data))
+}
+
+func unmarshalProposedEntry(data []byte, _ runtime.Consumer) (ProposedEntry, error) {
+	return fastUnmarshalTargetedProposedEntry(data)
 }
 
 // Validate validates this proposed entry

--- a/pkg/generated/models/proposed_entry_benchmark_test.go
+++ b/pkg/generated/models/proposed_entry_benchmark_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package models
 
 import (

--- a/pkg/generated/models/proposed_entry_benchmark_test.go
+++ b/pkg/generated/models/proposed_entry_benchmark_test.go
@@ -1,0 +1,79 @@
+package models
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/json"
+	"testing"
+
+	"github.com/go-openapi/runtime"
+)
+
+// Real ProposedEntry fixtures constructed from checked-in test inputs:
+//
+//	dsse.json         — wraps tests/intoto_dsse.json (a real signed DSSE
+//	                    envelope) as a ProposedEntry with the matching
+//	                    verifier from tests/intoto_dsse.pem.
+//	hashedrekord.json — real ECDSA signature + PEM from
+//	                    pkg/pki/x509/testdata/ over hello_world.txt.
+//	intoto.json       — same DSSE envelope wrapped in intoto v0.0.2 shape
+//	                    with real envelope hash + PEM.
+//
+//go:embed testdata/dsse.json
+var realDSSEBody []byte
+
+//go:embed testdata/hashedrekord.json
+var realHashedRekordBody []byte
+
+//go:embed testdata/intoto.json
+var realIntotoBody []byte
+
+var benchmarkProposedEntrySink ProposedEntry
+
+func BenchmarkUnmarshalProposedEntry(b *testing.B) {
+	cases := []struct {
+		name    string
+		body    []byte
+		wantErr bool
+	}{
+		{"dsse", realDSSEBody, false},
+		{"hashedrekord", realHashedRekordBody, false},
+		{"intoto", realIntotoBody, false},
+		{"unknown_kind", unknownKindBody(b), true},
+	}
+
+	consumer := runtime.JSONConsumer()
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(tc.body)))
+			for b.Loop() {
+				pe, err := UnmarshalProposedEntry(bytes.NewReader(tc.body), consumer)
+				if tc.wantErr {
+					if err == nil {
+						b.Fatalf("expected error, got %#v", pe)
+					}
+					continue
+				}
+				if err != nil {
+					b.Fatalf("UnmarshalProposedEntry failed: %v", err)
+				}
+				benchmarkProposedEntrySink = pe
+			}
+		})
+	}
+}
+
+func unknownKindBody(b *testing.B) []byte {
+	b.Helper()
+	body, err := json.Marshal(map[string]any{
+		"kind":       "not-a-real-kind",
+		"apiVersion": "0.0.1",
+		"spec":       map[string]any{},
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	return body
+}

--- a/pkg/generated/models/proposed_entry_large_benchmark_test.go
+++ b/pkg/generated/models/proposed_entry_large_benchmark_test.go
@@ -1,3 +1,19 @@
+//
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package models
 
 import (

--- a/pkg/generated/models/proposed_entry_large_benchmark_test.go
+++ b/pkg/generated/models/proposed_entry_large_benchmark_test.go
@@ -1,0 +1,316 @@
+package models
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	cryptox509 "crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/go-openapi/runtime"
+	"github.com/in-toto/in-toto-golang/in_toto"
+	ssldsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
+	"github.com/sigstore/sigstore/pkg/signature"
+	sigdsse "github.com/sigstore/sigstore/pkg/signature/dsse"
+)
+
+// BenchmarkUnmarshalProposedEntryLarge exercises the unmarshal path with real,
+// ECDSA-signed DSSE envelopes wrapping an in-toto Statement whose predicate
+// carries a large opaque field. The same underlying signed envelope is wrapped
+// two ways so DSSE and intoto v0.0.2 can be compared apples-to-apples.
+//
+// Sizes below refer to the raw predicate opaque field; the resulting
+// ProposedEntry JSON is larger due to base64 inflation of the envelope +
+// verifier PEM. Only DSSE and intoto v0.0.2 vary in size — hashedrekord bodies
+// are always tiny in production (real ECDSA sigs are ~72 B), so hashedrekord
+// gets a single realistic case built with a genuine ECDSA-P256 signature.
+// Fixtures are generated once per process at first use.
+func BenchmarkUnmarshalProposedEntryLarge(b *testing.B) {
+	sizes := []int{256 * 1024, 1024 * 1024, 32 * 1024 * 1024}
+	consumer := runtime.JSONConsumer()
+
+	for _, sz := range sizes {
+		f := largeFixtureCache.get(b, sz)
+		sizeName := strconv.Itoa(sz) + "B"
+
+		b.Run("dsse/"+sizeName, func(b *testing.B) {
+			runUnmarshalBench(b, f.dsseBody, consumer)
+		})
+
+		b.Run("intoto_v002/"+sizeName, func(b *testing.B) {
+			runUnmarshalBench(b, f.intotoV002Body, consumer)
+		})
+	}
+
+	b.Run("hashedrekord", func(b *testing.B) {
+		runUnmarshalBench(b, hashedRekordFixture(b), consumer)
+	})
+}
+
+func runUnmarshalBench(b *testing.B, body []byte, consumer runtime.Consumer) {
+	b.ReportAllocs()
+	b.SetBytes(int64(len(body)))
+	b.ResetTimer()
+	for b.Loop() {
+		pe, err := UnmarshalProposedEntry(bytes.NewReader(body), consumer)
+		if err != nil {
+			b.Fatalf("UnmarshalProposedEntry failed: %v", err)
+		}
+		benchmarkProposedEntrySink = pe
+	}
+}
+
+// TestLargeSignedProposedEntriesBuild ensures the fixture generators produce
+// ProposedEntries the unmarshal path accepts. Keeps the crypto setup on the
+// tested path so a broken helper doesn't silently no-op the benchmark.
+func TestLargeSignedProposedEntriesBuild(t *testing.T) {
+	f := largeFixtureCache.get(t, 4096)
+
+	for _, tc := range []struct {
+		name     string
+		body     []byte
+		wantKind string
+	}{
+		{"dsse", f.dsseBody, "dsse"},
+		{"intoto_v002", f.intotoV002Body, "intoto"},
+		{"hashedrekord", hashedRekordFixture(t), "hashedrekord"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pe, err := UnmarshalProposedEntry(bytes.NewReader(tc.body), runtime.JSONConsumer())
+			if err != nil {
+				t.Fatalf("UnmarshalProposedEntry: %v", err)
+			}
+			if pe.Kind() != tc.wantKind {
+				t.Fatalf("Kind() = %q, want %q", pe.Kind(), tc.wantKind)
+			}
+		})
+	}
+}
+
+// largeFixture holds a signed DSSE envelope pre-wrapped as two ProposedEntry
+// shapes so DSSE and intoto v0.0.2 benchmarks share the same crypto material.
+type largeFixture struct {
+	dsseBody       []byte
+	intotoV002Body []byte
+}
+
+type fixtureCache struct {
+	mu     sync.Mutex
+	byLen  map[int]*sync.Once
+	values map[int]*largeFixture
+	errs   map[int]error
+}
+
+var largeFixtureCache = &fixtureCache{
+	byLen:  map[int]*sync.Once{},
+	values: map[int]*largeFixture{},
+	errs:   map[int]error{},
+}
+
+func (c *fixtureCache) get(tb testing.TB, sz int) *largeFixture {
+	tb.Helper()
+
+	c.mu.Lock()
+	once, ok := c.byLen[sz]
+	if !ok {
+		once = &sync.Once{}
+		c.byLen[sz] = once
+	}
+	c.mu.Unlock()
+
+	once.Do(func() {
+		f, err := buildLargeFixture(sz)
+		c.mu.Lock()
+		c.values[sz] = f
+		c.errs[sz] = err
+		c.mu.Unlock()
+	})
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err := c.errs[sz]; err != nil {
+		tb.Fatalf("build large fixture (size=%d): %v", sz, err)
+	}
+	return c.values[sz]
+}
+
+func buildLargeFixture(payloadSize int) (*largeFixture, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate ECDSA key: %w", err)
+	}
+	der, err := cryptox509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("marshal PKIX public key: %w", err)
+	}
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
+
+	payload, err := json.Marshal(map[string]any{
+		"_type":         "https://in-toto.io/Statement/v0.1",
+		"predicateType": "https://slsa.dev/provenance/v0.2",
+		"subject": []map[string]any{
+			{
+				"name":   "artifact.tar.gz",
+				"digest": map[string]string{"sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+			},
+		},
+		"predicate": map[string]any{
+			"builder":   map[string]any{"id": "https://github.com/sigstore/rekor/benchmark"},
+			"buildType": "https://example.com/build",
+			"materials": []map[string]any{{
+				"uri":    "git+https://github.com/sigstore/rekor",
+				"digest": map[string]string{"sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+			}},
+			// Opaque field sized to the caller's request; base64-encoding
+			// keeps it a valid JSON string and roughly the requested length.
+			"buildConfig": base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{'x'}, payloadSize)),
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal in-toto statement: %w", err)
+	}
+
+	signer, err := signature.LoadECDSASigner(key, crypto.SHA256)
+	if err != nil {
+		return nil, fmt.Errorf("load ECDSA signer: %w", err)
+	}
+	envSigner, err := ssldsse.NewEnvelopeSigner(&sigdsse.SignerAdapter{SignatureSigner: signer})
+	if err != nil {
+		return nil, fmt.Errorf("new envelope signer: %w", err)
+	}
+	env, err := envSigner.SignPayload(context.Background(), in_toto.PayloadType, payload)
+	if err != nil {
+		return nil, fmt.Errorf("sign payload: %w", err)
+	}
+	envJSON, err := json.Marshal(env)
+	if err != nil {
+		return nil, fmt.Errorf("marshal envelope: %w", err)
+	}
+
+	dsseBody, err := wrapAsDSSEProposedEntry(envJSON, pubPEM)
+	if err != nil {
+		return nil, fmt.Errorf("wrap DSSE: %w", err)
+	}
+	intotoBody, err := wrapAsIntotoV002ProposedEntry(env, envJSON, pubPEM, payload)
+	if err != nil {
+		return nil, fmt.Errorf("wrap intoto v0.0.2: %w", err)
+	}
+
+	return &largeFixture{
+		dsseBody:       dsseBody,
+		intotoV002Body: intotoBody,
+	}, nil
+}
+
+func wrapAsDSSEProposedEntry(envJSON, pubPEM []byte) ([]byte, error) {
+	return json.Marshal(map[string]any{
+		"kind":       "dsse",
+		"apiVersion": "0.0.1",
+		"spec": map[string]any{
+			"proposedContent": map[string]any{
+				"envelope":  string(envJSON),
+				"verifiers": []string{base64.StdEncoding.EncodeToString(pubPEM)},
+			},
+		},
+	})
+}
+
+// wrapAsIntotoV002ProposedEntry produces an intoto v0.0.2 body. Envelope is a
+// nested JSON object (not a string like DSSE), each signature carries a
+// base64-encoded PEM public key, and content includes hash + payloadHash.
+func wrapAsIntotoV002ProposedEntry(env *ssldsse.Envelope, envJSON, pubPEM, payload []byte) ([]byte, error) {
+	sigs := make([]map[string]any, 0, len(env.Signatures))
+	for _, s := range env.Signatures {
+		sigs = append(sigs, map[string]any{
+			"keyid":     s.KeyID,
+			"sig":       s.Sig,
+			"publicKey": base64.StdEncoding.EncodeToString(pubPEM),
+		})
+	}
+	envHash := sha256.Sum256(envJSON)
+	payloadHash := sha256.Sum256(payload)
+	return json.Marshal(map[string]any{
+		"kind":       "intoto",
+		"apiVersion": "0.0.2",
+		"spec": map[string]any{
+			"content": map[string]any{
+				"envelope": map[string]any{
+					"payload":     env.Payload,
+					"payloadType": env.PayloadType,
+					"signatures":  sigs,
+				},
+				"hash":        map[string]any{"algorithm": "sha256", "value": fmt.Sprintf("%x", envHash[:])},
+				"payloadHash": map[string]any{"algorithm": "sha256", "value": fmt.Sprintf("%x", payloadHash[:])},
+			},
+		},
+	})
+}
+
+// hashedRekordFixture returns a ProposedEntry carrying a real ECDSA-P256
+// signature over a small artifact. Produced once per process; body size is
+// whatever a real signature + PEM comes to (~500 B), because hashedrekord
+// payloads don't scale in production.
+func hashedRekordFixture(tb testing.TB) []byte {
+	tb.Helper()
+	hashedRekordOnce.Do(func() {
+		hashedRekordBody, hashedRekordErr = buildHashedRekordFixture()
+	})
+	if hashedRekordErr != nil {
+		tb.Fatalf("build hashedrekord fixture: %v", hashedRekordErr)
+	}
+	return hashedRekordBody
+}
+
+var (
+	hashedRekordOnce sync.Once
+	hashedRekordBody []byte
+	hashedRekordErr  error
+)
+
+func buildHashedRekordFixture() ([]byte, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate ECDSA key: %w", err)
+	}
+	der, err := cryptox509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("marshal PKIX public key: %w", err)
+	}
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
+
+	artifact := []byte("rekor benchmark artifact")
+	sum := sha256.Sum256(artifact)
+	sig, err := ecdsa.SignASN1(rand.Reader, key, sum[:])
+	if err != nil {
+		return nil, fmt.Errorf("sign artifact hash: %w", err)
+	}
+
+	return json.Marshal(map[string]any{
+		"kind":       "hashedrekord",
+		"apiVersion": "0.0.1",
+		"spec": map[string]any{
+			"data": map[string]any{
+				"hash": map[string]any{
+					"algorithm": "sha256",
+					"value":     fmt.Sprintf("%x", sum[:]),
+				},
+			},
+			"signature": map[string]any{
+				"content": base64.StdEncoding.EncodeToString(sig),
+				"publicKey": map[string]any{
+					"content": base64.StdEncoding.EncodeToString(pubPEM),
+				},
+			},
+		},
+	})
+}

--- a/pkg/generated/models/proposed_entry_test.go
+++ b/pkg/generated/models/proposed_entry_test.go
@@ -1,3 +1,19 @@
+//
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package models
 
 import (

--- a/pkg/generated/models/proposed_entry_test.go
+++ b/pkg/generated/models/proposed_entry_test.go
@@ -1,0 +1,255 @@
+package models
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/go-openapi/runtime"
+)
+
+// TestUnmarshalProposedEntry_KnownKinds verifies that every registered kind
+// unmarshals into the correct concrete type with kind/apiVersion/spec preserved.
+func TestUnmarshalProposedEntry_KnownKinds(t *testing.T) {
+	apiVersion := "0.0.1"
+	spec := map[string]any{"data": "value"}
+
+	cases := []struct {
+		kind    string
+		wantPtr any
+	}{
+		{"alpine", (*Alpine)(nil)},
+		{"cose", (*Cose)(nil)},
+		{"dsse", (*DSSE)(nil)},
+		{"hashedrekord", (*Hashedrekord)(nil)},
+		{"helm", (*Helm)(nil)},
+		{"intoto", (*Intoto)(nil)},
+		{"jar", (*Jar)(nil)},
+		{"rekord", (*Rekord)(nil)},
+		{"rfc3161", (*Rfc3161)(nil)},
+		{"rpm", (*Rpm)(nil)},
+		{"tuf", (*TUF)(nil)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.kind, func(t *testing.T) {
+			body := mustMarshal(t, map[string]any{
+				"kind":       tc.kind,
+				"apiVersion": apiVersion,
+				"spec":       spec,
+			})
+
+			pe, err := UnmarshalProposedEntry(bytes.NewReader(body), runtime.JSONConsumer())
+			if err != nil {
+				t.Fatalf("UnmarshalProposedEntry: %v", err)
+			}
+			if pe.Kind() != tc.kind {
+				t.Errorf("Kind() = %q, want %q", pe.Kind(), tc.kind)
+			}
+			if got, want := reflect.TypeOf(pe), reflect.TypeOf(tc.wantPtr); got != want {
+				t.Errorf("concrete type = %v, want %v", got, want)
+			}
+
+			// apiVersion + spec should round-trip via reflection since every
+			// concrete kind has APIVersion *string and Spec any fields.
+			gotAPI := reflect.ValueOf(pe).Elem().FieldByName("APIVersion")
+			if gotAPI.IsNil() || gotAPI.Elem().String() != apiVersion {
+				t.Errorf("APIVersion = %v, want %q", gotAPI, apiVersion)
+			}
+			gotSpec := reflect.ValueOf(pe).Elem().FieldByName("Spec")
+			if !gotSpec.IsValid() || gotSpec.IsZero() {
+				t.Errorf("Spec is zero/invalid")
+			}
+		})
+	}
+}
+
+// TestUnmarshalProposedEntry_ProposedEntryKind covers the "ProposedEntry"
+// discriminator case, which returns the private base type and discards spec.
+func TestUnmarshalProposedEntry_ProposedEntryKind(t *testing.T) {
+	body := mustMarshal(t, map[string]any{
+		"kind":       "ProposedEntry",
+		"apiVersion": "0.0.1",
+		"spec":       map[string]any{"ignored": true},
+	})
+	pe, err := UnmarshalProposedEntry(bytes.NewReader(body), runtime.JSONConsumer())
+	if err != nil {
+		t.Fatalf("UnmarshalProposedEntry: %v", err)
+	}
+	if pe.Kind() != "ProposedEntry" {
+		t.Errorf("Kind() = %q, want %q", pe.Kind(), "ProposedEntry")
+	}
+}
+
+// TestUnmarshalProposedEntry_EquivalenceWithGeneratedUnmarshal proves the fast
+// path returns semantically identical values to invoking the per-kind
+// generated UnmarshalJSON directly. This is the invariant that lets the fast
+// path bypass the two-pass consumer decode.
+func TestUnmarshalProposedEntry_EquivalenceWithGeneratedUnmarshal(t *testing.T) {
+	cases := []struct {
+		name string
+		body []byte
+		fn   func([]byte) (kind string, apiVersion *string, spec any, err error)
+	}{
+		{
+			name: "dsse",
+			body: realDSSEBody,
+			fn: func(body []byte) (string, *string, any, error) {
+				var old DSSE
+				err := json.Unmarshal(body, &old)
+				return old.Kind(), old.APIVersion, old.Spec, err
+			},
+		},
+		{
+			name: "hashedrekord",
+			body: realHashedRekordBody,
+			fn: func(body []byte) (string, *string, any, error) {
+				var old Hashedrekord
+				err := json.Unmarshal(body, &old)
+				return old.Kind(), old.APIVersion, old.Spec, err
+			},
+		},
+		{
+			name: "intoto",
+			body: realIntotoBody,
+			fn: func(body []byte) (string, *string, any, error) {
+				var old Intoto
+				err := json.Unmarshal(body, &old)
+				return old.Kind(), old.APIVersion, old.Spec, err
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Fast path via UnmarshalProposedEntry.
+			pe, err := UnmarshalProposedEntry(bytes.NewReader(tc.body), runtime.JSONConsumer())
+			if err != nil {
+				t.Fatalf("fast path: %v", err)
+			}
+
+			// Old path via json.Unmarshal directly into the concrete generated
+			// type; this invokes the per-kind UnmarshalJSON method.
+			oldKind, oldAPI, oldSpec, err := tc.fn(tc.body)
+			if err != nil {
+				t.Fatalf("old path: %v", err)
+			}
+
+			if pe.Kind() != oldKind {
+				t.Errorf("Kind mismatch: fast=%q old=%q", pe.Kind(), oldKind)
+			}
+
+			newAPI := reflect.ValueOf(pe).Elem().FieldByName("APIVersion").Interface().(*string)
+			if !equalStringPtr(newAPI, oldAPI) {
+				t.Errorf("APIVersion mismatch: fast=%v old=%v", derefStr(newAPI), derefStr(oldAPI))
+			}
+
+			newSpec := reflect.ValueOf(pe).Elem().FieldByName("Spec").Interface()
+			// Both paths run UseNumber() so nested numerics are json.Number.
+			// Both DSSESchema/HashedrekordSchema/IntotoSchema are `type X any`
+			// so old and new Spec should be DeepEqual map[string]any trees.
+			if !reflect.DeepEqual(newSpec, oldSpec) {
+				t.Errorf("Spec mismatch\n fast: %#v\n  old: %#v", newSpec, oldSpec)
+			}
+		})
+	}
+}
+
+// TestUnmarshalProposedEntry_PreservesJSONNumber asserts UseNumber semantics
+// are preserved so downstream mapstructure decode sees json.Number, matching
+// the old per-kind UnmarshalJSON behavior.
+func TestUnmarshalProposedEntry_PreservesJSONNumber(t *testing.T) {
+	body := mustMarshal(t, map[string]any{
+		"kind":       "hashedrekord",
+		"apiVersion": "0.0.1",
+		"spec": map[string]any{
+			"nested": map[string]any{"count": 42},
+		},
+	})
+	pe, err := UnmarshalProposedEntry(bytes.NewReader(body), runtime.JSONConsumer())
+	if err != nil {
+		t.Fatalf("UnmarshalProposedEntry: %v", err)
+	}
+	spec := pe.(*Hashedrekord).Spec.(map[string]any)
+	nested := spec["nested"].(map[string]any)
+	if _, ok := nested["count"].(json.Number); !ok {
+		t.Errorf("nested count = %T, want json.Number", nested["count"])
+	}
+}
+
+func TestUnmarshalProposedEntry_UnknownKind(t *testing.T) {
+	body := mustMarshal(t, map[string]any{
+		"kind":       "no-such-kind",
+		"apiVersion": "0.0.1",
+		"spec":       map[string]any{},
+	})
+	pe, err := UnmarshalProposedEntry(bytes.NewReader(body), runtime.JSONConsumer())
+	if err == nil {
+		t.Fatalf("expected error, got %#v", pe)
+	}
+	if !strings.Contains(err.Error(), "no-such-kind") {
+		t.Errorf("error should mention offending kind, got %q", err.Error())
+	}
+}
+
+func TestUnmarshalProposedEntry_MissingKind(t *testing.T) {
+	body := mustMarshal(t, map[string]any{
+		"apiVersion": "0.0.1",
+		"spec":       map[string]any{},
+	})
+	if _, err := UnmarshalProposedEntry(bytes.NewReader(body), runtime.JSONConsumer()); err == nil {
+		t.Fatal("expected error for missing kind, got nil")
+	}
+}
+
+func TestUnmarshalProposedEntry_MalformedJSON(t *testing.T) {
+	body := []byte(`{"kind": "dsse", "apiVersion":`)
+	if _, err := UnmarshalProposedEntry(bytes.NewReader(body), runtime.JSONConsumer()); err == nil {
+		t.Fatal("expected error for malformed JSON, got nil")
+	}
+}
+
+// TestUnmarshalProposedEntrySlice covers the batched entry-point path.
+func TestUnmarshalProposedEntrySlice(t *testing.T) {
+	entries := []map[string]any{
+		{"kind": "dsse", "apiVersion": "0.0.1", "spec": map[string]any{"a": 1}},
+		{"kind": "intoto", "apiVersion": "0.0.1", "spec": map[string]any{"b": 2}},
+	}
+	body := mustMarshal(t, entries)
+
+	got, err := UnmarshalProposedEntrySlice(bytes.NewReader(body), runtime.JSONConsumer())
+	if err != nil {
+		t.Fatalf("UnmarshalProposedEntrySlice: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d entries, want 2", len(got))
+	}
+	if got[0].Kind() != "dsse" || got[1].Kind() != "intoto" {
+		t.Errorf("unexpected kinds: %q, %q", got[0].Kind(), got[1].Kind())
+	}
+}
+
+func mustMarshal(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func equalStringPtr(a, b *string) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+func derefStr(p *string) string {
+	if p == nil {
+		return "<nil>"
+	}
+	return *p
+}

--- a/pkg/generated/models/testdata/dsse.json
+++ b/pkg/generated/models/testdata/dsse.json
@@ -1,0 +1,12 @@
+{
+  "apiVersion": "0.0.1",
+  "kind": "dsse",
+  "spec": {
+    "proposedContent": {
+      "envelope": "{\"payloadType\":\"application/vnd.in-toto+json\",\"payload\":\"eyJfdHlwZSI6Imh0dHBzOi8vaW4tdG90by5pby9TdGF0ZW1lbnQvdjAuMSIsInByZWRpY2F0ZVR5cGUiOiJodHRwczovL3Nsc2EuZGV2L3Byb3ZlbmFuY2UvdjAuMiIsInN1YmplY3QiOlt7Im5hbWUiOiJmb29iYXIiLCJkaWdlc3QiOnsiZm9vIjoiYmFyIn19XSwicHJlZGljYXRlIjp7ImJ1aWxkZXIiOnsiaWQiOiJmb29ISzFiZ2Y1WC8xckNxZz09In0sImJ1aWxkVHlwZSI6IiIsImludm9jYXRpb24iOnsiY29uZmlnU291cmNlIjp7fX19fQ==\",\"signatures\":[{\"keyid\":\"\",\"sig\":\"MEQCIAIlnxHC3eU4jmUsqJExxfzqyy8bk+61btgnRiGcRDxgAiBwmdnJ/GX1yCYhYAvwAtkuYN0yFlVPQVAx9R6JpUUBiA==\"}]}",
+      "verifiers": [
+        "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFeCtpa3FVeFh1cmx4Wmx0YWpSQlYyanUzMWozMgpiYVQyYXgyZFhCY3BJbldhRkVTcUdGMzVLSVNmbFAxRW1NdkVuZkcrQXpIZWNRMFdRcDVRek5JZCt3PT0KLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0t"
+      ]
+    }
+  }
+}

--- a/pkg/generated/models/testdata/hashedrekord.json
+++ b/pkg/generated/models/testdata/hashedrekord.json
@@ -1,0 +1,18 @@
+{
+  "apiVersion": "0.0.1",
+  "kind": "hashedrekord",
+  "spec": {
+    "data": {
+      "hash": {
+        "algorithm": "sha256",
+        "value": "c98c24b677eff44860afea6f493bbaec5bb1c4cbb209c6fc2bbb47f66ff2ad31"
+      }
+    },
+    "signature": {
+      "content": "MEYCIQDiFwPAGqJa++V9r+poXTz/pSsC5RseGJIbh5RImy1IEwIhAI2fsry4mQzqWKB/byojL4nsCW8pTaUYt+z3IdS/8QYk",
+      "publicKey": {
+        "content": "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFSXhhQWMrVGF4WW9RVTBYOU5OVUpnV2ZmYm42aApqdW9FRFBRUW44MG5YL0V1czlJL3QwMGNjTnBjU3JVdzErSVB5R3AxcDlmZ21MMERsQmYwNUJORk5RPT0KLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCg=="
+      }
+    }
+  }
+}

--- a/pkg/generated/models/testdata/intoto.json
+++ b/pkg/generated/models/testdata/intoto.json
@@ -1,0 +1,14 @@
+{
+  "apiVersion": "0.0.2",
+  "kind": "intoto",
+  "spec": {
+    "content": {
+      "envelope": "{\"payloadType\":\"application/vnd.in-toto+json\",\"payload\":\"eyJfdHlwZSI6Imh0dHBzOi8vaW4tdG90by5pby9TdGF0ZW1lbnQvdjAuMSIsInByZWRpY2F0ZVR5cGUiOiJodHRwczovL3Nsc2EuZGV2L3Byb3ZlbmFuY2UvdjAuMiIsInN1YmplY3QiOlt7Im5hbWUiOiJmb29iYXIiLCJkaWdlc3QiOnsiZm9vIjoiYmFyIn19XSwicHJlZGljYXRlIjp7ImJ1aWxkZXIiOnsiaWQiOiJmb29ISzFiZ2Y1WC8xckNxZz09In0sImJ1aWxkVHlwZSI6IiIsImludm9jYXRpb24iOnsiY29uZmlnU291cmNlIjp7fX19fQ==\",\"signatures\":[{\"keyid\":\"\",\"sig\":\"MEQCIAIlnxHC3eU4jmUsqJExxfzqyy8bk+61btgnRiGcRDxgAiBwmdnJ/GX1yCYhYAvwAtkuYN0yFlVPQVAx9R6JpUUBiA==\"}]}",
+      "hash": {
+        "algorithm": "sha256",
+        "value": "7fa2e20d48a4c5582c7de504622dc2ea2bdc58f28cd871753c3a345c737eba5e"
+      }
+    },
+    "publicKey": "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFeCtpa3FVeFh1cmx4Wmx0YWpSQlYyanUzMWozMgpiYVQyYXgyZFhCY3BJbldhRkVTcUdGMzVLSVNmbFAxRW1NdkVuZkcrQXpIZWNRMFdRcDVRek5JZCt3PT0KLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0t"
+  }
+}


### PR DESCRIPTION
## Motivation

CPU + heap-alloc profiles captured from a production rekor-server showed the JSON unmarshal of `ProposedEntry` on the `CreateLogEntry` handler dominating request cost:

- `UnmarshalProposedEntry` — 31 % of total CPU (cumulative)
- `UnmarshalProposedEntry` — 60 % of total alloc_space
- `(*DSSE).UnmarshalJSON` alone — 27.8 % of allocs (~594 MB in a 10 s trace)
- `json.Decoder.refill` — 42 % of alloc_space, driven by repeated 4 KB-growing buffers on multi-hundred-KB bodies

Root cause is the polymorphic-unmarshal pattern go-swagger emits for a discriminated base type: the request body is decoded three times on the hot path:
* once via `io.ReadAll` + a sniff for `kind`
* once as the concrete type via the runtime Consumer, and 
* a third time inside the per-kind generated `UnmarshalJSON`

## Change

Replace the polymorphic sniff-then-consumer-decode with a single JSON pass into a shim, then construct the concrete value directly from the shim. 

This was done via overriding the swagger code-gen template rather than patching the generated code directly.

Because every `kind`'s Spec field is a `type X any` alias, the resulting Spec (a `map[string]any` tree with `UseNumber()` semantics) is byte-for-byte identical to what the per-kind generated `UnmarshalJSON` produced. 

## Performance Improvements from attached benchmarks

### Small real payloads (~700 B – 1 KB)

| Kind         | Time (before → after)               | Bytes/op                          | Allocs/op        |
| ------------ | ----------------------------------- | --------------------------------- | ---------------- |
| dsse         | 15.0 µs → 3.64 µs (**−75.7%**)      | 15.1 KiB → 4.8 KiB (−68.5%)       | 72 → 31 (−56.9%) |
| hashedrekord | 11.6 µs → 3.07 µs (**−73.7%**)      | 13.8 KiB → 4.8 KiB (−65.2%)       | 83 → 43 (−48.2%) |
| intoto       | 16.7 µs → 4.15 µs (**−75.2%**)      | 15.5 KiB → 5.2 KiB (−66.7%)       | 79 → 38 (−51.9%) |

### Large real signed payloads — time (sec/op)

| Case                          | Before → After                    |
| ----------------------------- | --------------------------------- |
| dsse / 256 KiB                | 6.71 ms → 1.52 ms (**−77.4%**)    |
| dsse / 1 MiB                  | 25.94 ms → 5.93 ms (**−77.2%**)   |
| **dsse / 32 MiB**             | **807 ms → 187 ms (−76.9%)**      |
| intoto_v002 / 256 KiB         | 6.55 ms → 1.38 ms (**−78.9%**)    |
| intoto_v002 / 1 MiB           | 25.40 ms → 5.35 ms (**−78.9%**)   |
| **intoto_v002 / 32 MiB**      | **789 ms → 170 ms (−78.5%)**      |

### Large real signed payloads — allocated bytes (B/op)

| Case                     | Before → After                     |
| ------------------------ | ---------------------------------- |
| dsse / 256 KiB           | 7.3 MiB → 1.9 MiB (**−74.1%**)     |
| dsse / 1 MiB             | 29.7 MiB → 7.6 MiB (**−74.5%**)    |
| **dsse / 32 MiB**        | **926 MiB → 242 MiB (−73.9%)**     |
| intoto_v002 / 256 KiB    | 6.9 MiB → 1.4 MiB (**−78.9%**)     |
| intoto_v002 / 1 MiB      | 27.9 MiB → 5.8 MiB (**−79.3%**)    |
| **intoto_v002 / 32 MiB** | **869 MiB → 185 MiB (−78.7%)**     |

### Large real signed payloads — allocation count (allocs/op)

| Case                     | Before → After         |
| ------------------------ | ---------------------- |
| dsse / 256 KiB           | 125 → 39 (**−68.8%**)  |
| dsse / 1 MiB             | 139 → 41 (**−70.5%**)  |
| **dsse / 32 MiB**        | **174 → 46 (−73.6%)**  |
| intoto_v002 / 256 KiB    | 163 → 71 (**−56.4%**)  |
| intoto_v002 / 1 MiB      | 177 → 73 (**−58.8%**)  |
| **intoto_v002 / 32 MiB** | **212 → 78 (−63.2%)**  |
