### PR TITLE
fix pprof 

### DIFF
--- a/cmd/rekor-server/app/root.go
+++ b/cmd/rekor-server/app/root.go
@@ -185,30 +185,43 @@ Memory and file-based signers should only be used for testing.`)
 	}
 
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}
 
-	log.Logger.Debugf("pprof enabled %v", enablePprof)
-	// Enable pprof
-	if enablePprof {
-		go func() {
-			mux := http.NewServeMux()
-
-			mux.HandleFunc("/debug/pprof/", pprof.Index)
-			mux.HandleFunc("/debug/pprof/{action}", pprof.Index)
-			mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-
-			srv := &http.Server{
-				Addr:         ":6060",
-				ReadTimeout:  10 * time.Second,
-				WriteTimeout: 10 * time.Second,
-				Handler:      mux,
-			}
-
-			if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-				log.Logger.Fatalf("Error when starting or running http server: %v", err)
-			}
-		}()
+// StartPprof serves net/http/pprof on port 6060 when --enable_pprof is set.
+// Called from the serve command rather than init() because init() runs before
+// cobra parses flags, so enablePprof is always false there.
+func StartPprof() {
+	if !enablePprof {
+		return
 	}
+	log.Logger.Info("pprof enabled on :6060")
 
+	go func() {
+		mux := http.NewServeMux()
+
+		// pprof.Index dispatches the runtime-provided profiles (heap, goroutine,
+		// allocs, ...) from the path suffix, but profile/trace/cmdline/symbol are
+		// distinct handlers it does not cover and must be routed explicitly.
+		mux.HandleFunc("/debug/pprof/", pprof.Index)
+		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+		srv := &http.Server{
+			Addr: ":6060",
+			// No WriteTimeout: a CPU profile or trace streams for its full
+			// requested duration (30s by default, often longer), and any write
+			// deadline shorter than that truncates the response into an
+			// unparseable profile.
+			ReadHeaderTimeout: 10 * time.Second,
+			Handler:           mux,
+		}
+
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Logger.Errorf("pprof server: %v", err)
+		}
+	}()
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/rekor-server/app/serve.go
+++ b/cmd/rekor-server/app/serve.go
@@ -70,6 +70,8 @@ var serveCmd = &cobra.Command{
 		// Setup the logger to dev/prod
 		log.ConfigureLogger(viper.GetString("log_type"), viper.GetString("trace-string-prefix"))
 
+		StartPprof()
+
 		// workaround for https://github.com/sigstore/rekor/issues/68
 		// from https://github.com/golang/glog/commit/fca8c8854093a154ff1eb580aae10276ad6b1b5f
 		_ = flag.CommandLine.Parse([]string{})

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,6 +116,7 @@ services:
       "--attestation_storage_bucket=file:///var/run/attestations",
       "--search_index.storage_provider=mysql",
       "--search_index.mysql.dsn=test:zaphod@tcp(mysql:3306)/test?parseTime=true&interpolateParams=true",
+      "--enable_pprof",
       # Uncomment this for production logging
       # "--log_type=prod",
       ]
@@ -125,6 +126,7 @@ services:
     ports:
       - "3000:3000"
       - "2112:2112"
+      - "6060:6060"
     depends_on:
       mysql:
         condition: service_healthy


### PR DESCRIPTION
Previously we enabled pprof in `init()`. However, the command line arguments had not been parsed then, so the value was always false. This fixes it appropriately. 