### PR TITLE
remove repetitive viper lookups from api endpoints

### DIFF
--- a/cmd/rekor-server/app/root.go
+++ b/cmd/rekor-server/app/root.go
@@ -25,14 +25,13 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5/middleware"
+	"github.com/sigstore/rekor/internal/config"
 	"github.com/sigstore/rekor/pkg/api"
 	"github.com/sigstore/rekor/pkg/log"
 	"github.com/sigstore/rekor/pkg/types"
-	"github.com/sigstore/rekor/pkg/types/alpine"
 	cose "github.com/sigstore/rekor/pkg/types/cose/v0.0.1"
 	intoto001 "github.com/sigstore/rekor/pkg/types/intoto/v0.0.1"
 	intoto002 "github.com/sigstore/rekor/pkg/types/intoto/v0.0.2"
-	jar_v001 "github.com/sigstore/rekor/pkg/types/jar/v0.0.1"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -244,6 +243,6 @@ func initConfig() {
 	intoto002.SetMaxAttestationSize(maxSize)
 	cose.SetMaxAttestationSize(maxSize)
 
-	alpine.SetMaxAPKMetadataSize(viper.GetUint64("max_apk_metadata_size"))
-	jar_v001.SetMaxJarMetadataSize(viper.GetUint64("max_jar_metadata_size"))
+	config.MaxAPKMetadataSize = viper.GetUint64("max_apk_metadata_size")
+	config.MaxJarMetadataSize = viper.GetUint64("max_jar_metadata_size")
 }

--- a/cmd/rekor-server/app/root.go
+++ b/cmd/rekor-server/app/root.go
@@ -28,9 +28,11 @@ import (
 	"github.com/sigstore/rekor/pkg/api"
 	"github.com/sigstore/rekor/pkg/log"
 	"github.com/sigstore/rekor/pkg/types"
+	"github.com/sigstore/rekor/pkg/types/alpine"
 	cose "github.com/sigstore/rekor/pkg/types/cose/v0.0.1"
 	intoto001 "github.com/sigstore/rekor/pkg/types/intoto/v0.0.1"
 	intoto002 "github.com/sigstore/rekor/pkg/types/intoto/v0.0.2"
+	jar_v001 "github.com/sigstore/rekor/pkg/types/jar/v0.0.1"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -241,4 +243,7 @@ func initConfig() {
 	intoto001.SetMaxAttestationSize(maxSize)
 	intoto002.SetMaxAttestationSize(maxSize)
 	cose.SetMaxAttestationSize(maxSize)
+
+	alpine.SetMaxAPKMetadataSize(viper.GetUint64("max_apk_metadata_size"))
+	jar_v001.SetMaxJarMetadataSize(viper.GetUint64("max_jar_metadata_size"))
 }

--- a/internal/config/limits.go
+++ b/internal/config/limits.go
@@ -1,0 +1,27 @@
+//
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package config holds process-wide limits that rekor-server populates from
+// viper at startup. These are read on hot paths, so they are plain variables
+// rather than repeated viper lookups, which allocate on every call.
+package config
+
+// Zero means unlimited. rekor-server overrides these from config at startup;
+// defaulting to zero preserves the unbounded behavior other callers (e.g.
+// rekor-cli) get when the flags were never registered with viper.
+var (
+	MaxAPKMetadataSize uint64
+	MaxJarMetadataSize uint64
+)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -50,6 +50,12 @@ type API struct {
 	// so we can fetch the checkpoint on service startup to
 	// minimize signature generations
 	cachedCheckpoints map[int64]string
+	// Config snapshotted at startup. viper rebuilds a flat map of every bound
+	// pflag on each lookup of a dotted key, so reading these per-request
+	// allocates for values that cannot change once the server is running.
+	checkpointHostname    string
+	publishEventsProtobuf bool
+	publishEventsJSON     bool
 }
 
 func (api *API) ActiveTreeID() int64 {
@@ -71,9 +77,9 @@ var DefaultClientSigningAlgorithms = AllowedClientSigningAlgorithms
 func NewAPI(treeID int64) (*API, error) {
 	ctx := context.Background()
 
-	checkpointHostname = viper.GetString("rekor_server.hostname")
-	publishEventsProtobuf = viper.GetBool("rekor_server.publish_events_protobuf")
-	publishEventsJSON = viper.GetBool("rekor_server.publish_events_json")
+	checkpointHostname := viper.GetString("rekor_server.hostname")
+	publishEventsProtobuf := viper.GetBool("rekor_server.publish_events_protobuf")
+	publishEventsJSON := viper.GetBool("rekor_server.publish_events_json")
 
 	// this is also used for the active tree
 	defaultGRPCConfig := trillianclient.GRPCConfig{
@@ -178,9 +184,12 @@ func NewAPI(treeID int64) (*API, error) {
 		trillianClientManager: tcm,
 		logRanges:             ranges,
 		// Utility functionality not required for operation of the core service
-		newEntryPublisher: newEntryPublisher,
-		algorithmRegistry: algorithmRegistry,
-		cachedCheckpoints: cachedCheckpoints,
+		newEntryPublisher:     newEntryPublisher,
+		algorithmRegistry:     algorithmRegistry,
+		cachedCheckpoints:     cachedCheckpoints,
+		checkpointHostname:    checkpointHostname,
+		publishEventsProtobuf: publishEventsProtobuf,
+		publishEventsJSON:     publishEventsJSON,
 	}, nil
 }
 
@@ -188,15 +197,6 @@ var (
 	api                      *API
 	attestationStorageClient storage.AttestationStorage
 	indexStorageClient       indexstorage.IndexStorage
-)
-
-// Immutable config snapshotted by NewAPI. viper rebuilds a flat map of every
-// bound pflag on each lookup of a dotted key, so reading these per-request
-// allocates for a value that cannot change after startup.
-var (
-	checkpointHostname    string
-	publishEventsProtobuf bool
-	publishEventsJSON     bool
 )
 
 func ConfigureAPI(treeID int64) {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -71,6 +71,10 @@ var DefaultClientSigningAlgorithms = AllowedClientSigningAlgorithms
 func NewAPI(treeID int64) (*API, error) {
 	ctx := context.Background()
 
+	checkpointHostname = viper.GetString("rekor_server.hostname")
+	publishEventsProtobuf = viper.GetBool("rekor_server.publish_events_protobuf")
+	publishEventsJSON = viper.GetBool("rekor_server.publish_events_json")
+
 	// this is also used for the active tree
 	defaultGRPCConfig := trillianclient.GRPCConfig{
 		Address:             viper.GetString("trillian_log_server.address"),
@@ -150,7 +154,7 @@ func NewAPI(treeID int64) (*API, error) {
 		if !ok {
 			return nil, fmt.Errorf("no root found for inactive shard %d", r.TreeID)
 		}
-		cp, err := util.CreateAndSignCheckpoint(ctx, viper.GetString("rekor_server.hostname"), r.TreeID, uint64(r.TreeLength), root.RootHash, r.Signer) //nolint:gosec
+		cp, err := util.CreateAndSignCheckpoint(ctx, checkpointHostname, r.TreeID, uint64(r.TreeLength), root.RootHash, r.Signer) //nolint:gosec
 		if err != nil {
 			return nil, fmt.Errorf("error signing checkpoint for inactive shard %d: %w", r.TreeID, err)
 		}
@@ -159,7 +163,7 @@ func NewAPI(treeID int64) (*API, error) {
 
 	var newEntryPublisher pubsub.Publisher
 	if p := viper.GetString("rekor_server.new_entry_publisher"); p != "" {
-		if !viper.GetBool("rekor_server.publish_events_protobuf") && !viper.GetBool("rekor_server.publish_events_json") {
+		if !publishEventsProtobuf && !publishEventsJSON {
 			return nil, fmt.Errorf("%q is configured but neither %q or %q are enabled", "new_entry_publisher", "publish_events_protobuf", "publish_events_json")
 		}
 		newEntryPublisher, err = pubsub.Get(ctx, p)
@@ -184,6 +188,15 @@ var (
 	api                      *API
 	attestationStorageClient storage.AttestationStorage
 	indexStorageClient       indexstorage.IndexStorage
+)
+
+// Immutable config snapshotted by NewAPI. viper rebuilds a flat map of every
+// bound pflag on each lookup of a dotted key, so reading these per-request
+// allocates for a value that cannot change after startup.
+var (
+	checkpointHostname    string
+	publishEventsProtobuf bool
+	publishEventsJSON     bool
 )
 
 func ConfigureAPI(treeID int64) {

--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -119,7 +119,7 @@ func logEntryFromLeaf(ctx context.Context, leaf *trillian.LogLeaf, signedLogRoot
 	if ok {
 		sc = val
 	} else {
-		scBytes, err := util.CreateAndSignCheckpoint(ctx, viper.GetString("rekor_server.hostname"), tid, root.TreeSize, root.RootHash, logRange.Signer)
+		scBytes, err := util.CreateAndSignCheckpoint(ctx, checkpointHostname, tid, root.TreeSize, root.RootHash, logRange.Signer)
 		if err != nil {
 			return nil, err
 		}
@@ -440,7 +440,7 @@ func createLogEntry(params entries.CreateLogEntryParams) (models.LogEntry, middl
 		hashes = append(hashes, hex.EncodeToString(hash))
 	}
 
-	scBytes, err := util.CreateAndSignCheckpoint(ctx, viper.GetString("rekor_server.hostname"), api.ActiveTreeID(), root.TreeSize, root.RootHash, api.logRanges.GetActive().Signer)
+	scBytes, err := util.CreateAndSignCheckpoint(ctx, checkpointHostname, api.ActiveTreeID(), root.TreeSize, root.RootHash, api.logRanges.GetActive().Signer)
 	if err != nil {
 		return nil, handleRekorAPIError(params, http.StatusInternalServerError, err, sthGenerateError)
 	}
@@ -488,10 +488,10 @@ func createLogEntry(params entries.CreateLogEntryParams) (models.LogEntry, middl
 				log.ContextLogger(ctx).Error(err)
 				return
 			}
-			if viper.GetBool("rekor_server.publish_events_protobuf") {
+			if publishEventsProtobuf {
 				go publishEvent(ctx, api.newEntryPublisher, event, events.ContentTypeProtobuf)
 			}
-			if viper.GetBool("rekor_server.publish_events_json") {
+			if publishEventsJSON {
 				go publishEvent(ctx, api.newEntryPublisher, event, events.ContentTypeJSON)
 			}
 		}()

--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -83,7 +83,8 @@ func signEntry(ctx context.Context, signer signature.Signer, entry models.LogEnt
 
 // logEntryFromLeaf creates a signed LogEntry struct from trillian structs
 func logEntryFromLeaf(ctx context.Context, leaf *trillian.LogLeaf, signedLogRoot *trillian.SignedLogRoot,
-	proof *trillian.Proof, tid int64, ranges *sharding.LogRanges, cachedCheckpoints map[int64]string) (models.LogEntry, error) {
+	proof *trillian.Proof, tid int64, ranges *sharding.LogRanges, cachedCheckpoints map[int64]string,
+	checkpointHostname string) (models.LogEntry, error) {
 
 	log.ContextLogger(ctx).Debugf("log entry from leaf %d", leaf.GetLeafIndex())
 	root := &ttypes.LogRootV1{}
@@ -440,7 +441,7 @@ func createLogEntry(params entries.CreateLogEntryParams) (models.LogEntry, middl
 		hashes = append(hashes, hex.EncodeToString(hash))
 	}
 
-	scBytes, err := util.CreateAndSignCheckpoint(ctx, checkpointHostname, api.ActiveTreeID(), root.TreeSize, root.RootHash, api.logRanges.GetActive().Signer)
+	scBytes, err := util.CreateAndSignCheckpoint(ctx, api.checkpointHostname, api.ActiveTreeID(), root.TreeSize, root.RootHash, api.logRanges.GetActive().Signer)
 	if err != nil {
 		return nil, handleRekorAPIError(params, http.StatusInternalServerError, err, sthGenerateError)
 	}
@@ -488,10 +489,10 @@ func createLogEntry(params entries.CreateLogEntryParams) (models.LogEntry, middl
 				log.ContextLogger(ctx).Error(err)
 				return
 			}
-			if publishEventsProtobuf {
+			if api.publishEventsProtobuf {
 				go publishEvent(ctx, api.newEntryPublisher, event, events.ContentTypeProtobuf)
 			}
-			if publishEventsJSON {
+			if api.publishEventsJSON {
 				go publishEvent(ctx, api.newEntryPublisher, event, events.ContentTypeJSON)
 			}
 		}()
@@ -653,7 +654,7 @@ func SearchLogQueryHandler(params entries.SearchLogQueryParams) middleware.Respo
 				if leafResp == nil {
 					continue
 				}
-				logEntry, err := logEntryFromLeaf(httpReqCtx, leafResp.Leaf, leafResp.SignedLogRoot, leafResp.Proof, shard, api.logRanges, api.cachedCheckpoints)
+				logEntry, err := logEntryFromLeaf(httpReqCtx, leafResp.Leaf, leafResp.SignedLogRoot, leafResp.Proof, shard, api.logRanges, api.cachedCheckpoints, api.checkpointHostname)
 				if err != nil {
 					return handleRekorAPIError(params, http.StatusInternalServerError, err, trillianUnexpectedResult)
 				}
@@ -701,7 +702,7 @@ func retrieveLogEntryByIndex(ctx context.Context, logIndex int) (models.LogEntry
 		return models.LogEntry{}, ErrNotFound
 	}
 
-	return logEntryFromLeaf(ctx, leaf, result.SignedLogRoot, result.Proof, tid, api.logRanges, api.cachedCheckpoints)
+	return logEntryFromLeaf(ctx, leaf, result.SignedLogRoot, result.Proof, tid, api.logRanges, api.cachedCheckpoints, api.checkpointHostname)
 }
 
 // Retrieve a Log Entry
@@ -778,7 +779,7 @@ func retrieveUUIDFromTree(ctx context.Context, uuid string, tid int64) (models.L
 			return models.LogEntry{}, resp.Err
 		}
 
-		logEntry, err := logEntryFromLeaf(ctx, result.Leaf, result.SignedLogRoot, result.Proof, tid, api.logRanges, api.cachedCheckpoints)
+		logEntry, err := logEntryFromLeaf(ctx, result.Leaf, result.SignedLogRoot, result.Proof, tid, api.logRanges, api.cachedCheckpoints, api.checkpointHostname)
 		if err != nil {
 			return models.LogEntry{}, fmt.Errorf("could not create log entry from leaf: %w", err)
 		}

--- a/pkg/api/tlog.go
+++ b/pkg/api/tlog.go
@@ -67,7 +67,7 @@ func GetLogInfoHandler(params tlog.GetLogInfoParams) middleware.Responder {
 	treeSize := int64(root.TreeSize) //nolint:gosec
 
 	scBytes, err := util.CreateAndSignCheckpoint(ctx,
-		checkpointHostname, api.logRanges.GetActive().TreeID, root.TreeSize, root.RootHash, api.logRanges.GetActive().Signer)
+		api.checkpointHostname, api.logRanges.GetActive().TreeID, root.TreeSize, root.RootHash, api.logRanges.GetActive().Signer)
 	if err != nil {
 		return handleRekorAPIError(params, http.StatusInternalServerError, err, sthGenerateError)
 	}

--- a/pkg/api/tlog.go
+++ b/pkg/api/tlog.go
@@ -26,7 +26,6 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/swag/conv"
 	"github.com/google/trillian/types"
-	"github.com/spf13/viper"
 	"google.golang.org/grpc/codes"
 
 	"github.com/sigstore/rekor/pkg/generated/models"
@@ -68,7 +67,7 @@ func GetLogInfoHandler(params tlog.GetLogInfoParams) middleware.Responder {
 	treeSize := int64(root.TreeSize) //nolint:gosec
 
 	scBytes, err := util.CreateAndSignCheckpoint(ctx,
-		viper.GetString("rekor_server.hostname"), api.logRanges.GetActive().TreeID, root.TreeSize, root.RootHash, api.logRanges.GetActive().Signer)
+		checkpointHostname, api.logRanges.GetActive().TreeID, root.TreeSize, root.RootHash, api.logRanges.GetActive().Signer)
 	if err != nil {
 		return handleRekorAPIError(params, http.StatusInternalServerError, err, sthGenerateError)
 	}

--- a/pkg/types/alpine/apk.go
+++ b/pkg/types/alpine/apk.go
@@ -33,9 +33,17 @@ import (
 
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature/options"
-	"github.com/spf13/viper"
 	"gopkg.in/ini.v1"
 )
+
+// Zero means unlimited. rekor-server overrides this from config at startup;
+// leaving the default at zero preserves the unbounded behavior other callers
+// (e.g. rekor-cli) get when the flag was never registered with viper.
+var maxAPKMetadataSize uint64
+
+func SetMaxAPKMetadataSize(limit uint64) {
+	maxAPKMetadataSize = limit
+}
 
 type Package struct {
 	Pkginfo           map[string]string // KVP pairs
@@ -106,7 +114,7 @@ func (p *Package) Unmarshal(pkgReader io.Reader) error {
 
 	// GZIP headers/footers are left unmodified; Tar footers are removed on first two archives
 	// signature.tar.gz | control.tar.gz | data.tar.gz
-	maxBufSize := viper.GetUint64("max_apk_metadata_size")
+	maxBufSize := maxAPKMetadataSize
 	if maxBufSize == 0 {
 		maxBufSize = 20 * 1024 * 1024
 	}
@@ -165,8 +173,8 @@ func (p *Package) Unmarshal(pkgReader io.Reader) error {
 			if header.Size < 0 {
 				return errors.New("negative header size for .SIGN file")
 			}
-			if uint64(header.Size) > viper.GetUint64("max_apk_metadata_size") && viper.GetUint64("max_apk_metadata_size") > 0 {
-				return fmt.Errorf("uncompressed .SIGN file size %d exceeds max allowed size %d", header.Size, viper.GetUint64("max_apk_metadata_size"))
+			if maxAPKMetadataSize > 0 && uint64(header.Size) > maxAPKMetadataSize {
+				return fmt.Errorf("uncompressed .SIGN file size %d exceeds max allowed size %d", header.Size, maxAPKMetadataSize)
 			}
 			sigBytes := make([]byte, header.Size)
 			if _, err = sigReader.Read(sigBytes); err != nil && err != io.EOF {
@@ -198,8 +206,8 @@ func (p *Package) Unmarshal(pkgReader io.Reader) error {
 			if header.Size < 0 {
 				return errors.New("negative header size for .PKGINFO file")
 			}
-			if uint64(header.Size) > viper.GetUint64("max_apk_metadata_size") && viper.GetUint64("max_apk_metadata_size") > 0 {
-				return fmt.Errorf("uncompressed .PKGINFO file size %d exceeds max allowed size %d", header.Size, viper.GetUint64("max_apk_metadata_size"))
+			if maxAPKMetadataSize > 0 && uint64(header.Size) > maxAPKMetadataSize {
+				return fmt.Errorf("uncompressed .PKGINFO file size %d exceeds max allowed size %d", header.Size, maxAPKMetadataSize)
 			}
 			pkginfoContent := make([]byte, header.Size)
 			if _, err = ctlReader.Read(pkginfoContent); err != nil && err != io.EOF {

--- a/pkg/types/alpine/apk.go
+++ b/pkg/types/alpine/apk.go
@@ -31,19 +31,11 @@ import (
 	"io"
 	"strings"
 
+	"github.com/sigstore/rekor/internal/config"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature/options"
 	"gopkg.in/ini.v1"
 )
-
-// Zero means unlimited. rekor-server overrides this from config at startup;
-// leaving the default at zero preserves the unbounded behavior other callers
-// (e.g. rekor-cli) get when the flag was never registered with viper.
-var maxAPKMetadataSize uint64
-
-func SetMaxAPKMetadataSize(limit uint64) {
-	maxAPKMetadataSize = limit
-}
 
 type Package struct {
 	Pkginfo           map[string]string // KVP pairs
@@ -114,7 +106,7 @@ func (p *Package) Unmarshal(pkgReader io.Reader) error {
 
 	// GZIP headers/footers are left unmodified; Tar footers are removed on first two archives
 	// signature.tar.gz | control.tar.gz | data.tar.gz
-	maxBufSize := maxAPKMetadataSize
+	maxBufSize := config.MaxAPKMetadataSize
 	if maxBufSize == 0 {
 		maxBufSize = 20 * 1024 * 1024
 	}
@@ -173,8 +165,8 @@ func (p *Package) Unmarshal(pkgReader io.Reader) error {
 			if header.Size < 0 {
 				return errors.New("negative header size for .SIGN file")
 			}
-			if maxAPKMetadataSize > 0 && uint64(header.Size) > maxAPKMetadataSize {
-				return fmt.Errorf("uncompressed .SIGN file size %d exceeds max allowed size %d", header.Size, maxAPKMetadataSize)
+			if config.MaxAPKMetadataSize > 0 && uint64(header.Size) > config.MaxAPKMetadataSize {
+				return fmt.Errorf("uncompressed .SIGN file size %d exceeds max allowed size %d", header.Size, config.MaxAPKMetadataSize)
 			}
 			sigBytes := make([]byte, header.Size)
 			if _, err = sigReader.Read(sigBytes); err != nil && err != io.EOF {
@@ -206,8 +198,8 @@ func (p *Package) Unmarshal(pkgReader io.Reader) error {
 			if header.Size < 0 {
 				return errors.New("negative header size for .PKGINFO file")
 			}
-			if maxAPKMetadataSize > 0 && uint64(header.Size) > maxAPKMetadataSize {
-				return fmt.Errorf("uncompressed .PKGINFO file size %d exceeds max allowed size %d", header.Size, maxAPKMetadataSize)
+			if config.MaxAPKMetadataSize > 0 && uint64(header.Size) > config.MaxAPKMetadataSize {
+				return fmt.Errorf("uncompressed .PKGINFO file size %d exceeds max allowed size %d", header.Size, config.MaxAPKMetadataSize)
 			}
 			pkginfoContent := make([]byte, header.Size)
 			if _, err = ctlReader.Read(pkginfoContent); err != nil && err != io.EOF {

--- a/pkg/types/alpine/apk_test.go
+++ b/pkg/types/alpine/apk_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sigstore/rekor/internal/config"
 	"github.com/sigstore/rekor/pkg/pki/x509"
 )
 
@@ -56,10 +57,10 @@ func TestAlpinePackage(t *testing.T) {
 }
 
 func TestAlpineMetadataSize(t *testing.T) {
-	origVal := maxAPKMetadataSize
-	defer SetMaxAPKMetadataSize(origVal)
+	origVal := config.MaxAPKMetadataSize
+	defer func() { config.MaxAPKMetadataSize = origVal }()
 
-	SetMaxAPKMetadataSize(10)
+	config.MaxAPKMetadataSize = 10
 
 	inputArchive, err := os.Open("tests/test_alpine.apk")
 	if err != nil {
@@ -78,10 +79,10 @@ func TestAlpineMetadataSize(t *testing.T) {
 }
 
 func TestAlpineMetadataSizeDefault(t *testing.T) {
-	origVal := maxAPKMetadataSize
-	defer SetMaxAPKMetadataSize(origVal)
+	origVal := config.MaxAPKMetadataSize
+	defer func() { config.MaxAPKMetadataSize = origVal }()
 
-	SetMaxAPKMetadataSize(0)
+	config.MaxAPKMetadataSize = 0
 
 	inputArchive, err := os.Open("tests/test_alpine.apk")
 	if err != nil {
@@ -97,14 +98,14 @@ func TestAlpineMetadataSizeDefault(t *testing.T) {
 }
 
 func TestAlpineMetadataSizeBoundary(t *testing.T) {
-	origVal := maxAPKMetadataSize
-	defer SetMaxAPKMetadataSize(origVal)
+	origVal := config.MaxAPKMetadataSize
+	defer func() { config.MaxAPKMetadataSize = origVal }()
 
 	// The signature.tar.gz decompressed size in test_alpine.apk is exactly 1024 bytes.
 	boundary := 1024
 
 	// 1. Verify that max_apk_metadata_size = 1024 succeeds
-	SetMaxAPKMetadataSize(uint64(boundary))
+	config.MaxAPKMetadataSize = uint64(boundary)
 	inputArchive, err := os.Open("tests/test_alpine.apk")
 	if err != nil {
 		t.Fatalf("could not open archive %v", err)
@@ -117,7 +118,7 @@ func TestAlpineMetadataSizeBoundary(t *testing.T) {
 	}
 
 	// 2. Verify that max_apk_metadata_size = 1023 fails
-	SetMaxAPKMetadataSize(uint64(boundary - 1))
+	config.MaxAPKMetadataSize = uint64(boundary - 1)
 	inputArchive, err = os.Open("tests/test_alpine.apk")
 	if err != nil {
 		t.Fatalf("could not open archive %v", err)

--- a/pkg/types/alpine/apk_test.go
+++ b/pkg/types/alpine/apk_test.go
@@ -23,8 +23,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/spf13/viper"
-
 	"github.com/sigstore/rekor/pkg/pki/x509"
 )
 
@@ -58,10 +56,10 @@ func TestAlpinePackage(t *testing.T) {
 }
 
 func TestAlpineMetadataSize(t *testing.T) {
-	origVal := viper.Get("max_apk_metadata_size")
-	defer viper.Set("max_apk_metadata_size", origVal)
+	origVal := maxAPKMetadataSize
+	defer SetMaxAPKMetadataSize(origVal)
 
-	viper.Set("max_apk_metadata_size", 10)
+	SetMaxAPKMetadataSize(10)
 
 	inputArchive, err := os.Open("tests/test_alpine.apk")
 	if err != nil {
@@ -80,10 +78,10 @@ func TestAlpineMetadataSize(t *testing.T) {
 }
 
 func TestAlpineMetadataSizeDefault(t *testing.T) {
-	origVal := viper.Get("max_apk_metadata_size")
-	defer viper.Set("max_apk_metadata_size", origVal)
+	origVal := maxAPKMetadataSize
+	defer SetMaxAPKMetadataSize(origVal)
 
-	viper.Set("max_apk_metadata_size", 0)
+	SetMaxAPKMetadataSize(0)
 
 	inputArchive, err := os.Open("tests/test_alpine.apk")
 	if err != nil {
@@ -99,14 +97,14 @@ func TestAlpineMetadataSizeDefault(t *testing.T) {
 }
 
 func TestAlpineMetadataSizeBoundary(t *testing.T) {
-	origVal := viper.Get("max_apk_metadata_size")
-	defer viper.Set("max_apk_metadata_size", origVal)
+	origVal := maxAPKMetadataSize
+	defer SetMaxAPKMetadataSize(origVal)
 
 	// The signature.tar.gz decompressed size in test_alpine.apk is exactly 1024 bytes.
 	boundary := 1024
 
 	// 1. Verify that max_apk_metadata_size = 1024 succeeds
-	viper.Set("max_apk_metadata_size", uint64(boundary))
+	SetMaxAPKMetadataSize(uint64(boundary))
 	inputArchive, err := os.Open("tests/test_alpine.apk")
 	if err != nil {
 		t.Fatalf("could not open archive %v", err)
@@ -119,7 +117,7 @@ func TestAlpineMetadataSizeBoundary(t *testing.T) {
 	}
 
 	// 2. Verify that max_apk_metadata_size = 1023 fails
-	viper.Set("max_apk_metadata_size", uint64(boundary-1))
+	SetMaxAPKMetadataSize(uint64(boundary - 1))
 	inputArchive, err = os.Open("tests/test_alpine.apk")
 	if err != nil {
 		t.Fatalf("could not open archive %v", err)

--- a/pkg/types/alpine/fuzz_test.go
+++ b/pkg/types/alpine/fuzz_test.go
@@ -20,16 +20,14 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/spf13/viper"
-
 	fuzz "github.com/AdamKorcz/go-fuzz-headers-1"
 	utils "github.com/sigstore/rekor/pkg/fuzz"
 )
 
 func init() {
-	viper.Set("max_apk_metadata_size", 60000)
-	if viper.GetUint64("max_apk_metadata_size") != 60000 {
-		panic(fmt.Sprintf("max metadata size is not defined: %d", viper.GetUint64("max_apk_metadata_size")))
+	SetMaxAPKMetadataSize(60000)
+	if maxAPKMetadataSize != 60000 {
+		panic(fmt.Sprintf("max metadata size is not defined: %d", maxAPKMetadataSize))
 	}
 }
 

--- a/pkg/types/alpine/fuzz_test.go
+++ b/pkg/types/alpine/fuzz_test.go
@@ -17,18 +17,15 @@ package alpine
 
 import (
 	"bytes"
-	"fmt"
 	"testing"
 
 	fuzz "github.com/AdamKorcz/go-fuzz-headers-1"
+	"github.com/sigstore/rekor/internal/config"
 	utils "github.com/sigstore/rekor/pkg/fuzz"
 )
 
 func init() {
-	SetMaxAPKMetadataSize(60000)
-	if maxAPKMetadataSize != 60000 {
-		panic(fmt.Sprintf("max metadata size is not defined: %d", maxAPKMetadataSize))
-	}
+	config.MaxAPKMetadataSize = 60000
 }
 
 // FuzzPackageUnmarshal implements the fuzz test

--- a/pkg/types/jar/v0.0.1/entry.go
+++ b/pkg/types/jar/v0.0.1/entry.go
@@ -32,6 +32,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/sigstore/rekor/internal/config"
 	"github.com/sigstore/rekor/pkg/log"
 	"github.com/sigstore/rekor/pkg/pki"
 	"github.com/sigstore/rekor/pkg/pki/pkcs7"
@@ -50,15 +51,6 @@ import (
 const (
 	APIVERSION = "0.0.1"
 )
-
-// Zero means unlimited. rekor-server overrides this from config at startup;
-// leaving the default at zero preserves the unbounded behavior other callers
-// (e.g. rekor-cli) get when the flag was never registered with viper.
-var maxJarMetadataSize uint64
-
-func SetMaxJarMetadataSize(limit uint64) {
-	maxJarMetadataSize = limit
-}
 
 func init() {
 	if err := jar.VersionMap.SetEntryFactory(APIVERSION, NewEntry); err != nil {
@@ -225,8 +217,8 @@ func (v *V001Entry) fetchExternalEntities(_ context.Context) (*pkcs7.PublicKey, 
 		if dir != "META-INF/" || name == "" || strings.LastIndex(name, ".") < 0 {
 			continue
 		}
-		if maxJarMetadataSize > 0 && f.UncompressedSize64 > maxJarMetadataSize {
-			return nil, nil, &types.InputValidationError{Err: fmt.Errorf("uncompressed jar metadata of size %d exceeds max allowed size %d", f.UncompressedSize64, maxJarMetadataSize)}
+		if config.MaxJarMetadataSize > 0 && f.UncompressedSize64 > config.MaxJarMetadataSize {
+			return nil, nil, &types.InputValidationError{Err: fmt.Errorf("uncompressed jar metadata of size %d exceeds max allowed size %d", f.UncompressedSize64, config.MaxJarMetadataSize)}
 		}
 	}
 

--- a/pkg/types/jar/v0.0.1/entry.go
+++ b/pkg/types/jar/v0.0.1/entry.go
@@ -45,12 +45,20 @@ import (
 	"github.com/go-openapi/swag/conv"
 	jarutils "github.com/sassoftware/relic/v8/lib/signjar"
 	"github.com/sigstore/rekor/pkg/generated/models"
-	"github.com/spf13/viper"
 )
 
 const (
 	APIVERSION = "0.0.1"
 )
+
+// Zero means unlimited. rekor-server overrides this from config at startup;
+// leaving the default at zero preserves the unbounded behavior other callers
+// (e.g. rekor-cli) get when the flag was never registered with viper.
+var maxJarMetadataSize uint64
+
+func SetMaxJarMetadataSize(limit uint64) {
+	maxJarMetadataSize = limit
+}
 
 func init() {
 	if err := jar.VersionMap.SetEntryFactory(APIVERSION, NewEntry); err != nil {
@@ -217,8 +225,8 @@ func (v *V001Entry) fetchExternalEntities(_ context.Context) (*pkcs7.PublicKey, 
 		if dir != "META-INF/" || name == "" || strings.LastIndex(name, ".") < 0 {
 			continue
 		}
-		if f.UncompressedSize64 > viper.GetUint64("max_jar_metadata_size") && viper.GetUint64("max_jar_metadata_size") > 0 {
-			return nil, nil, &types.InputValidationError{Err: fmt.Errorf("uncompressed jar metadata of size %d exceeds max allowed size %d", f.UncompressedSize64, viper.GetUint64("max_jar_metadata_size"))}
+		if maxJarMetadataSize > 0 && f.UncompressedSize64 > maxJarMetadataSize {
+			return nil, nil, &types.InputValidationError{Err: fmt.Errorf("uncompressed jar metadata of size %d exceeds max allowed size %d", f.UncompressedSize64, maxJarMetadataSize)}
 		}
 	}
 

--- a/pkg/types/jar/v0.0.1/entry_test.go
+++ b/pkg/types/jar/v0.0.1/entry_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag/conv"
+	"github.com/sigstore/rekor/internal/config"
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/rekor/pkg/types"
 	"go.uber.org/goleak"
@@ -171,8 +172,10 @@ Hr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ==
 func TestJarMetadataSize(t *testing.T) {
 	jarBytes, _ := os.ReadFile("tests/test.jar")
 
-	defer SetMaxJarMetadataSize(maxJarMetadataSize)
-	SetMaxJarMetadataSize(10)
+	origVal := config.MaxJarMetadataSize
+	defer func() { config.MaxJarMetadataSize = origVal }()
+
+	config.MaxJarMetadataSize = 10
 
 	v := V001Entry{
 		JARModel: models.JarV001Schema{

--- a/pkg/types/jar/v0.0.1/entry_test.go
+++ b/pkg/types/jar/v0.0.1/entry_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/go-openapi/swag/conv"
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/rekor/pkg/types"
-	"github.com/spf13/viper"
 	"go.uber.org/goleak"
 )
 
@@ -172,8 +171,8 @@ Hr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ==
 func TestJarMetadataSize(t *testing.T) {
 	jarBytes, _ := os.ReadFile("tests/test.jar")
 
-	os.Setenv("MAX_JAR_METADATA_SIZE", "10")
-	viper.AutomaticEnv()
+	defer SetMaxJarMetadataSize(maxJarMetadataSize)
+	SetMaxJarMetadataSize(10)
 
 	v := V001Entry{
 		JARModel: models.JarV001Schema{


### PR DESCRIPTION
viper lookups cause unnecessary allocation churn, and since they are write-once we should keep them as vars instead of re-looking up over & over