### PR TITLE
alpine: hash only the bytes read when computing the control.tar.gz digest

### DIFF
--- a/pkg/types/alpine/apk.go
+++ b/pkg/types/alpine/apk.go
@@ -62,7 +62,7 @@ func newSHA1Reader(b *bufio.Reader) *sha1Reader {
 func (s *sha1Reader) Read(p []byte) (int, error) {
 	n, err := s.r.Read(p)
 	if err == nil && n > 0 && s.addToHash {
-		s.hasher.Write(p)
+		s.hasher.Write(p[:n])
 	}
 	return n, err
 }

--- a/pkg/types/alpine/apk_test.go
+++ b/pkg/types/alpine/apk_test.go
@@ -16,7 +16,9 @@
 package alpine
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -134,5 +136,56 @@ func TestAlpineMetadataSizeBoundary(t *testing.T) {
 	expectedErr := fmt.Sprintf("decompressed size (%d) for signature.tar.gz exceeds max allowed size %d", boundary, boundary-1)
 	if !strings.Contains(err.Error(), expectedErr) {
 		t.Fatalf("expected error containing %q, got %q", expectedErr, err.Error())
+	}
+}
+
+// oneByteReader returns at most one byte per Read, forcing the short reads
+// that a network stream (e.g. an http.Response.Body) can legitimately return.
+type oneByteReader struct {
+	r io.Reader
+}
+
+func (o oneByteReader) Read(p []byte) (int, error) {
+	if len(p) > 1 {
+		p = p[:1]
+	}
+	return o.r.Read(p)
+}
+
+// TestAlpinePackagePartialReads guards against the control.tar.gz SHA1 digest
+// depending on how the input reader chunks its data. The digest that the
+// package signature is checked against must be a function of the bytes only,
+// not of the read sizes the underlying reader happens to return.
+func TestAlpinePackagePartialReads(t *testing.T) {
+	apk, err := os.ReadFile("tests/test_alpine.apk")
+	if err != nil {
+		t.Fatalf("could not read archive: %v", err)
+	}
+	pubKey, err := os.Open("tests/test_alpine.pub")
+	if err != nil {
+		t.Fatalf("could not open public key: %v", err)
+	}
+	defer pubKey.Close()
+	pub, err := x509.NewPublicKey(pubKey)
+	if err != nil {
+		t.Fatalf("failed to parse public key: %v", err)
+	}
+
+	full := Package{}
+	if err := full.Unmarshal(bytes.NewReader(apk)); err != nil {
+		t.Fatalf("unmarshal (full reads): %v", err)
+	}
+
+	chunked := Package{}
+	if err := chunked.Unmarshal(oneByteReader{r: bytes.NewReader(apk)}); err != nil {
+		t.Fatalf("unmarshal (partial reads): %v", err)
+	}
+
+	if !bytes.Equal(full.controlSHA1Digest, chunked.controlSHA1Digest) {
+		t.Fatalf("control.tar.gz SHA1 depends on read chunking:\n full    = %x\n chunked = %x",
+			full.controlSHA1Digest, chunked.controlSHA1Digest)
+	}
+	if err := chunked.VerifySignature(pub.CryptoPubKey()); err != nil {
+		t.Fatalf("signature verification failed for validly signed package read in small chunks: %v", err)
 	}
 }


### PR DESCRIPTION
`sha1Reader.Read` hashes the whole read buffer instead of the part that was actually filled:

```go
n, err := s.r.Read(p)
if err == nil && n > 0 && s.addToHash {
    s.hasher.Write(p)   // hashes p[:len(p)], not p[:n]
}
```

When the underlying read returns fewer bytes than requested (`n < len(p)`), the stale tail of `p` gets folded into the SHA1. That digest is the value the package signature is checked against in `VerifySignature`, so once it is off a validly signed package fails verification.

It doesn't show up in the existing test because `Package.Unmarshal` is handed an `*os.File`, and reads on a regular file fill the buffer. A reader that can return short reads hits it — a network stream / `http.Response.Body`, or `bufio` at a refill boundary. `gzip` reads the compressed stream in chunks larger than one byte, so a short read there feeds stale bytes into the digest.

The fix is `Write(p[:n])`.

I added `TestAlpinePackagePartialReads`: it unmarshals the existing signed fixture through a reader that returns one byte per call, then checks the control digest matches the whole-file read and the signature still verifies. Before the change the two digests differ and verification returns `crypto/rsa: verification error`; after it, they match.

```
go test ./pkg/types/alpine/...
```
