### PR TITLE
remove unused semver type version map

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.25.8
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
-	github.com/blang/semver v3.5.1+incompatible
 	github.com/go-openapi/errors v0.22.8
 	github.com/go-openapi/loads v0.25.0
 	github.com/go-openapi/runtime v0.32.5

--- a/go.sum
+++ b/go.sum
@@ -112,8 +112,6 @@ github.com/aws/smithy-go v1.27.3/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqx
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
-github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=

--- a/pkg/types/alpine/alpine.go
+++ b/pkg/types/alpine/alpine.go
@@ -43,7 +43,7 @@ func New() types.TypeImpl {
 	return &bat
 }
 
-var VersionMap = types.NewSemVerEntryFactoryMap()
+var VersionMap = types.NewEntryFactoryMap()
 
 func (bat *BaseAlpineType) UnmarshalEntry(pe models.ProposedEntry) (types.EntryImpl, error) {
 	if pe == nil {

--- a/pkg/types/alpine/alpine_test.go
+++ b/pkg/types/alpine/alpine_test.go
@@ -58,17 +58,17 @@ func TestAlpineType(t *testing.T) {
 	}
 
 	u := UnmarshalTester{}
-	// ensure semver range parser is working
-	invalidSemVerRange := "not a valid semver range"
+	// ensure empty version is rejected
+	invalidSemVerRange := ""
 	err := VersionMap.SetEntryFactory(invalidSemVerRange, u.NewEntry)
 	if err == nil || VersionMap.Count() > 0 {
-		t.Error("invalid semver range was incorrectly added to SemVerToFacFnMap")
+		t.Error("invalid version was incorrectly added to SemVerToFacFnMap")
 	}
 
-	// valid semver range can be parsed
-	err = VersionMap.SetEntryFactory(">= 1.2.3", u.NewEntry)
+	// valid version can be parsed
+	err = VersionMap.SetEntryFactory("2.0.1", u.NewEntry)
 	if err != nil || VersionMap.Count() != 1 {
-		t.Error("valid semver range was not added to SemVerToFacFnMap")
+		t.Error("valid version was not added to SemVerToFacFnMap")
 	}
 
 	u.Alpine.APIVersion = nil
@@ -95,7 +95,7 @@ func TestAlpineType(t *testing.T) {
 	// error in Unmarshal call is raised appropriately
 	u.Alpine.APIVersion = conv.Pointer("2.2.0")
 	u2 := UnmarshalFailsTester{}
-	_ = VersionMap.SetEntryFactory(">= 1.2.3", u2.NewEntry)
+	_ = VersionMap.SetEntryFactory("2.2.0", u2.NewEntry)
 	if _, err := brt.UnmarshalEntry(&u.Alpine); err == nil {
 		t.Error("unexpected success in Unmarshal when error is thrown")
 	}

--- a/pkg/types/cose/cose.go
+++ b/pkg/types/cose/cose.go
@@ -43,7 +43,7 @@ func New() types.TypeImpl {
 	return &bit
 }
 
-var VersionMap = types.NewSemVerEntryFactoryMap()
+var VersionMap = types.NewEntryFactoryMap()
 
 func (it BaseCOSEType) UnmarshalEntry(pe models.ProposedEntry) (types.EntryImpl, error) {
 	if pe == nil {

--- a/pkg/types/cose/cose_test.go
+++ b/pkg/types/cose/cose_test.go
@@ -59,17 +59,17 @@ func TestCOSEType(t *testing.T) {
 	}
 
 	u := UnmarshalTester{}
-	// ensure semver range parser is working
-	invalidSemVerRange := "not a valid semver range"
+	// ensure empty version is rejected
+	invalidSemVerRange := ""
 	err := VersionMap.SetEntryFactory(invalidSemVerRange, u.NewEntry)
 	if err == nil || VersionMap.Count() > 0 {
-		t.Error("invalid semver range was incorrectly added to SemVerToFacFnMap")
+		t.Error("invalid version was incorrectly added to SemVerToFacFnMap")
 	}
 
-	// valid semver range can be parsed
-	err = VersionMap.SetEntryFactory(">= 1.2.3", u.NewEntry)
+	// valid version can be parsed
+	err = VersionMap.SetEntryFactory("2.0.1", u.NewEntry)
 	if err != nil || VersionMap.Count() != 1 {
-		t.Error("valid semver range was not added to SemVerToFacFnMap")
+		t.Error("valid version was not added to SemVerToFacFnMap")
 	}
 
 	u.Cose.APIVersion = nil
@@ -96,7 +96,7 @@ func TestCOSEType(t *testing.T) {
 	// error in Unmarshal call is raised appropriately
 	u.Cose.APIVersion = conv.Pointer("2.2.0")
 	u2 := UnmarshalFailsTester{}
-	_ = VersionMap.SetEntryFactory(">= 1.2.3", u2.NewEntry)
+	_ = VersionMap.SetEntryFactory("2.2.0", u2.NewEntry)
 	if _, err := brt.UnmarshalEntry(&u.Cose); err == nil {
 		t.Error("unexpected success in Unmarshal when error is thrown")
 	}
@@ -135,7 +135,7 @@ func TestCOSEDefaultVersion(t *testing.T) {
 
 func TestCOSECreateProposedEntry(t *testing.T) {
 	// Reset semver map
-	VersionMap = types.NewSemVerEntryFactoryMap()
+	VersionMap = types.NewEntryFactoryMap()
 	u := UnmarshalTester{}
 	VersionMap.SetEntryFactory("0.0.3", u.NewEntry)
 	VersionMap.SetEntryFactory(New().DefaultVersion(), u.NewEntry)

--- a/pkg/types/dsse/dsse.go
+++ b/pkg/types/dsse/dsse.go
@@ -43,7 +43,7 @@ func New() types.TypeImpl {
 	return &bit
 }
 
-var VersionMap = types.NewSemVerEntryFactoryMap()
+var VersionMap = types.NewEntryFactoryMap()
 
 func (it BaseDSSEType) UnmarshalEntry(pe models.ProposedEntry) (types.EntryImpl, error) {
 	if pe == nil {

--- a/pkg/types/dsse/dsse_test.go
+++ b/pkg/types/dsse/dsse_test.go
@@ -55,17 +55,17 @@ func TestDSSEType(t *testing.T) {
 	}
 
 	u := UnmarshalTester{}
-	// ensure semver range parser is working
-	invalidSemVerRange := "not a valid semver range"
+	// ensure empty version is rejected
+	invalidSemVerRange := ""
 	err := VersionMap.SetEntryFactory(invalidSemVerRange, u.NewEntry)
 	if err == nil || VersionMap.Count() > 0 {
-		t.Error("invalid semver range was incorrectly added to SemVerToFacFnMap")
+		t.Error("invalid version was incorrectly added to SemVerToFacFnMap")
 	}
 
-	// valid semver range can be parsed
-	err = VersionMap.SetEntryFactory(">= 1.2.3", u.NewEntry)
+	// valid version can be parsed
+	err = VersionMap.SetEntryFactory("2.0.1", u.NewEntry)
 	if err != nil || VersionMap.Count() != 1 {
-		t.Error("valid semver range was not added to SemVerToFacFnMap")
+		t.Error("valid version was not added to SemVerToFacFnMap")
 	}
 
 	u.DSSE.APIVersion = nil
@@ -92,7 +92,7 @@ func TestDSSEType(t *testing.T) {
 	// error in Unmarshal call is raised appropriately
 	u.DSSE.APIVersion = conv.Pointer("2.2.0")
 	u2 := UnmarshalFailsTester{}
-	_ = VersionMap.SetEntryFactory(">= 1.2.3", u2.NewEntry)
+	_ = VersionMap.SetEntryFactory("2.2.0", u2.NewEntry)
 	if _, err := brt.UnmarshalEntry(&u.DSSE); err == nil {
 		t.Error("unexpected success in Unmarshal when error is thrown")
 	}
@@ -131,7 +131,7 @@ func TestDSSEDefaultVersion(t *testing.T) {
 
 func TestDSSECreateProposedEntry(t *testing.T) {
 	// Reset semver map
-	VersionMap = types.NewSemVerEntryFactoryMap()
+	VersionMap = types.NewEntryFactoryMap()
 	u := UnmarshalTester{}
 	VersionMap.SetEntryFactory("0.0.1", u.NewEntry)
 	VersionMap.SetEntryFactory(New().DefaultVersion(), u.NewEntry)

--- a/pkg/types/hashedrekord/hashedrekord.go
+++ b/pkg/types/hashedrekord/hashedrekord.go
@@ -43,7 +43,7 @@ func New() types.TypeImpl {
 	return &brt
 }
 
-var VersionMap = types.NewSemVerEntryFactoryMap()
+var VersionMap = types.NewEntryFactoryMap()
 
 func (rt BaseRekordType) UnmarshalEntry(pe models.ProposedEntry) (types.EntryImpl, error) {
 	if pe == nil {

--- a/pkg/types/hashedrekord/hashedrekord_test.go
+++ b/pkg/types/hashedrekord/hashedrekord_test.go
@@ -58,17 +58,17 @@ func TestRekordType(t *testing.T) {
 	}
 
 	u := UnmarshalTester{}
-	// ensure semver range parser is working
-	invalidSemVerRange := "not a valid semver range"
+	// ensure empty version is rejected
+	invalidSemVerRange := ""
 	err := VersionMap.SetEntryFactory(invalidSemVerRange, u.NewEntry)
 	if err == nil || VersionMap.Count() > 0 {
-		t.Error("invalid semver range was incorrectly added to SemVerToFacFnMap")
+		t.Error("invalid version was incorrectly added to SemVerToFacFnMap")
 	}
 
-	// valid semver range can be parsed
-	err = VersionMap.SetEntryFactory(">= 1.2.3", u.NewEntry)
+	// valid version can be parsed
+	err = VersionMap.SetEntryFactory("2.0.1", u.NewEntry)
 	if err != nil || VersionMap.Count() != 1 {
-		t.Error("valid semver range was not added to SemVerToFacFnMap")
+		t.Error("valid version was not added to SemVerToFacFnMap")
 	}
 
 	u.Hashedrekord.APIVersion = nil
@@ -95,7 +95,7 @@ func TestRekordType(t *testing.T) {
 	// error in Unmarshal call is raised appropriately
 	u.Hashedrekord.APIVersion = conv.Pointer("2.2.0")
 	u2 := UnmarshalFailsTester{}
-	_ = VersionMap.SetEntryFactory(">= 1.2.3", u2.NewEntry)
+	_ = VersionMap.SetEntryFactory("2.2.0", u2.NewEntry)
 	if _, err := brt.UnmarshalEntry(&u.Hashedrekord); err == nil {
 		t.Error("unexpected success in Unmarshal when error is thrown")
 	}

--- a/pkg/types/helm/helm.go
+++ b/pkg/types/helm/helm.go
@@ -43,7 +43,7 @@ func New() types.TypeImpl {
 	return &bit
 }
 
-var VersionMap = types.NewSemVerEntryFactoryMap()
+var VersionMap = types.NewEntryFactoryMap()
 
 func (it BaseHelmType) UnmarshalEntry(pe models.ProposedEntry) (types.EntryImpl, error) {
 	if pe == nil {

--- a/pkg/types/helm/helm_test.go
+++ b/pkg/types/helm/helm_test.go
@@ -54,17 +54,17 @@ func TestHelmType(t *testing.T) {
 	}
 
 	u := UnmarshalTester{}
-	// ensure semver range parser is working
-	invalidSemVerRange := "not a valid semver range"
+	// ensure empty version is rejected
+	invalidSemVerRange := ""
 	err := VersionMap.SetEntryFactory(invalidSemVerRange, u.NewEntry)
 	if err == nil || VersionMap.Count() > 0 {
-		t.Error("invalid semver range was incorrectly added to SemVerToFacFnMap")
+		t.Error("invalid version was incorrectly added to SemVerToFacFnMap")
 	}
 
-	// valid semver range can be parsed
-	err = VersionMap.SetEntryFactory(">= 1.2.3", u.NewEntry)
+	// valid version can be parsed
+	err = VersionMap.SetEntryFactory("2.0.1", u.NewEntry)
 	if err != nil || VersionMap.Count() != 1 {
-		t.Error("valid semver range was not added to SemVerToFacFnMap")
+		t.Error("valid version was not added to SemVerToFacFnMap")
 	}
 
 	u.Helm.APIVersion = nil
@@ -91,7 +91,7 @@ func TestHelmType(t *testing.T) {
 	// error in Unmarshal call is raised appropriately
 	u.Helm.APIVersion = conv.Pointer("2.2.0")
 	u2 := UnmarshalFailsTester{}
-	_ = VersionMap.SetEntryFactory(">= 1.2.3", u2.NewEntry)
+	_ = VersionMap.SetEntryFactory("2.2.0", u2.NewEntry)
 	if _, err := brt.UnmarshalEntry(&u.Helm); err == nil {
 		t.Error("unexpected success in Unmarshal when error is thrown")
 	}

--- a/pkg/types/intoto/intoto.go
+++ b/pkg/types/intoto/intoto.go
@@ -45,7 +45,7 @@ func New() types.TypeImpl {
 	return &bit
 }
 
-var VersionMap = types.NewSemVerEntryFactoryMap()
+var VersionMap = types.NewEntryFactoryMap()
 
 func (it BaseIntotoType) UnmarshalEntry(pe models.ProposedEntry) (types.EntryImpl, error) {
 	if pe == nil {

--- a/pkg/types/intoto/intoto_test.go
+++ b/pkg/types/intoto/intoto_test.go
@@ -54,17 +54,17 @@ func TestIntotoType(t *testing.T) {
 	}
 
 	u := UnmarshalTester{}
-	// ensure semver range parser is working
-	invalidSemVerRange := "not a valid semver range"
+	// ensure empty version is rejected
+	invalidSemVerRange := ""
 	err := VersionMap.SetEntryFactory(invalidSemVerRange, u.NewEntry)
 	if err == nil || VersionMap.Count() > 0 {
-		t.Error("invalid semver range was incorrectly added to SemVerToFacFnMap")
+		t.Error("invalid version was incorrectly added to SemVerToFacFnMap")
 	}
 
-	// valid semver range can be parsed
-	err = VersionMap.SetEntryFactory(">= 1.2.3", u.NewEntry)
+	// valid version can be parsed
+	err = VersionMap.SetEntryFactory("2.0.1", u.NewEntry)
 	if err != nil || VersionMap.Count() != 1 {
-		t.Error("valid semver range was not added to SemVerToFacFnMap")
+		t.Error("valid version was not added to SemVerToFacFnMap")
 	}
 
 	u.Intoto.APIVersion = nil
@@ -91,7 +91,7 @@ func TestIntotoType(t *testing.T) {
 	// error in Unmarshal call is raised appropriately
 	u.Intoto.APIVersion = conv.Pointer("2.2.0")
 	u2 := UnmarshalFailsTester{}
-	_ = VersionMap.SetEntryFactory(">= 1.2.3", u2.NewEntry)
+	_ = VersionMap.SetEntryFactory("2.2.0", u2.NewEntry)
 	if _, err := brt.UnmarshalEntry(&u.Intoto); err == nil {
 		t.Error("unexpected success in Unmarshal when error is thrown")
 	}

--- a/pkg/types/jar/jar.go
+++ b/pkg/types/jar/jar.go
@@ -43,7 +43,7 @@ func New() types.TypeImpl {
 	return &bjt
 }
 
-var VersionMap = types.NewSemVerEntryFactoryMap()
+var VersionMap = types.NewEntryFactoryMap()
 
 func (bjt *BaseJARType) UnmarshalEntry(pe models.ProposedEntry) (types.EntryImpl, error) {
 	if pe == nil {

--- a/pkg/types/jar/jar_test.go
+++ b/pkg/types/jar/jar_test.go
@@ -53,17 +53,17 @@ func TestJARType(t *testing.T) {
 	}
 
 	u := UnmarshalTester{}
-	// ensure semver range parser is working
-	invalidSemVerRange := "not a valid semver range"
-	VersionMap.SetEntryFactory(invalidSemVerRange, u.NewEntry)
+	// ensure empty version is rejected
+	invalidSemVerRange := ""
+	_ = VersionMap.SetEntryFactory(invalidSemVerRange, u.NewEntry)
 	if VersionMap.Count() > 0 {
-		t.Error("invalid semver range was incorrectly added to SemVerToFacFnMap")
+		t.Error("invalid version was incorrectly added to SemVerToFacFnMap")
 	}
 
-	// valid semver range can be parsed
-	VersionMap.SetEntryFactory(">= 1.2.3", u.NewEntry)
+	// valid version can be parsed
+	_ = VersionMap.SetEntryFactory("2.0.1", u.NewEntry)
 	if VersionMap.Count() != 1 {
-		t.Error("valid semver range was not added to SemVerToFacFnMap")
+		t.Error("valid version was not added to SemVerToFacFnMap")
 	}
 
 	u.Jar.APIVersion = nil
@@ -90,7 +90,7 @@ func TestJARType(t *testing.T) {
 	// error in Unmarshal call is raised appropriately
 	u.Jar.APIVersion = conv.Pointer("2.2.0")
 	u2 := UnmarshalFailsTester{}
-	VersionMap.SetEntryFactory(">= 1.2.3", u2.NewEntry)
+	_ = VersionMap.SetEntryFactory("2.2.0", u2.NewEntry)
 	if _, err := brt.UnmarshalEntry(&u.Jar); err == nil {
 		t.Error("unexpected success in Unmarshal when error is thrown")
 	}

--- a/pkg/types/rekord/rekord.go
+++ b/pkg/types/rekord/rekord.go
@@ -43,7 +43,7 @@ func New() types.TypeImpl {
 	return &brt
 }
 
-var VersionMap = types.NewSemVerEntryFactoryMap()
+var VersionMap = types.NewEntryFactoryMap()
 
 func (rt BaseRekordType) UnmarshalEntry(pe models.ProposedEntry) (types.EntryImpl, error) {
 	if pe == nil {

--- a/pkg/types/rekord/rekord_test.go
+++ b/pkg/types/rekord/rekord_test.go
@@ -54,17 +54,17 @@ func TestRekordType(t *testing.T) {
 	}
 
 	u := UnmarshalTester{}
-	// ensure semver range parser is working
-	invalidSemVerRange := "not a valid semver range"
+	// ensure empty version is rejected
+	invalidSemVerRange := ""
 	err := VersionMap.SetEntryFactory(invalidSemVerRange, u.NewEntry)
 	if err == nil || VersionMap.Count() > 0 {
-		t.Error("invalid semver range was incorrectly added to SemVerToFacFnMap")
+		t.Error("invalid version was incorrectly added to SemVerToFacFnMap")
 	}
 
-	// valid semver range can be parsed
-	err = VersionMap.SetEntryFactory(">= 1.2.3", u.NewEntry)
+	// valid version can be parsed
+	err = VersionMap.SetEntryFactory("2.0.1", u.NewEntry)
 	if err != nil || VersionMap.Count() != 1 {
-		t.Error("valid semver range was not added to SemVerToFacFnMap")
+		t.Error("valid version was not added to SemVerToFacFnMap")
 	}
 
 	u.Rekord.APIVersion = nil
@@ -91,7 +91,7 @@ func TestRekordType(t *testing.T) {
 	// error in Unmarshal call is raised appropriately
 	u.Rekord.APIVersion = conv.Pointer("2.2.0")
 	u2 := UnmarshalFailsTester{}
-	_ = VersionMap.SetEntryFactory(">= 1.2.3", u2.NewEntry)
+	_ = VersionMap.SetEntryFactory("2.2.0", u2.NewEntry)
 	if _, err := brt.UnmarshalEntry(&u.Rekord); err == nil {
 		t.Error("unexpected success in Unmarshal when error is thrown")
 	}

--- a/pkg/types/rfc3161/rfc3161.go
+++ b/pkg/types/rfc3161/rfc3161.go
@@ -43,7 +43,7 @@ func New() types.TypeImpl {
 	return &btt
 }
 
-var VersionMap = types.NewSemVerEntryFactoryMap()
+var VersionMap = types.NewEntryFactoryMap()
 
 func (btt BaseTimestampType) UnmarshalEntry(pe models.ProposedEntry) (types.EntryImpl, error) {
 	if pe == nil {

--- a/pkg/types/rfc3161/rfc3161_test.go
+++ b/pkg/types/rfc3161/rfc3161_test.go
@@ -54,17 +54,17 @@ func TestRfc3161Type(t *testing.T) {
 	}
 
 	u := UnmarshalTester{}
-	// ensure semver range parser is working
-	invalidSemVerRange := "not a valid semver range"
+	// ensure empty version is rejected
+	invalidSemVerRange := ""
 	err := VersionMap.SetEntryFactory(invalidSemVerRange, u.NewEntry)
 	if err == nil || VersionMap.Count() > 0 {
-		t.Error("invalid semver range was incorrectly added to SemVerToFacFnMap")
+		t.Error("invalid version was incorrectly added to SemVerToFacFnMap")
 	}
 
-	// valid semver range can be parsed
-	err = VersionMap.SetEntryFactory(">= 1.2.3", u.NewEntry)
+	// valid version can be parsed
+	err = VersionMap.SetEntryFactory("2.0.1", u.NewEntry)
 	if err != nil || VersionMap.Count() != 1 {
-		t.Error("valid semver range was not added to SemVerToFacFnMap")
+		t.Error("valid version was not added to SemVerToFacFnMap")
 	}
 
 	u.Rfc3161.APIVersion = nil
@@ -91,7 +91,7 @@ func TestRfc3161Type(t *testing.T) {
 	// error in Unmarshal call is raised appropriately
 	u.Rfc3161.APIVersion = conv.Pointer("2.2.0")
 	u2 := UnmarshalFailsTester{}
-	_ = VersionMap.SetEntryFactory(">= 1.2.3", u2.NewEntry)
+	_ = VersionMap.SetEntryFactory("2.2.0", u2.NewEntry)
 	if _, err := brt.UnmarshalEntry(&u.Rfc3161); err == nil {
 		t.Error("unexpected success in Unmarshal when error is thrown")
 	}

--- a/pkg/types/rpm/rpm.go
+++ b/pkg/types/rpm/rpm.go
@@ -43,7 +43,7 @@ func New() types.TypeImpl {
 	return &brt
 }
 
-var VersionMap = types.NewSemVerEntryFactoryMap()
+var VersionMap = types.NewEntryFactoryMap()
 
 func (brt *BaseRPMType) UnmarshalEntry(pe models.ProposedEntry) (types.EntryImpl, error) {
 	if pe == nil {

--- a/pkg/types/rpm/rpm_test.go
+++ b/pkg/types/rpm/rpm_test.go
@@ -54,17 +54,17 @@ func TestRPMType(t *testing.T) {
 	}
 
 	u := UnmarshalTester{}
-	// ensure semver range parser is working
-	invalidSemVerRange := "not a valid semver range"
+	// ensure empty version is rejected
+	invalidSemVerRange := ""
 	err := VersionMap.SetEntryFactory(invalidSemVerRange, u.NewEntry)
 	if err == nil || VersionMap.Count() > 0 {
-		t.Error("invalid semver range was incorrectly added to SemVerToFacFnMap")
+		t.Error("invalid version was incorrectly added to SemVerToFacFnMap")
 	}
 
-	// valid semver range can be parsed
-	err = VersionMap.SetEntryFactory(">= 1.2.3", u.NewEntry)
+	// valid version can be parsed
+	err = VersionMap.SetEntryFactory("2.0.1", u.NewEntry)
 	if err != nil || VersionMap.Count() != 1 {
-		t.Error("valid semver range was not added to SemVerToFacFnMap")
+		t.Error("valid version was not added to SemVerToFacFnMap")
 	}
 
 	u.Rpm.APIVersion = nil
@@ -91,7 +91,7 @@ func TestRPMType(t *testing.T) {
 	// error in Unmarshal call is raised appropriately
 	u.Rpm.APIVersion = conv.Pointer("2.2.0")
 	u2 := UnmarshalFailsTester{}
-	_ = VersionMap.SetEntryFactory(">= 1.2.3", u2.NewEntry)
+	_ = VersionMap.SetEntryFactory("2.2.0", u2.NewEntry)
 	if _, err := brt.UnmarshalEntry(&u.Rpm); err == nil {
 		t.Error("unexpected success in Unmarshal when error is thrown")
 	}

--- a/pkg/types/tuf/tuf.go
+++ b/pkg/types/tuf/tuf.go
@@ -44,7 +44,7 @@ func New() types.TypeImpl {
 	return &btt
 }
 
-var VersionMap = types.NewSemVerEntryFactoryMap()
+var VersionMap = types.NewEntryFactoryMap()
 
 func (btt BaseTufType) UnmarshalEntry(pe models.ProposedEntry) (types.EntryImpl, error) {
 	if pe == nil {

--- a/pkg/types/tuf/tuf_test.go
+++ b/pkg/types/tuf/tuf_test.go
@@ -54,17 +54,17 @@ func TestTufType(t *testing.T) {
 	}
 
 	u := UnmarshalTester{}
-	// ensure semver range parser is working
-	invalidSemVerRange := "not a valid semver range"
+	// ensure empty version is rejected
+	invalidSemVerRange := ""
 	err := VersionMap.SetEntryFactory(invalidSemVerRange, u.NewEntry)
 	if err == nil || VersionMap.Count() > 0 {
-		t.Error("invalid semver range was incorrectly added to SemVerToFacFnMap")
+		t.Error("invalid version was incorrectly added to SemVerToFacFnMap")
 	}
 
-	// valid semver range can be parsed
-	err = VersionMap.SetEntryFactory(">= 1.2.3", u.NewEntry)
+	// valid version can be parsed
+	err = VersionMap.SetEntryFactory("2.0.1", u.NewEntry)
 	if err != nil || VersionMap.Count() != 1 {
-		t.Error("valid semver range was not added to SemVerToFacFnMap")
+		t.Error("valid version was not added to SemVerToFacFnMap")
 	}
 
 	u.TUF.APIVersion = nil
@@ -91,7 +91,7 @@ func TestTufType(t *testing.T) {
 	// error in Unmarshal call is raised appropriately
 	u.TUF.APIVersion = conv.Pointer("2.2.0")
 	u2 := UnmarshalFailsTester{}
-	_ = VersionMap.SetEntryFactory(">= 1.2.3", u2.NewEntry)
+	_ = VersionMap.SetEntryFactory("2.2.0", u2.NewEntry)
 	if _, err := brt.UnmarshalEntry(&u.TUF); err == nil {
 		t.Error("unexpected success in Unmarshal when error is thrown")
 	}

--- a/pkg/types/versionmap.go
+++ b/pkg/types/versionmap.go
@@ -19,12 +19,11 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/blang/semver"
 	"github.com/sigstore/rekor/pkg/internal/log"
 )
 
 // VersionEntryFactoryMap defines a map-like interface to find the correct implementation for a version string
-// This could be a simple map[string][EntryFactory], or something more elegant (e.g. semver)
+// This could be a simple map[string][EntryFactory], or something more elegant
 type VersionEntryFactoryMap interface {
 	GetEntryFactory(string) (EntryFactory, error) // return the entry factory for the specified version
 	SetEntryFactory(string, EntryFactory) error   // set the entry factory for the specified version
@@ -32,63 +31,53 @@ type VersionEntryFactoryMap interface {
 	SupportedVersions() []string                  // return a list of versions currently stored in the map
 }
 
-// SemVerEntryFactoryMap implements a map that allows implementations to specify their supported versions using
-// semver-compliant strings
-type SemVerEntryFactoryMap struct {
+// EntryFactoryMap implements a thread-safe map of version strings to EntryFactory functions
+type EntryFactoryMap struct {
 	factoryMap map[string]EntryFactory
 
 	sync.RWMutex
 }
 
-func NewSemVerEntryFactoryMap() VersionEntryFactoryMap {
-	s := SemVerEntryFactoryMap{}
+func NewEntryFactoryMap() VersionEntryFactoryMap {
+	s := EntryFactoryMap{}
 	s.factoryMap = make(map[string]EntryFactory)
 	return &s
 }
 
-func (s *SemVerEntryFactoryMap) Count() int {
+func (s *EntryFactoryMap) Count() int {
+	s.RLock()
+	defer s.RUnlock()
 	return len(s.factoryMap)
 }
 
-func (s *SemVerEntryFactoryMap) GetEntryFactory(version string) (EntryFactory, error) {
+func (s *EntryFactoryMap) GetEntryFactory(version string) (EntryFactory, error) {
 	s.RLock()
 	defer s.RUnlock()
 
-	semverToMatch, err := semver.Parse(version)
-	if err != nil {
-		log.Logger.Error(err)
-		return nil, err
+	if ef, ok := s.factoryMap[version]; ok {
+		return ef, nil
 	}
 
-	// will return first function that matches
-	for k, v := range s.factoryMap {
-		semverRange, err := semver.ParseRange(k)
-		if err != nil {
-			log.Logger.Error(err)
-			return nil, err
-		}
-
-		if semverRange(semverToMatch) {
-			return v, nil
-		}
-	}
 	return nil, fmt.Errorf("unable to locate entry for version %s", version)
 }
 
-func (s *SemVerEntryFactoryMap) SetEntryFactory(constraint string, ef EntryFactory) error {
+func (s *EntryFactoryMap) SetEntryFactory(version string, ef EntryFactory) error {
 	s.Lock()
 	defer s.Unlock()
 
-	if _, err := semver.ParseRange(constraint); err != nil {
+	if version == "" {
+		err := fmt.Errorf("empty version string")
 		log.Logger.Error(err)
 		return err
 	}
 
-	s.factoryMap[constraint] = ef
+	s.factoryMap[version] = ef
 	return nil
 }
 
-func (s *SemVerEntryFactoryMap) SupportedVersions() []string {
+func (s *EntryFactoryMap) SupportedVersions() []string {
+	s.RLock()
+	defer s.RUnlock()
 	var versions []string
 	for k := range s.factoryMap {
 		versions = append(versions, k)

--- a/pkg/types/versionmap_test.go
+++ b/pkg/types/versionmap_test.go
@@ -1,0 +1,57 @@
+//
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"testing"
+)
+
+func dummyFactory() EntryImpl {
+	return nil
+}
+
+func TestVersionMap(t *testing.T) {
+	vm := NewEntryFactoryMap()
+	if vm.Count() != 0 {
+		t.Errorf("expected 0 entries, got %d", vm.Count())
+	}
+
+	if err := vm.SetEntryFactory("", dummyFactory); err == nil {
+		t.Error("expected error setting empty version string")
+	}
+
+	if err := vm.SetEntryFactory("0.0.1", dummyFactory); err != nil {
+		t.Errorf("unexpected error setting valid version string: %v", err)
+	}
+
+	if vm.Count() != 1 {
+		t.Errorf("expected 1 entry, got %d", vm.Count())
+	}
+
+	versions := vm.SupportedVersions()
+	if len(versions) != 1 || versions[0] != "0.0.1" {
+		t.Errorf("expected ['0.0.1'], got %v", versions)
+	}
+
+	ef, err := vm.GetEntryFactory("0.0.1")
+	if err != nil || ef == nil {
+		t.Errorf("unexpected error getting factory for 0.0.1: %v", err)
+	}
+
+	if _, err := vm.GetEntryFactory("9.9.9"); err == nil {
+		t.Error("expected error getting factory for nonexistent version")
+	}
+}


### PR DESCRIPTION
none of the types ever made use of semver matching. to prune the dependency graph, re-implementing this with a simple map lookup.