### PR TITLE
use more efficient table schema for mysql-backed indexes

### DIFF
--- a/cmd/backfill-index/main.go
+++ b/cmd/backfill-index/main.go
@@ -73,11 +73,9 @@ import (
 const (
 	mysqlWriteStmt       = "INSERT IGNORE INTO EntryIndex (EntryKey, EntryUUID) VALUES (:key, :uuid)"
 	mysqlCreateTableStmt = `CREATE TABLE IF NOT EXISTS EntryIndex (
-		PK BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-		EntryKey varchar(512) NOT NULL,
-		EntryUUID char(80) NOT NULL,
-		PRIMARY KEY(PK),
-		UNIQUE(EntryKey, EntryUUID)
+		EntryKey varchar(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+		EntryUUID char(80) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+		PRIMARY KEY(EntryKey, EntryUUID)
 	)`
 	maxInsertErrors = 5
 )

--- a/cmd/copy-index/main.go
+++ b/cmd/copy-index/main.go
@@ -45,11 +45,9 @@ import (
 const (
 	mysqlWriteStmt       = "INSERT IGNORE INTO EntryIndex (EntryKey, EntryUUID) VALUES (:key, :uuid)"
 	mysqlCreateTableStmt = `CREATE TABLE IF NOT EXISTS EntryIndex (
-		PK BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-		EntryKey varchar(512) NOT NULL,
-		EntryUUID char(80) NOT NULL,
-		PRIMARY KEY(PK),
-		UNIQUE(EntryKey, EntryUUID)
+		EntryKey varchar(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+		EntryUUID char(80) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+		PRIMARY KEY(EntryKey, EntryUUID)
 	)`
 )
 

--- a/pkg/indexstorage/mysql/mysql.go
+++ b/pkg/indexstorage/mysql/mysql.go
@@ -32,11 +32,9 @@ const (
 	lookupStmt      = "SELECT EntryUUID FROM EntryIndex WHERE EntryKey IN (?)"
 	writeStmt       = "INSERT IGNORE INTO EntryIndex (EntryKey, EntryUUID) VALUES (:key, :uuid)"
 	createTableStmt = `CREATE TABLE IF NOT EXISTS EntryIndex (
-		PK BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-		EntryKey varchar(512) NOT NULL,
-		EntryUUID char(80) NOT NULL,
-		PRIMARY KEY(PK),
-		UNIQUE(EntryKey, EntryUUID)
+		EntryKey varchar(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+		EntryUUID char(80) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+		PRIMARY KEY(EntryKey, EntryUUID)
 	)`
 )
 

--- a/scripts/performance/index-storage/index-performance.sh
+++ b/scripts/performance/index-storage/index-performance.sh
@@ -266,11 +266,9 @@ upload() {
         if [ ! $dbsize -ge $wantsize ] ; then
             echo "Uploading entries into mysql..."
             mysql -h $MYSQL_IP -P 3306 -utrillian -p${MYSQL_PASS} -D trillian -e "CREATE TABLE IF NOT EXISTS EntryIndex (
-                    PK BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-                    EntryKey varchar(512) NOT NULL,
-                    EntryUUID char(80) NOT NULL,
-                    PRIMARY KEY(PK),
-                    UNIQUE(EntryKey, EntryUUID)
+                    EntryKey varchar(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+                    EntryUUID char(80) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+                    PRIMARY KEY(EntryKey, EntryUUID)
             );
             LOAD DATA LOCAL INFILE './indices.csv'
             INTO TABLE EntryIndex


### PR DESCRIPTION
*Note: this does not do an in-place migration of existing tables, but for new deployments, this uses a more efficient index strategy.*

This eliminates a redundant primary key, as well as a redundant index.  It also leverages an optimization in how the entry uuid is stored to be more efficient on disk. This should result in an approximate 50% savings in disk space required for the search index. 