### PR TITLE
return a 400 error for invalid TreeID

### DIFF
--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -712,6 +712,9 @@ func retrieveLogEntry(ctx context.Context, entryUUID string) (models.LogEntry, e
 
 	uuid, err := sharding.GetUUIDFromIDString(entryUUID)
 	if err != nil {
+		if len(entryUUID) == sharding.EntryIDHexStringLen {
+			return nil, &types.InputValidationError{Err: err}
+		}
 		return nil, sharding.ErrPlainUUID
 	}
 

--- a/pkg/api/entries_test.go
+++ b/pkg/api/entries_test.go
@@ -17,8 +17,12 @@ package api
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/go-openapi/runtime"
+	"github.com/sigstore/rekor/pkg/generated/restapi/operations/entries"
 	"github.com/sigstore/rekor/pkg/sharding"
 	"github.com/sigstore/rekor/pkg/signer"
 )
@@ -43,5 +47,24 @@ func TestRetrieveUUIDFromTree_UnconfiguredTreeID(t *testing.T) {
 
 	if err != ErrNotFound {
 		t.Errorf("Expected ErrNotFound, got: %v", err)
+	}
+}
+
+func TestGetLogEntryByUUIDHandler_InvalidTreeID(t *testing.T) {
+	invalidEntryID := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+	req := httptest.NewRequest("GET", "/api/v1/log/entries/"+invalidEntryID, nil)
+	params := entries.GetLogEntryByUUIDParams{
+		HTTPRequest: req,
+		EntryUUID:   invalidEntryID,
+	}
+
+	responder := GetLogEntryByUUIDHandler(params)
+
+	recorder := httptest.NewRecorder()
+	responder.WriteResponse(recorder, runtime.JSONProducer())
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Errorf("Expected status code %d (Bad Request), got %d", http.StatusBadRequest, recorder.Code)
 	}
 }

--- a/pkg/sharding/sharding.go
+++ b/pkg/sharding/sharding.go
@@ -152,7 +152,7 @@ func ValidateTreeID(t string) error {
 		// Check that it's a valid int64 in hex (base 16)
 		i, err := strconv.ParseInt(t, 16, 64)
 		if err != nil {
-			return fmt.Errorf("could not convert treeID %v to int64: %w", t, err)
+			return fmt.Errorf("%v is not a valid TreeID", t)
 		}
 
 		// Check for invalid TreeID values


### PR DESCRIPTION
If a client requests an entry in a treeID that is greater than `math.MaxInt64`, the error returned to the caller is not appropriately wrapped as a `types.InputValidationError` - and a 500 response code is returned (incorrectly indicating the error was server-side, not a bad request). 

This fixes that behavior and returns a 400 error, and adds a test case for it as well. It also returns a more generic error message than the full `ParseInt` error string.