### PR TITLE
index client: fix shadowed err, wrong err label

### DIFF
--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -402,7 +402,7 @@ func createLogEntry(params entries.CreateLogEntryParams) (models.LogEntry, middl
 				log.ContextLogger(ctx).Errorf("getting entry index keys: %v", err)
 				return
 			}
-			if err := addToIndex(context.Background(), keys, entryID); err != nil {
+			if err = addToIndex(context.Background(), keys, entryID); err != nil {
 				log.ContextLogger(ctx).Errorf("adding keys to index: %v", err)
 			}
 		}()

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -132,11 +132,7 @@ func SearchIndexNotImplementedHandler(_ index.SearchIndexParams) middleware.Resp
 }
 
 func addToIndex(ctx context.Context, keys []string, value string) error {
-	err := indexStorageClient.WriteIndex(ctx, keys, value)
-	if err != nil {
-		return fmt.Errorf("redis client: %w", err)
-	}
-	return nil
+	return indexStorageClient.WriteIndex(ctx, keys, value)
 }
 
 func storeAttestation(ctx context.Context, uuid string, attestation []byte) error {


### PR DESCRIPTION
`err` was being shadowed in the assignment in L405, so the success metrics only reported parsing failures, not the db txn.

`addToIndex` was always wrapping its errors with "redis client", even if that was not the configured provider. this was likely leftover from when redis was the only impl