### PR TITLE
test mysql with production dsn strings

### DIFF
--- a/docker-compose.backfill-test.yml
+++ b/docker-compose.backfill-test.yml
@@ -34,7 +34,7 @@ services:
       "--attestation_storage_bucket=file:///var/run/attestations",
       "--max_request_body_size=32792576",
       "--search_index.storage_provider=${INDEX_BACKEND:-mysql}",
-      "--search_index.mysql.dsn=test:zaphod@tcp(mysql:3306)/test",
+      "--search_index.mysql.dsn=test:zaphod@tcp(mysql:3306)/test?parseTime=true&interpolateParams=true",
       ]
     ports:
       - "3000:3000"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -39,7 +39,7 @@ services:
       "--rekor_server.new_entry_publisher=gcppubsub://projects/test-project/topics/new-entry",
       "--rekor_server.publish_events_json=true",
       "--search_index.storage_provider=${INDEX_BACKEND:-mysql}",
-      "--search_index.mysql.dsn=test:zaphod@tcp(mysql:3306)/test",
+      "--search_index.mysql.dsn=test:zaphod@tcp(mysql:3306)/test?parseTime=true&interpolateParams=true",
       ]
     ports:
       - "3000:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
     command: [
       "--quota_system=noop",
       "--storage_system=mysql",
-      "--mysql_uri=test:zaphod@tcp(mysql:3306)/test",
+      "--mysql_uri=test:zaphod@tcp(mysql:3306)/test?parseTime=true&interpolateParams=true",
       "--rpc_endpoint=0.0.0.0:8090",
       "--http_endpoint=0.0.0.0:8091",
       "--alsologtostderr",
@@ -81,7 +81,7 @@ services:
     command: [
       "--quota_system=noop",
       "--storage_system=mysql",
-      "--mysql_uri=test:zaphod@tcp(mysql:3306)/test",
+      "--mysql_uri=test:zaphod@tcp(mysql:3306)/test?parseTime=true&interpolateParams=true",
       "--rpc_endpoint=0.0.0.0:8090",
       "--http_endpoint=0.0.0.0:8091",
       "--force_master",
@@ -115,7 +115,7 @@ services:
       "--enable_attestation_storage",
       "--attestation_storage_bucket=file:///var/run/attestations",
       "--search_index.storage_provider=mysql",
-      "--search_index.mysql.dsn=test:zaphod@tcp(mysql:3306)/test",
+      "--search_index.mysql.dsn=test:zaphod@tcp(mysql:3306)/test?parseTime=true&interpolateParams=true",
       # Uncomment this for production logging
       # "--log_type=prod",
       ]

--- a/tests/backfill-test.sh
+++ b/tests/backfill-test.sh
@@ -135,7 +135,7 @@ run_backfill() {
             --concurrency 5 --start 0 --end $end_index
     else
         go run cmd/backfill-index/main.go --rekor-address $REKOR_ADDRESS \
-            --mysql-dsn "${MYSQL_USER}:${MYSQL_PASSWORD}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/${MYSQL_DB}" \
+            --mysql-dsn "${MYSQL_USER}:${MYSQL_PASSWORD}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/${MYSQL_DB}?parseTime=true&interpolateParams=true" \
             --concurrency 5 --start 0 --end $end_index
     fi
     set +e

--- a/tests/cleanup-index-test.sh
+++ b/tests/cleanup-index-test.sh
@@ -81,7 +81,7 @@ fi
 # search_index.storage_provider still points to redis, but it's useful
 # to test that the key cleanup is working
 go run cmd/backfill-index/main.go --rekor-address $REKOR_ADDRESS \
-    --mysql-dsn "${MYSQL_USER}:${MYSQL_PASSWORD}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/${MYSQL_DB}" \
+    --mysql-dsn "${MYSQL_USER}:${MYSQL_PASSWORD}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/${MYSQL_DB}?parseTime=true&interpolateParams=true" \
     --concurrency 5 --start 0 --end $end_index
 
 # run the cleanup script

--- a/tests/client-algos-e2e-test.sh
+++ b/tests/client-algos-e2e-test.sh
@@ -129,7 +129,7 @@ services:
       "--enable_attestation_storage",
       "--attestation_storage_bucket=file:///var/run/attestations",
       "--search_index.storage_provider=mysql",
-      "--search_index.mysql.dsn=test:zaphod@tcp(mysql:3306)/test",
+      "--search_index.mysql.dsn=test:zaphod@tcp(mysql:3306)/test?parseTime=true&interpolateParams=true",
       "--client-signing-algorithms=rsa-sign-pkcs1-2048-sha256,ed25519-ph",
       # Uncomment this for production logging
       # "--log_type=prod",

--- a/tests/copy-index-test.sh
+++ b/tests/copy-index-test.sh
@@ -131,7 +131,7 @@ check_intoto_entries() {
 run_copy() {
     set -e
     go run cmd/copy-index/main.go \
-        --mysql-dsn "${MYSQL_USER}:${MYSQL_PASSWORD}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/${MYSQL_DB}" \
+        --mysql-dsn "${MYSQL_USER}:${MYSQL_PASSWORD}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/${MYSQL_DB}?parseTime=true&interpolateParams=true" \
         --redis-hostname $REDIS_HOST --redis-port $REDIS_PORT --redis-password $REDIS_PASSWORD \
         --batch-size 5
     set +e

--- a/tests/sharding-e2e-test.sh
+++ b/tests/sharding-e2e-test.sh
@@ -183,7 +183,7 @@ services:
       "--trillian_log_server.tlog_id=$SHARD_TREE_ID",
       "--trillian_log_server.sharding_config=/$SHARDING_CONFIG",
       "--search_index.storage_provider=mysql",
-      "--search_index.mysql.dsn=test:zaphod@tcp(mysql:3306)/test",
+      "--search_index.mysql.dsn=test:zaphod@tcp(mysql:3306)/test?parseTime=true&interpolateParams=true",
       # Uncomment this for production logging
       # "--log_type=prod",
       ]


### PR DESCRIPTION
[`parseTime`](https://github.com/go-sql-driver/mysql#parsetime) returns timestamps in Go-friendly values, and [`interpolateParams`](https://github.com/go-sql-driver/mysql#interpolateparams) reduces the round trips between client & db