### PR TITLE
separate read/write sql traffic for indexservice into separate pools

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -6,5 +6,35 @@ You can read more about Sigstore's deprecation policy [here](https://docs.sigsto
 | **Feature Being Deprecated**               | **API Stability Level** | **Earliest Date of Removal** |
 |--------------------------------------------|-------------------------|------------------------------|
 | Specifying URLs inline in proposed entries | Experimental/Beta/GA    | DD/MM/YY                     |
-|                                            |                         |                              |
-|                                            |                         |                              |
+| `search_index.mysql.max_open_connections`  | Experimental/Beta/GA    | DD/MM/YY                     |
+| `search_index.mysql.max_idle_connections`  | Experimental/Beta/GA    | DD/MM/YY                     |
+
+## `search_index.mysql.max_open_connections` and `search_index.mysql.max_idle_connections`
+
+The MySQL search index now uses separate connection pools for reads and writes, so that a
+burst of index writes cannot starve the lookups that serve `/api/v1/index/retrieve`. Each
+pool is sized independently by `search_index.mysql.read.*` and `search_index.mysql.write.*`.
+
+The two keys above sized the single pool that preceded the split. They are still honored: the
+value is split 70/30 between the write and read pools (rounded down, with a floor of 1) so that
+the total connection budget is preserved. For example, `max_open_connections: 10` becomes 7
+write plus 3 read.
+
+**Do not mix the deprecated keys with the per-pool keys.** If any `read.*` or `write.*` key is
+set, the deprecated keys are ignored entirely and a warning is logged at startup.
+
+To size each pool precisely, replace the deprecated keys with explicit per-pool limits:
+
+```yaml
+search_index:
+  mysql:
+    read:
+      max_open_connections: 3
+      max_idle_connections: 3
+    write:
+      max_open_connections: 7
+      max_idle_connections: 7
+```
+
+An index insert is far slower than a lookup's primary-key range scan, so the write pool deserves the
+larger share.

--- a/cmd/rekor-server/app/root.go
+++ b/cmd/rekor-server/app/root.go
@@ -149,8 +149,21 @@ Memory and file-based signers should only be used for testing.`)
 	rootCmd.PersistentFlags().String("search_index.mysql.dsn", "", "DSN for index storage using MySQL")
 	rootCmd.PersistentFlags().Duration("search_index.mysql.conn_max_idletime", 0*time.Second, "maximum connection idle time")
 	rootCmd.PersistentFlags().Duration("search_index.mysql.conn_max_lifetime", 0*time.Second, "maximum connection lifetime")
-	rootCmd.PersistentFlags().Int("search_index.mysql.max_open_connections", 0, "maximum open connections")
-	rootCmd.PersistentFlags().Int("search_index.mysql.max_idle_connections", 0, "maximum idle connections")
+	rootCmd.PersistentFlags().Int("search_index.mysql.read.max_open_connections", 0, "maximum open connections in the index read pool; 0 for unlimited")
+	rootCmd.PersistentFlags().Int("search_index.mysql.read.max_idle_connections", 0, "maximum idle connections retained in the index read pool")
+	rootCmd.PersistentFlags().Int("search_index.mysql.write.max_open_connections", 0, "maximum open connections in the index write pool; 0 for unlimited")
+	rootCmd.PersistentFlags().Int("search_index.mysql.write.max_idle_connections", 0, "maximum idle connections retained in the index write pool")
+
+	// superseded by the per-pool flags above; these sized the single pool that predates the
+	// read/write split and are now split 70/30 between the write and read pools
+	rootCmd.PersistentFlags().Int("search_index.mysql.max_open_connections", 0, "deprecated: total provided will be split 70/30 across write/read pools; use per-pool flags instead")
+	rootCmd.PersistentFlags().Int("search_index.mysql.max_idle_connections", 0, "deprecated: total provided will be split 70/30 across write/read pools; use per-pool flags instead")
+	for _, f := range []string{"search_index.mysql.max_open_connections", "search_index.mysql.max_idle_connections"} {
+		if err := rootCmd.PersistentFlags().MarkDeprecated(f, "value is split 70/30 between the write and read pools; "+
+			"use the search_index.mysql.read.* and search_index.mysql.write.* equivalents"); err != nil {
+			log.Logger.Fatal(err)
+		}
+	}
 
 	rootCmd.PersistentFlags().String("http-request-id-header-name", middleware.RequestIDHeader, "name of HTTP Request Header to use as request correlation ID")
 	rootCmd.PersistentFlags().String("trace-string-prefix", "", "if set, this will be used to prefix the 'trace' field when outputting structured logs")

--- a/pkg/indexstorage/indexstorage.go
+++ b/pkg/indexstorage/indexstorage.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/sigstore/rekor/pkg/indexstorage/mysql"
 	"github.com/sigstore/rekor/pkg/indexstorage/redis"
+	"github.com/sigstore/rekor/pkg/log"
 	"github.com/spf13/viper"
 )
 
@@ -35,12 +36,70 @@ func NewIndexStorage(providerType string) (IndexStorage, error) {
 	case redis.ProviderType:
 		return redis.NewProvider(viper.GetString("redis_server.address"), viper.GetString("redis_server.port"), viper.GetString("redis_server.password"), viper.GetBool("redis_server.enable-tls"), viper.GetBool("redis_server.insecure-skip-verify"))
 	case mysql.ProviderType:
+		limits := mysqlConnLimits()
 		return mysql.NewProvider(viper.GetString("search_index.mysql.dsn"),
 			mysql.WithConnMaxIdleTime(viper.GetDuration("search_index.mysql.conn_max_idletime")),
 			mysql.WithConnMaxLifetime(viper.GetDuration("search_index.mysql.conn_max_lifetime")),
-			mysql.WithMaxIdleConns(viper.GetInt("search_index.mysql.max_idle_connections")),
-			mysql.WithMaxOpenConns(viper.GetInt("search_index.mysql.max_open_connections")))
+			mysql.WithReadMaxIdleConns(limits.readIdle),
+			mysql.WithReadMaxOpenConns(limits.readOpen),
+			mysql.WithWriteMaxIdleConns(limits.writeIdle),
+			mysql.WithWriteMaxOpenConns(limits.writeOpen))
 	default:
 		return nil, fmt.Errorf("invalid index storage provider type: %v", providerType)
 	}
+}
+
+type connLimits struct {
+	readOpen, readIdle   int
+	writeOpen, writeIdle int
+}
+
+// mysqlConnLimits resolves each index pool's connection limits from viper.
+func mysqlConnLimits() connLimits {
+	// the deprecated keys sized a single pool; the total is now split 70/30 between the
+	// write and read pools so the operator's original connection budget is preserved
+	deprecatedOpen := viper.GetInt("search_index.mysql.max_open_connections")
+	deprecatedIdle := viper.GetInt("search_index.mysql.max_idle_connections")
+	hasDeprecated := deprecatedOpen != 0 || deprecatedIdle != 0
+
+	readOpen := viper.GetInt("search_index.mysql.read.max_open_connections")
+	readIdle := viper.GetInt("search_index.mysql.read.max_idle_connections")
+	writeOpen := viper.GetInt("search_index.mysql.write.max_open_connections")
+	writeIdle := viper.GetInt("search_index.mysql.write.max_idle_connections")
+	hasPerPool := readOpen != 0 || readIdle != 0 || writeOpen != 0 || writeIdle != 0
+
+	if hasDeprecated && hasPerPool {
+		log.Logger.Warnf("search_index.mysql.max_open_connections / max_idle_connections must not be mixed " +
+			"with the per-pool search_index.mysql.read.* / write.* keys; the deprecated keys will be ignored")
+		deprecatedOpen = 0
+		deprecatedIdle = 0
+	} else if hasDeprecated {
+		log.Logger.Warnf("search_index.mysql.max_open_connections and max_idle_connections are deprecated "+
+			"and will be split 70/30 between the write and read pools; "+
+			"set the search_index.mysql.read.* and search_index.mysql.write.* keys instead")
+	}
+
+	return connLimits{
+		readOpen:  poolLimit(readOpen, deprecatedOpen, false),
+		readIdle:  poolLimit(readIdle, deprecatedIdle, false),
+		writeOpen: poolLimit(writeOpen, deprecatedOpen, true),
+		writeIdle: poolLimit(writeIdle, deprecatedIdle, true),
+	}
+}
+
+// poolLimit prefers a pool-specific connection limit, falling back to a 70/30
+// (write/read) split of the deprecated unprefixed key that predates the read/write
+// pool split. The split preserves the operator's original total connection budget.
+func poolLimit(pool, deprecated int, write bool) int {
+	if pool != 0 {
+		return pool
+	}
+	if deprecated == 0 {
+		return 0
+	}
+	w := max(deprecated*7/10, 1)
+	if write {
+		return w
+	}
+	return max(deprecated-w, 1)
 }

--- a/pkg/indexstorage/indexstorage.go
+++ b/pkg/indexstorage/indexstorage.go
@@ -74,8 +74,8 @@ func mysqlConnLimits() connLimits {
 		deprecatedOpen = 0
 		deprecatedIdle = 0
 	} else if hasDeprecated {
-		log.Logger.Warnf("search_index.mysql.max_open_connections and max_idle_connections are deprecated "+
-			"and will be split 70/30 between the write and read pools; "+
+		log.Logger.Warnf("search_index.mysql.max_open_connections and max_idle_connections are deprecated " +
+			"and will be split 70/30 between the write and read pools; " +
 			"set the search_index.mysql.read.* and search_index.mysql.write.* keys instead")
 	}
 

--- a/pkg/indexstorage/indexstorage_test.go
+++ b/pkg/indexstorage/indexstorage_test.go
@@ -1,0 +1,107 @@
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package indexstorage
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestMySQLConnLimits(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		keys map[string]int
+		want connLimits
+	}{
+		{
+			name: "nothing configured",
+			keys: map[string]int{},
+			want: connLimits{},
+		},
+		{
+			// the upgrade case: the deprecated keys sized one pool; the total is now
+			// split 70/30 between write and read to preserve the connection budget
+			name: "deprecated keys only",
+			keys: map[string]int{
+				"search_index.mysql.max_open_connections": 10,
+				"search_index.mysql.max_idle_connections": 10,
+			},
+			want: connLimits{readOpen: 3, readIdle: 3, writeOpen: 7, writeIdle: 7},
+		},
+		{
+			name: "per pool only",
+			keys: map[string]int{
+				"search_index.mysql.read.max_open_connections":  2,
+				"search_index.mysql.read.max_idle_connections":  1,
+				"search_index.mysql.write.max_open_connections": 8,
+				"search_index.mysql.write.max_idle_connections": 4,
+			},
+			want: connLimits{readOpen: 2, readIdle: 1, writeOpen: 8, writeIdle: 4},
+		},
+		{
+			// mixing deprecated and per-pool keys is unsupported; the deprecated keys
+			// are dropped so the per-pool values are used as-is
+			name: "mixed keys drops deprecated",
+			keys: map[string]int{
+				"search_index.mysql.max_open_connections":       10,
+				"search_index.mysql.write.max_open_connections": 20,
+			},
+			want: connLimits{writeOpen: 20},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			viper.Reset()
+			t.Cleanup(viper.Reset)
+			for k, v := range tc.keys {
+				viper.Set(k, v)
+			}
+			if got := mysqlConnLimits(); got != tc.want {
+				t.Errorf("got %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPoolLimit(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		pool, deprecated int
+		write            bool
+		want             int
+	}{
+		{"pool specific wins for read", 5, 10, false, 5},
+		{"pool specific wins for write", 5, 10, true, 5},
+		{"pool specific wins even when smaller", 1, 9, false, 1},
+		{"neither set read", 0, 0, false, 0},
+		{"neither set write", 0, 0, true, 0},
+
+		// 70/30 split of deprecated value
+		{"deprecated 10 write gets 70%", 0, 10, true, 7},
+		{"deprecated 10 read gets remainder", 0, 10, false, 3},
+		{"deprecated 3 write", 0, 3, true, 2},
+		{"deprecated 3 read", 0, 3, false, 1},
+
+		// floor of 1 prevents 0 (which means unlimited in database/sql)
+		{"deprecated 1 write floors to 1", 0, 1, true, 1},
+		{"deprecated 1 read floors to 1", 0, 1, false, 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := poolLimit(tc.pool, tc.deprecated, tc.write); got != tc.want {
+				t.Errorf("poolLimit(%d, %d, write=%v) = %d, want %d", tc.pool, tc.deprecated, tc.write, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/indexstorage/mysql/metrics.go
+++ b/pkg/indexstorage/mysql/metrics.go
@@ -1,0 +1,89 @@
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mysql
+
+import (
+	"github.com/jmoiron/sqlx"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	openConnsDesc = prometheus.NewDesc(
+		"rekor_index_storage_db_connections_open",
+		"Established connections to the search index database, both in use and idle",
+		[]string{"pool"}, nil)
+	inUseConnsDesc = prometheus.NewDesc(
+		"rekor_index_storage_db_connections_in_use",
+		"Connections to the search index database currently in use",
+		[]string{"pool"}, nil)
+	idleConnsDesc = prometheus.NewDesc(
+		"rekor_index_storage_db_connections_idle",
+		"Idle connections to the search index database",
+		[]string{"pool"}, nil)
+	maxOpenConnsDesc = prometheus.NewDesc(
+		"rekor_index_storage_db_connections_max_open",
+		"Configured limit on open connections to the search index database, or 0 if unlimited",
+		[]string{"pool"}, nil)
+	waitCountDesc = prometheus.NewDesc(
+		"rekor_index_storage_db_wait_count_total",
+		"Total number of times a caller blocked waiting for a search index database connection",
+		[]string{"pool"}, nil)
+	waitDurationDesc = prometheus.NewDesc(
+		"rekor_index_storage_db_wait_duration_seconds_total",
+		"Total time callers spent blocked waiting for a search index database connection",
+		[]string{"pool"}, nil)
+)
+
+// dbStatsCollector exports connection pool statistics for the search index
+// read and write pools.
+//
+// collectors.NewDBStatsCollector covers the same DBStats fields, but hardcodes
+// the go_sql_* metric prefix, which would leave these sitting apart from the
+// rest of the rekor_index_storage_* family an operator correlates them against.
+//
+// One collector serves both pools because pool is a variable label here; two
+// collectors sharing these descriptors would collide on registration.
+type dbStatsCollector struct {
+	readDB  *sqlx.DB
+	writeDB *sqlx.DB
+}
+
+func (c *dbStatsCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- openConnsDesc
+	ch <- inUseConnsDesc
+	ch <- idleConnsDesc
+	ch <- maxOpenConnsDesc
+	ch <- waitCountDesc
+	ch <- waitDurationDesc
+}
+
+func (c *dbStatsCollector) Collect(ch chan<- prometheus.Metric) {
+	c.collectPool(ch, poolRead, c.readDB)
+	c.collectPool(ch, poolWrite, c.writeDB)
+}
+
+func (c *dbStatsCollector) collectPool(ch chan<- prometheus.Metric, role poolRole, db *sqlx.DB) {
+	if db == nil {
+		return
+	}
+	pool := role.String()
+	stats := db.Stats()
+	ch <- prometheus.MustNewConstMetric(openConnsDesc, prometheus.GaugeValue, float64(stats.OpenConnections), pool)
+	ch <- prometheus.MustNewConstMetric(inUseConnsDesc, prometheus.GaugeValue, float64(stats.InUse), pool)
+	ch <- prometheus.MustNewConstMetric(idleConnsDesc, prometheus.GaugeValue, float64(stats.Idle), pool)
+	ch <- prometheus.MustNewConstMetric(maxOpenConnsDesc, prometheus.GaugeValue, float64(stats.MaxOpenConnections), pool)
+	ch <- prometheus.MustNewConstMetric(waitCountDesc, prometheus.CounterValue, float64(stats.WaitCount), pool)
+	ch <- prometheus.MustNewConstMetric(waitDurationDesc, prometheus.CounterValue, stats.WaitDuration.Seconds(), pool)
+}

--- a/pkg/indexstorage/mysql/mysql.go
+++ b/pkg/indexstorage/mysql/mysql.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sigstore/rekor/pkg/log"
 
 	// this imports the mysql driver for go
@@ -39,39 +40,77 @@ const (
 )
 
 // IndexStorageProvider implements indexstorage.IndexStorage
+//
+// Reads and writes use independent connection pools against the same DSN.
+// LookupIndices runs synchronously in the HTTP request path while WriteIndex is
+// dispatched from a detached goroutine per entry, so a shared pool lets a burst
+// of writes queue ahead of every read. database/sql wakes a uniformly random
+// waiter rather than the longest-waiting one, so reads cannot be prioritized
+// within a pool no matter how large it is.
 type IndexStorageProvider struct {
-	db *sqlx.DB
+	readDB    *sqlx.DB
+	writeDB   *sqlx.DB
+	collector *dbStatsCollector
 }
 
 func NewProvider(dsn string, opts ...Options) (*IndexStorageProvider, error) {
-	var err error
 	provider := &IndexStorageProvider{}
-	provider.db, err = sqlx.Open(ProviderType, dsn)
+
+	readDB, err := openPool(dsn, poolRead, opts)
 	if err != nil {
 		return nil, err
 	}
-	if err = provider.db.Ping(); err != nil {
-		return nil, err
+	provider.readDB = readDB
+
+	writeDB, err := openPool(dsn, poolWrite, opts)
+	if err != nil {
+		return nil, errors.Join(err, readDB.Close())
+	}
+	provider.writeDB = writeDB
+
+	if _, err := provider.writeDB.Exec(createTableStmt); err != nil {
+		return nil, errors.Join(fmt.Errorf("create table if not exists failed: %w", err), provider.Shutdown())
 	}
 
-	for _, o := range opts {
-		o.applyConnMaxIdleTime(provider.db)
-		o.applyConnMaxLifetime(provider.db)
-		o.applyMaxIdleConns(provider.db)
-		o.applyMaxOpenConns(provider.db)
+	provider.collector = &dbStatsCollector{readDB: provider.readDB, writeDB: provider.writeDB}
+	if err := prometheus.DefaultRegisterer.Register(provider.collector); err != nil {
+		provider.collector = nil
+		var alreadyRegistered prometheus.AlreadyRegisteredError
+		if !errors.As(err, &alreadyRegistered) {
+			return nil, errors.Join(fmt.Errorf("registering db stats collector: %w", err), provider.Shutdown())
+		}
+		log.Logger.Warnf("search index db stats already registered by another provider; this provider's pools will not be reported")
 	}
 
-	if _, err := provider.db.Exec(createTableStmt); err != nil {
-		return nil, fmt.Errorf("create table if not exists failed: %w", err)
-	}
+	// a limit of 0 means unlimited, so report what each pool actually got
+	log.Logger.Infof("search index connection pools: %d read, %d write",
+		provider.readDB.Stats().MaxOpenConnections, provider.writeDB.Stats().MaxOpenConnections)
 
 	return provider, nil
 }
 
-// LookupIndices looks up and returns all indices for the specified keys. The key value(s) will be canonicalized
-// by converting all characters into a lowercase value before looking up in Redis
+// openPool opens one connection pool, applying only the options that name role.
+func openPool(dsn string, role poolRole, opts []Options) (*sqlx.DB, error) {
+	db, err := sqlx.Open(ProviderType, dsn)
+	if err != nil {
+		return nil, fmt.Errorf("opening %s pool: %w", role, err)
+	}
+	if err := db.Ping(); err != nil {
+		return nil, errors.Join(fmt.Errorf("pinging %s pool: %w", role, err), db.Close())
+	}
+
+	for _, o := range opts {
+		o.applyConnMaxIdleTime(db)
+		o.applyConnMaxLifetime(db)
+		o.applyMaxIdleConns(db, role)
+		o.applyMaxOpenConns(db, role)
+	}
+	return db, nil
+}
+
+// LookupIndices looks up and returns all indices for the specified keys.
 func (isp *IndexStorageProvider) LookupIndices(ctx context.Context, keys []string) ([]string, error) {
-	if isp.db == nil {
+	if isp.readDB == nil {
 		return []string{}, errors.New("sql client has not been initialized")
 	}
 
@@ -79,7 +118,7 @@ func (isp *IndexStorageProvider) LookupIndices(ctx context.Context, keys []strin
 	if err != nil {
 		return []string{}, fmt.Errorf("error preparing statement: %w", err)
 	}
-	rows, err := isp.db.QueryContext(ctx, isp.db.Rebind(query), args...)
+	rows, err := isp.readDB.QueryContext(ctx, isp.readDB.Rebind(query), args...)
 	if err != nil {
 		return []string{}, fmt.Errorf("error looking up indices from mysql: %w", err)
 	}
@@ -100,18 +139,17 @@ func (isp *IndexStorageProvider) LookupIndices(ctx context.Context, keys []strin
 	return entryUUIDs, nil
 }
 
-// WriteIndex adds the index for the specified key. The key value will be canonicalized
-// by converting all characters into a lowercase value before appending the index in Redis
+// WriteIndex adds the index for the specified keys.
 func (isp *IndexStorageProvider) WriteIndex(ctx context.Context, keys []string, index string) error {
-	if isp.db == nil {
+	if isp.writeDB == nil {
 		return errors.New("sql client has not been initialized")
 	}
 
-	var valueMaps []map[string]interface{}
+	valueMaps := make([]map[string]interface{}, 0, len(keys))
 	for _, key := range keys {
 		valueMaps = append(valueMaps, map[string]interface{}{"key": key, "uuid": index})
 	}
-	result, err := isp.db.NamedExecContext(ctx, writeStmt, valueMaps)
+	result, err := isp.writeDB.NamedExecContext(ctx, writeStmt, valueMaps)
 	if err != nil {
 		return fmt.Errorf("mysql write error: %w", err)
 	}
@@ -125,9 +163,19 @@ func (isp *IndexStorageProvider) WriteIndex(ctx context.Context, keys []string, 
 
 // Shutdown cleans up any client resources that may be held by the provider
 func (isp *IndexStorageProvider) Shutdown() error {
-	if isp.db == nil {
-		return nil
+	// a registered collector keeps reporting the closed pools as all-zero, and blocks a
+	// replacement provider from registering its own
+	if isp.collector != nil {
+		prometheus.DefaultRegisterer.Unregister(isp.collector)
+		isp.collector = nil
 	}
 
-	return isp.db.Close()
+	var errs []error
+	if isp.readDB != nil {
+		errs = append(errs, isp.readDB.Close())
+	}
+	if isp.writeDB != nil {
+		errs = append(errs, isp.writeDB.Close())
+	}
+	return errors.Join(errs...)
 }

--- a/pkg/indexstorage/mysql/mysql.go
+++ b/pkg/indexstorage/mysql/mysql.go
@@ -72,15 +72,11 @@ func NewProvider(dsn string, opts ...Options) (*IndexStorageProvider, error) {
 		return nil, errors.Join(fmt.Errorf("create table if not exists failed: %w", err), provider.Shutdown())
 	}
 
-	provider.collector = &dbStatsCollector{readDB: provider.readDB, writeDB: provider.writeDB}
-	if err := prometheus.DefaultRegisterer.Register(provider.collector); err != nil {
-		provider.collector = nil
-		var alreadyRegistered prometheus.AlreadyRegisteredError
-		if !errors.As(err, &alreadyRegistered) {
-			return nil, errors.Join(fmt.Errorf("registering db stats collector: %w", err), provider.Shutdown())
-		}
-		log.Logger.Warnf("search index db stats already registered by another provider; this provider's pools will not be reported")
+	collector := &dbStatsCollector{readDB: provider.readDB, writeDB: provider.writeDB}
+	if err := prometheus.DefaultRegisterer.Register(collector); err != nil {
+		return nil, errors.Join(fmt.Errorf("registering db stats collector: %w", err), provider.Shutdown())
 	}
+	provider.collector = collector
 
 	// a limit of 0 means unlimited, so report what each pool actually got
 	log.Logger.Infof("search index connection pools: %d read, %d write",
@@ -163,8 +159,7 @@ func (isp *IndexStorageProvider) WriteIndex(ctx context.Context, keys []string, 
 
 // Shutdown cleans up any client resources that may be held by the provider
 func (isp *IndexStorageProvider) Shutdown() error {
-	// a registered collector keeps reporting the closed pools as all-zero, and blocks a
-	// replacement provider from registering its own
+	// a registered collector keeps reporting the closed pools as all-zero
 	if isp.collector != nil {
 		prometheus.DefaultRegisterer.Unregister(isp.collector)
 		isp.collector = nil

--- a/pkg/indexstorage/mysql/mysql_test.go
+++ b/pkg/indexstorage/mysql/mysql_test.go
@@ -22,25 +22,40 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/jmoiron/sqlx"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 
 	"go.uber.org/goleak"
 )
 
-func TestLookupIndices(t *testing.T) {
-	keys := []string{"87c1b129fbadd7b6e9abc0a9ef7695436d767aece042bec198a97e949fcbe14c"}
-	value := []string{"1e1f2c881ae0608ec77ebf88a75c66d3099113a7343238f2f7a0ebb91a4ed335"}
-	db, mock, err := sqlmock.New()
+// newMockDB returns a sqlx handle over a sqlmock connection. Mocks that expect writeStmt
+// need QueryMatcherEqual, since its positional form contains "(?" and is not a valid regexp.
+func newMockDB(t *testing.T, matcher sqlmock.QueryMatcher) (*sqlx.DB, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(matcher))
 	if err != nil {
 		t.Fatalf("unexpected error creating mock db: %v", err)
 	}
+	return sqlx.NewDb(db, "mysql"), mock
+}
 
-	isp := IndexStorageProvider{sqlx.NewDb(db, "mysql")}
+// positionalWriteStmt renders writeStmt's named parameters in the positional form the driver
+// actually receives.
+func positionalWriteStmt() string {
+	return regexp.MustCompile(`:[a-z]*`).ReplaceAllString(writeStmt, "?")
+}
+
+func TestLookupIndices(t *testing.T) {
+	keys := []string{"87c1b129fbadd7b6e9abc0a9ef7695436d767aece042bec198a97e949fcbe14c"}
+	value := []string{"1e1f2c881ae0608ec77ebf88a75c66d3099113a7343238f2f7a0ebb91a4ed335"}
+	db, mock := newMockDB(t, sqlmock.QueryMatcherRegexp)
+
+	isp := IndexStorageProvider{readDB: db}
 	defer isp.Shutdown()
 
 	mock.ExpectQuery(lookupStmt).WithArgs(keys[0]).WillReturnRows(sqlmock.NewRows(value))
 
-	_, err = isp.LookupIndices(context.Background(), keys)
-	if err != nil {
+	if _, err := isp.LookupIndices(context.Background(), keys); err != nil {
 		t.Error(err)
 	}
 
@@ -61,15 +76,10 @@ func TestLookupIndices(t *testing.T) {
 func TestWriteIndex(t *testing.T) {
 	keys := []string{"87c1b129fbadd7b6e9abc0a9ef7695436d767aece042bec198a97e949fcbe14c"}
 	value := "1e1f2c881ae0608ec77ebf88a75c66d3099113a7343238f2f7a0ebb91a4ed335"
-	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
-	if err != nil {
-		t.Fatalf("unexpected error creating mock db: %v", err)
-	}
+	db, mock := newMockDB(t, sqlmock.QueryMatcherEqual)
+	expectedStmt := positionalWriteStmt()
 
-	re := regexp.MustCompile(`:[a-z]*`)
-	expectedStmt := string(re.ReplaceAll([]byte(writeStmt), []byte("?")))
-
-	isp := IndexStorageProvider{sqlx.NewDb(db, "mysql")}
+	isp := IndexStorageProvider{writeDB: db}
 	defer isp.Shutdown()
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("expectations not met: %v", err)
@@ -91,6 +101,132 @@ func TestWriteIndex(t *testing.T) {
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Error(err)
+	}
+}
+
+// TestPoolSeparation asserts reads never touch the write pool and vice versa.
+// Each mock fails the test if it receives an unexpected statement.
+func TestPoolSeparation(t *testing.T) {
+	keys := []string{"87c1b129fbadd7b6e9abc0a9ef7695436d767aece042bec198a97e949fcbe14c"}
+	value := "1e1f2c881ae0608ec77ebf88a75c66d3099113a7343238f2f7a0ebb91a4ed335"
+
+	readDB, readMock := newMockDB(t, sqlmock.QueryMatcherRegexp)
+	writeDB, writeMock := newMockDB(t, sqlmock.QueryMatcherEqual)
+
+	isp := IndexStorageProvider{readDB: readDB, writeDB: writeDB}
+	defer isp.Shutdown()
+
+	readMock.ExpectQuery(lookupStmt).WithArgs(keys[0]).
+		WillReturnRows(sqlmock.NewRows([]string{"EntryUUID"}).AddRow(value))
+	got, err := isp.LookupIndices(context.Background(), keys)
+	if err != nil {
+		t.Errorf("lookup: %v", err)
+	}
+	if len(got) != 1 || got[0] != value {
+		t.Errorf("lookup returned %v, want [%s]", got, value)
+	}
+
+	writeMock.ExpectExec(positionalWriteStmt()).WithArgs(keys[0], value).WillReturnResult(sqlmock.NewResult(1, 1))
+	if err := isp.WriteIndex(context.Background(), keys, value); err != nil {
+		t.Errorf("write: %v", err)
+	}
+
+	// an unmet expectation on either mock means a statement went to the wrong pool
+	if err := readMock.ExpectationsWereMet(); err != nil {
+		t.Errorf("read pool: %v", err)
+	}
+	if err := writeMock.ExpectationsWereMet(); err != nil {
+		t.Errorf("write pool: %v", err)
+	}
+}
+
+func TestDBStatsCollector(t *testing.T) {
+	readDB, _ := newMockDB(t, sqlmock.QueryMatcherRegexp)
+	writeDB, _ := newMockDB(t, sqlmock.QueryMatcherRegexp)
+	isp := IndexStorageProvider{readDB: readDB, writeDB: writeDB}
+	defer isp.Shutdown()
+
+	collector := &dbStatsCollector{readDB: isp.readDB, writeDB: isp.writeDB}
+	for _, name := range []string{
+		"rekor_index_storage_db_connections_open",
+		"rekor_index_storage_db_wait_count_total",
+		"rekor_index_storage_db_wait_duration_seconds_total",
+	} {
+		if got := testutil.CollectAndCount(collector, name); got != 2 {
+			t.Errorf("%s: got %d series, want 2 (one per pool)", name, got)
+		}
+	}
+
+	problems, err := testutil.CollectAndLint(collector)
+	if err != nil {
+		t.Fatalf("lint: %v", err)
+	}
+	for _, p := range problems {
+		t.Errorf("lint: %s: %s", p.Metric, p.Text)
+	}
+}
+
+// TestDBStatsCollectorNilPool covers a partially constructed provider, where one pool was
+// never opened.
+func TestDBStatsCollectorNilPool(t *testing.T) {
+	collector := &dbStatsCollector{}
+	if got := testutil.CollectAndCount(collector); got != 0 {
+		t.Errorf("got %d series from an empty collector, want 0", got)
+	}
+}
+
+// TestShutdownUnregistersCollector guards against a closed provider holding the registry
+// slot, which would report all-zero pool stats forever and block any replacement provider.
+func TestShutdownUnregistersCollector(t *testing.T) {
+	readDB, readMock := newMockDB(t, sqlmock.QueryMatcherRegexp)
+	writeDB, writeMock := newMockDB(t, sqlmock.QueryMatcherRegexp)
+	isp := IndexStorageProvider{readDB: readDB, writeDB: writeDB}
+	isp.collector = &dbStatsCollector{readDB: isp.readDB, writeDB: isp.writeDB}
+
+	if err := prometheus.DefaultRegisterer.Register(isp.collector); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	readMock.ExpectClose()
+	writeMock.ExpectClose()
+	if err := isp.Shutdown(); err != nil {
+		t.Fatalf("shutdown: %v", err)
+	}
+	for name, mock := range map[string]sqlmock.Sqlmock{"read": readMock, "write": writeMock} {
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Errorf("%s pool not closed: %v", name, err)
+		}
+	}
+
+	// the slot is free only if a replacement can claim it
+	replacement := &dbStatsCollector{}
+	if err := prometheus.DefaultRegisterer.Register(replacement); err != nil {
+		t.Fatalf("registry slot still held after shutdown: %v", err)
+	}
+	prometheus.DefaultRegisterer.Unregister(replacement)
+}
+
+func TestConnOptionsAreRoleScoped(t *testing.T) {
+	// each pool is opened with the full option slice, so an option meant for the other
+	// pool must leave this one at its default of unlimited
+	for _, tc := range []struct {
+		name string
+		opt  Options
+		role poolRole
+		want int
+	}{
+		{"read option on read pool", WithReadMaxOpenConns(5), poolRead, 5},
+		{"read option on write pool", WithReadMaxOpenConns(5), poolWrite, 0},
+		{"write option on write pool", WithWriteMaxOpenConns(7), poolWrite, 7},
+		{"write option on read pool", WithWriteMaxOpenConns(7), poolRead, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, _ := newMockDB(t, sqlmock.QueryMatcherRegexp)
+			defer db.Close()
+			tc.opt.applyMaxOpenConns(db, tc.role)
+			if got := db.Stats().MaxOpenConnections; got != tc.want {
+				t.Errorf("got %d max open connections, want %d", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/pkg/indexstorage/mysql/options.go
+++ b/pkg/indexstorage/mysql/options.go
@@ -20,12 +20,15 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-// Options configures connections to the MySQL index storage system
+// Options configures connections to the MySQL index storage system.
+//
+// The read and write pools are sized independently, so the connection limit options name
+// the pool they configure and are ignored when the other pool is being opened.
 type Options interface {
 	applyConnMaxIdleTime(*sqlx.DB)
 	applyConnMaxLifetime(*sqlx.DB)
-	applyMaxIdleConns(*sqlx.DB)
-	applyMaxOpenConns(*sqlx.DB)
+	applyMaxIdleConns(*sqlx.DB, poolRole)
+	applyMaxOpenConns(*sqlx.DB, poolRole)
 }
 
 // NoOpOptionImpl implements the MySQLOption interfaces as no-ops.
@@ -38,10 +41,10 @@ func (noOpOptionImpl) applyConnMaxIdleTime(_ *sqlx.DB) {}
 func (noOpOptionImpl) applyConnMaxLifetime(_ *sqlx.DB) {}
 
 // ApplyMaxOpenConns is a no-op required to fully implement the requisite interfaces
-func (noOpOptionImpl) applyMaxOpenConns(_ *sqlx.DB) {}
+func (noOpOptionImpl) applyMaxOpenConns(_ *sqlx.DB, _ poolRole) {}
 
 // ApplyMaxIdleConns is a no-op required to fully implement the requisite interfaces
-func (noOpOptionImpl) applyMaxIdleConns(_ *sqlx.DB) {}
+func (noOpOptionImpl) applyMaxIdleConns(_ *sqlx.DB, _ poolRole) {}
 
 // RequestConnMaxIdleTime implements the functional option pattern for specifying the maximum connection idle time
 type RequestConnMaxIdleTime struct {
@@ -79,38 +82,69 @@ func WithConnMaxLifetime(lifetime time.Duration) RequestConnMaxLifetime {
 	return RequestConnMaxLifetime{lifetime: lifetime}
 }
 
-// RequestMaxIdleConns implements the functional option pattern for specifying the maximum number of idle connections
+// RequestMaxIdleConns implements the functional option pattern for specifying the maximum
+// number of idle connections in one pool
 type RequestMaxIdleConns struct {
 	noOpOptionImpl
+	role      poolRole
 	idleConns int
 }
 
-// ApplyMaxIdleConns sets the maximum number of idle connections
-func (r RequestMaxIdleConns) applyMaxIdleConns(db *sqlx.DB) {
-	if db != nil {
+// ApplyMaxIdleConns sets the maximum number of idle connections, if db is the pool this
+// option was built for
+func (r RequestMaxIdleConns) applyMaxIdleConns(db *sqlx.DB, role poolRole) {
+	if db != nil && role == r.role {
 		db.SetMaxIdleConns(r.idleConns)
 	}
 }
 
-// WithMaxIdleConns specifies the maximum number of idle connections
-func WithMaxIdleConns(idleConns int) RequestMaxIdleConns {
-	return RequestMaxIdleConns{idleConns: idleConns}
+// WithReadMaxIdleConns specifies the maximum number of idle connections in the read pool
+func WithReadMaxIdleConns(idleConns int) RequestMaxIdleConns {
+	return RequestMaxIdleConns{role: poolRead, idleConns: idleConns}
 }
 
-// RequestMaxOpenConns implements the functional option pattern for specifying the maximum number of open connections
+// WithWriteMaxIdleConns specifies the maximum number of idle connections in the write pool
+func WithWriteMaxIdleConns(idleConns int) RequestMaxIdleConns {
+	return RequestMaxIdleConns{role: poolWrite, idleConns: idleConns}
+}
+
+// RequestMaxOpenConns implements the functional option pattern for specifying the maximum
+// number of open connections in one pool
 type RequestMaxOpenConns struct {
 	noOpOptionImpl
+	role      poolRole
 	openConns int
 }
 
-// applyMaxOpenConns sets the maximum number of open connections
-func (r RequestMaxOpenConns) applyMaxOpenConns(db *sqlx.DB) {
-	if db != nil {
+// applyMaxOpenConns sets the maximum number of open connections, if db is the pool this
+// option was built for
+func (r RequestMaxOpenConns) applyMaxOpenConns(db *sqlx.DB, role poolRole) {
+	if db != nil && role == r.role {
 		db.SetMaxOpenConns(r.openConns)
 	}
 }
 
-// WithMaxOpenConns specifies the maximum number of open connections
-func WithMaxOpenConns(openConns int) RequestMaxOpenConns {
-	return RequestMaxOpenConns{openConns: openConns}
+// WithReadMaxOpenConns specifies the maximum number of open connections in the read pool
+func WithReadMaxOpenConns(openConns int) RequestMaxOpenConns {
+	return RequestMaxOpenConns{role: poolRead, openConns: openConns}
+}
+
+// WithWriteMaxOpenConns specifies the maximum number of open connections in the write pool
+func WithWriteMaxOpenConns(openConns int) RequestMaxOpenConns {
+	return RequestMaxOpenConns{role: poolWrite, openConns: openConns}
+}
+
+// poolRole identifies which of the provider's two connection pools is being configured.
+type poolRole int
+
+const (
+	poolRead poolRole = iota
+	poolWrite
+)
+
+func (r poolRole) String() string {
+	if r == poolWrite {
+		return "write"
+	}
+	return "read"
 }


### PR DESCRIPTION
This refactors IndexStorageProvider in `mysql.go` to separate database connection management into two dedicated `*sqlx.DB` pools: `readDB` and `writeDB`.

1. Prevents Read Starvation / Denial of Service (DoS):
Rekor dispatches entry index writes asynchronously per entry while lookups (`LookupIndices`) run synchronously on the HTTP request path (`/api/v1/index/retrieve`). With a single shared pool, write bursts could consume all open connections. Because `database/sql` selects waiting goroutines randomly, read requests faced unbounded latency or request context timeouts. Splitting pools guarantees dedicated capacity for reads.

2. Backward-Compatible Connection Sizing:
Legacy connection limits (`search_index.mysql.max_open_connections / max_idle_connections`) are automatically split 70% write / 30% read in `indexstorage.go` to preserve the total connection budget without exceeding server limits.

3. DB Observability per Pool:
A custom Prometheus collector `metrics.go` was added to export Prometheus metrics tagged with `pool="read"` and `pool="write"`.