### PR TITLE
remove duplicative log entry

### DIFF
--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -679,8 +679,6 @@ func SearchLogQueryHandler(params entries.SearchLogQueryParams) middleware.Respo
 var ErrNotFound = errors.New("grpc returned 0 leaves with success code")
 
 func retrieveLogEntryByIndex(ctx context.Context, logIndex int) (models.LogEntry, error) {
-	log.ContextLogger(ctx).Infof("Retrieving log entry by index %d", logIndex)
-
 	tid, resolvedIndex := api.logRanges.ResolveVirtualIndex(logIndex)
 	tc, err := api.trillianClientManager.GetTrillianClient(tid)
 	if err != nil {


### PR DESCRIPTION
`Retrieving log entry by index X` is `INFO` logged on every fetch - and there are many other ways to get the same information from http request logging; removing this to save on disk i/o