### PR TITLE
Replace hashicorp/go-retryablehttp with std lib retry transport

### DIFF
--- a/cmd/backfill-index/main.go
+++ b/cmd/backfill-index/main.go
@@ -130,9 +130,9 @@ var (
 	endIndex                = flag.Int("end", -1, "Last index to backfill")
 	rekorAddress            = flag.String("rekor-address", "", "Address for Rekor, e.g. https://rekor.sigstore.dev")
 	rekorDisableKeepalives  = flag.Bool("rekor-disable-keepalives", true, "Disable Keep-Alive connections (defaults to true, meaning Keep-Alive is disabled)")
-	rekorRetryCount         = flag.Uint("rekor-retry-count", 3, "Maximum number of times to retry rekor requests")                          // https://github.com/sigstore/rekor/blob/5988bfa6b0761be3a810047d23b3d3191ed5af3d/pkg/client/options.go#L36
-	rekorRetryWaitMin       = flag.Duration("rekor-retry-wait-min", 1*time.Second, "Minimum time to wait between retrying rekor requests")  //nolint:revive // https://github.com/hashicorp/go-retryablehttp/blob/1542b31176d3973a6ecbc06c05a2d0df89b59afb/client.go#L49
-	rekorRetryWaitMax       = flag.Duration("rekor-retry-wait-max", 30*time.Second, "Maximum time to wait between retrying rekor requests") // https://github.com/hashicorp/go-retryablehttp/blob/1542b31176d3973a6ecbc06c05a2d0df89b59afb/client.go#L50
+	rekorRetryCount         = flag.Uint("rekor-retry-count", 3, "Maximum number of times to retry rekor requests") // https://github.com/sigstore/rekor/blob/5988bfa6b0761be3a810047d23b3d3191ed5af3d/pkg/client/options.go#L36
+	rekorRetryWaitMin       = flag.Duration("rekor-retry-wait-min", 1*time.Second, "Minimum time to wait between retrying rekor requests")
+	rekorRetryWaitMax       = flag.Duration("rekor-retry-wait-max", 30*time.Second, "Maximum time to wait between retrying rekor requests")
 	rekorHeaders            headers
 	versionFlag             = flag.Bool("version", false, "Print the current version of Backfill MySQL")
 	concurrency             = flag.Int("concurrency", 1, "Number of workers to use for backfill")

--- a/go.mod
+++ b/go.mod
@@ -59,8 +59,6 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/golang/mock v1.7.0-rc.1
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3
-	github.com/hashicorp/go-cleanhttp v0.5.2
-	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/redis/go-redis/v9 v9.22.0
 	github.com/sassoftware/go-rpmutils v0.4.0
@@ -143,7 +141,9 @@ require (
 	github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.2.0 // indirect
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -18,8 +18,6 @@ import (
 	"crypto/tls"
 	"net/http"
 	"time"
-
-	"github.com/hashicorp/go-retryablehttp"
 )
 
 // Option is a functional option for customizing static signatures.
@@ -32,7 +30,7 @@ type options struct {
 	RetryWaitMax        time.Duration
 	InsecureTLS         bool
 	TLSConfig           *tls.Config
-	Logger              interface{}
+	Logger              any
 	NoDisableKeepalives bool
 	Headers             map[string][]string
 }
@@ -83,12 +81,15 @@ func WithRetryWaitMax(t time.Duration) Option {
 	}
 }
 
-// WithLogger sets the logger; it must implement either retryablehttp.Logger or retryablehttp.LeveledLogger; if not, this will not take effect.
-func WithLogger(logger interface{}) Option {
+// WithLogger sets the logger; it must implement either a simple logger interface
+// with a `Printf(string, ...any)` method, or a leveled logger interface with
+// `Error`, `Info`, `Debug`, and `Warn` methods that take a message string and
+// variadic `keysAndValues`.
+func WithLogger(l any) Option {
 	return func(o *options) {
-		switch logger.(type) {
-		case retryablehttp.Logger, retryablehttp.LeveledLogger:
-			o.Logger = logger
+		switch l.(type) {
+		case logger, leveledLogger:
+			o.Logger = l
 		}
 	}
 }

--- a/pkg/client/rekor_client.go
+++ b/pkg/client/rekor_client.go
@@ -26,8 +26,6 @@ import (
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 
-	"github.com/hashicorp/go-cleanhttp"
-	retryablehttp "github.com/hashicorp/go-retryablehttp"
 	"github.com/sigstore/rekor/pkg/generated/client"
 	"github.com/sigstore/rekor/pkg/util"
 )
@@ -43,7 +41,7 @@ const maxErrorBodyBytes = 512
 // reason the retries failed — especially when the server returned an error
 // response (5xx) rather than a transport error. See
 // https://github.com/sigstore/rekor/issues/2640.
-func retryErrorHandler(resp *http.Response, err error, numTries int) (*http.Response, error) {
+func retryErrorHandler(resp *http.Response, err error, numTries uint) (*http.Response, error) {
 	if err != nil {
 		return nil, fmt.Errorf("giving up after %d attempt(s): %w", numTries, err)
 	}
@@ -69,28 +67,35 @@ func GetRekorClient(rekorServerURL string, opts ...Option) (*client.Rekor, error
 	}
 	o := makeOptions(opts...)
 
-	retryableClient := retryablehttp.NewClient()
-	defaultTransport := cleanhttp.DefaultTransport()
+	dt, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil, fmt.Errorf("default transport does not implement *http.Transport")
+	}
+	t := dt.Clone()
+	t.DisableKeepAlives = true
+	t.MaxIdleConnsPerHost = -1
 	if o.NoDisableKeepalives {
-		defaultTransport.DisableKeepAlives = false
+		t.DisableKeepAlives = false
 	}
 	if o.InsecureTLS {
 		/* #nosec G402 */
-		defaultTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		t.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	} else if o.TLSConfig != nil {
-		defaultTransport.TLSClientConfig = o.TLSConfig
+		t.TLSClientConfig = o.TLSConfig
 	}
-	retryableClient.HTTPClient = &http.Client{
-		Transport: defaultTransport,
-	}
-	retryableClient.RetryMax = int(o.RetryCount)
-	retryableClient.RetryWaitMin = o.RetryWaitMin
-	retryableClient.RetryWaitMax = o.RetryWaitMax
-	retryableClient.Logger = o.Logger
-	retryableClient.ErrorHandler = retryErrorHandler
 
-	httpClient := retryableClient.StandardClient()
-	httpClient.Transport = createRoundTripper(httpClient.Transport, o)
+	retryTransport := &retryTransport{
+		Transport:    t,
+		MaxRetries:   o.RetryCount,
+		RetryWaitMin: o.RetryWaitMin,
+		RetryWaitMax: o.RetryWaitMax,
+		Logger:       o.Logger,
+		ErrorHandler: retryErrorHandler,
+	}
+
+	httpClient := &http.Client{
+		Transport: createRoundTripper(retryTransport, o),
+	}
 
 	// sanitize path
 	if url.Path == "" {

--- a/pkg/client/retry.go
+++ b/pkg/client/retry.go
@@ -1,0 +1,256 @@
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"math/rand/v2"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// logger interface allows to use other loggers than standard log.Logger.
+type logger interface {
+	Printf(string, ...any)
+}
+
+// leveledLogger is an interface that can be implemented by any logger or a
+// logger wrapper to provide leveled logging.
+type leveledLogger interface {
+	Error(msg string, keysAndValues ...any)
+	Info(msg string, keysAndValues ...any)
+	Debug(msg string, keysAndValues ...any)
+	Warn(msg string, keysAndValues ...any)
+}
+
+// retryTransport is an http.RoundTripper that retries requests based on policy.
+type retryTransport struct {
+	Transport    http.RoundTripper
+	MaxRetries   uint
+	RetryWaitMin time.Duration
+	RetryWaitMax time.Duration
+	Logger       any
+	ErrorHandler func(resp *http.Response, err error, numTries uint) (*http.Response, error)
+}
+
+func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	var resp *http.Response
+	var err error
+	var bodyBytes []byte
+
+	if t.Logger != nil {
+		switch v := t.Logger.(type) {
+		case leveledLogger:
+			v.Debug("performing request", "method", req.Method, "url", req.URL.String())
+		case logger:
+			v.Printf("[DEBUG] %s %s", req.Method, req.URL.String())
+		}
+	}
+
+	if req.Body != nil {
+		defer req.Body.Close()
+		// Clone the request to avoid modifying the original request's Body or GetBody,
+		// which would violate the http.RoundTripper contract.
+		cloneReq := req.Clone(req.Context())
+		if req.GetBody == nil {
+			// Read the body so we can replay it
+			bodyBytes, err = io.ReadAll(req.Body)
+			if err != nil {
+				return nil, err
+			}
+			cloneReq.GetBody = func() (io.ReadCloser, error) {
+				return io.NopCloser(bytes.NewReader(bodyBytes)), nil
+			}
+		}
+		cloneReq.Body, err = cloneReq.GetBody()
+		if err != nil {
+			return nil, err
+		}
+		req = cloneReq
+	}
+
+	for i := uint(0); i <= t.MaxRetries; i++ {
+		if err := req.Context().Err(); err != nil {
+			if i == 0 && req.Body != nil {
+				req.Body.Close()
+			}
+			return nil, err
+		}
+
+		if i > 0 {
+			wait := t.RetryWaitMin
+			if wait == 0 {
+				wait = 1 * time.Second // Default
+			}
+			waitMax := t.RetryWaitMax
+			if waitMax == 0 {
+				waitMax = 10 * time.Second // Default max
+			}
+
+			// Exponential backoff
+			backoff := float64(wait) * math.Pow(2, float64(i-1))
+			if backoff > float64(waitMax) {
+				backoff = float64(waitMax)
+			}
+			// Add jitter (between 0.8 and 1.0 of the backoff) to avoid thundering herd.
+			//nolint:gosec // cryptographic randomness is not required for retry jitter
+			jitter := (rand.Float64() * 0.2) + 0.8
+			wait = time.Duration(backoff * jitter)
+
+			if resp != nil {
+				if retryAfterStr := resp.Header.Get("Retry-After"); retryAfterStr != "" {
+					if sleepSec, err := strconv.ParseInt(retryAfterStr, 10, 64); err == nil {
+						headerWait := time.Duration(sleepSec) * time.Second
+						if headerWait > wait {
+							wait = headerWait
+						}
+					} else if parsedDate, err := http.ParseTime(retryAfterStr); err == nil {
+						headerWait := time.Until(parsedDate)
+						if headerWait > wait {
+							wait = headerWait
+						}
+					}
+				}
+			}
+
+			if wait > waitMax {
+				wait = waitMax
+			}
+
+			remain := t.MaxRetries - i + 1
+			if t.Logger != nil {
+				desc := fmt.Sprintf("%s %s", req.Method, req.URL.String())
+				if resp != nil {
+					desc = fmt.Sprintf("%s (status: %d)", desc, resp.StatusCode)
+				}
+				switch v := t.Logger.(type) {
+				case leveledLogger:
+					v.Debug("retrying request", "request", desc, "timeout", wait, "remaining", remain)
+				case logger:
+					v.Printf("[DEBUG] %s: retrying in %s (%d left)", desc, wait, remain)
+				}
+			}
+
+			timer := time.NewTimer(wait)
+			select {
+			case <-timer.C:
+			case <-req.Context().Done():
+				timer.Stop()
+				return nil, req.Context().Err()
+			}
+
+			if req.GetBody != nil {
+				var getErr error
+				req.Body, getErr = req.GetBody()
+				if getErr != nil {
+					return nil, getErr
+				}
+			}
+		}
+
+		transport := t.Transport
+		if transport == nil {
+			transport = http.DefaultTransport
+		}
+		resp, err = transport.RoundTrip(req)
+
+		if err != nil {
+			if t.Logger != nil {
+				switch v := t.Logger.(type) {
+				case leveledLogger:
+					if i < t.MaxRetries {
+						v.Debug("request failed", "error", err, "method", req.Method, "url", req.URL.String())
+					} else {
+						v.Error("request failed", "error", err, "method", req.Method, "url", req.URL.String())
+					}
+				case logger:
+					if i < t.MaxRetries {
+						v.Printf("[DEBUG] %s %s request failed: %v", req.Method, req.URL.String(), err)
+					} else {
+						v.Printf("[ERR] %s %s request failed: %v", req.Method, req.URL.String(), err)
+					}
+				}
+			}
+			// If context is canceled, exit immediately instead of exhausting retries
+			if req.Context().Err() != nil {
+				return nil, err
+			}
+			if !isRecoverableError(err) {
+				return nil, err
+			}
+			continue
+		}
+
+		if resp.StatusCode == http.StatusTooManyRequests || (resp.StatusCode >= 500 && resp.StatusCode != http.StatusNotImplemented) {
+			// Recoverable error
+			// Close body before next retry
+			if i < t.MaxRetries {
+				_, _ = io.CopyN(io.Discard, resp.Body, 4096)
+				resp.Body.Close()
+				continue
+			}
+			break
+		}
+
+		return resp, err
+	}
+
+	if t.ErrorHandler != nil {
+		newResp, newErr := t.ErrorHandler(resp, err, t.MaxRetries+1)
+		if newResp != resp && resp != nil {
+			_, _ = io.CopyN(io.Discard, resp.Body, 4096)
+			resp.Body.Close()
+		}
+		return newResp, newErr
+	}
+	return resp, err
+}
+
+func isRecoverableError(err error) bool {
+	if err == nil {
+		return true
+	}
+
+	var tlsErr *tls.CertificateVerificationError
+	if errors.As(err, &tlsErr) {
+		return false
+	}
+	var unkAuthErr x509.UnknownAuthorityError
+	if errors.As(err, &unkAuthErr) {
+		return false
+	}
+	var invCertErr x509.CertificateInvalidError
+	if errors.As(err, &invCertErr) {
+		return false
+	}
+	var hostErr x509.HostnameError
+	if errors.As(err, &hostErr) {
+		return false
+	}
+
+	// Unsupported protocol scheme
+	if strings.Contains(err.Error(), "unsupported protocol scheme") {
+		return false
+	}
+	return true
+}

--- a/pkg/client/retry_test.go
+++ b/pkg/client/retry_test.go
@@ -1,0 +1,551 @@
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRetryTransport(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		maxRetries   int
+		statusCodes  []int
+		expectStatus int
+		expectErrors int
+	}{
+		{
+			name:         "success on first try",
+			maxRetries:   3,
+			statusCodes:  []int{200},
+			expectStatus: 200,
+			expectErrors: 0,
+		},
+		{
+			name:         "success on second try",
+			maxRetries:   3,
+			statusCodes:  []int{500, 200},
+			expectStatus: 200,
+			expectErrors: 1, // one 500
+		},
+		{
+			name:         "fail all retries",
+			maxRetries:   2,
+			statusCodes:  []int{503, 503, 503},
+			expectStatus: 503,
+			expectErrors: 3,
+		},
+		{
+			name:         "retry on 429",
+			maxRetries:   2,
+			statusCodes:  []int{429, 200},
+			expectStatus: 200,
+			expectErrors: 1, // one 429
+		},
+		{
+			name:         "don't retry on 4xx",
+			maxRetries:   3,
+			statusCodes:  []int{404},
+			expectStatus: 404,
+			expectErrors: 0, // 404 is returned immediately
+		},
+		{
+			name:         "don't retry on 501",
+			maxRetries:   3,
+			statusCodes:  []int{501},
+			expectStatus: 501,
+			expectErrors: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tryCount := 0
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				status := tt.statusCodes[tryCount]
+				tryCount++
+
+				w.WriteHeader(status)
+
+				// Read body to test body replay
+				body, _ := io.ReadAll(r.Body)
+				if len(body) > 0 && string(body) != "request body" {
+					t.Errorf("expected body 'request body', got %q", string(body))
+				}
+			}))
+			defer ts.Close()
+
+			rt := &retryTransport{
+				Transport:    http.DefaultTransport,
+				MaxRetries:   uint(tt.maxRetries),
+				RetryWaitMin: 1 * time.Millisecond,
+				RetryWaitMax: 5 * time.Millisecond,
+			}
+
+			req, err := http.NewRequest(http.MethodPost, ts.URL, bytes.NewBufferString("request body"))
+			if err != nil {
+				t.Fatalf("failed to create request: %v", err)
+			}
+
+			resp, err := rt.RoundTrip(req)
+			if tt.expectStatus == 0 {
+				if err == nil {
+					t.Errorf("expected error, got nil (status %d)", resp.StatusCode)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				} else if resp.StatusCode != tt.expectStatus {
+					t.Errorf("expected status %d, got %d", tt.expectStatus, resp.StatusCode)
+				}
+			}
+
+			if tryCount != tt.expectErrors+1 && tryCount != len(tt.statusCodes) {
+				t.Errorf("expected %d or %d tries, got %d", tt.expectErrors+1, len(tt.statusCodes), tryCount)
+			}
+		})
+	}
+}
+
+func TestRetryTransportContextCancel(t *testing.T) {
+	t.Parallel()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(500)
+	}))
+	defer ts.Close()
+
+	rt := &retryTransport{
+		Transport:    http.DefaultTransport,
+		MaxRetries:   3,
+		RetryWaitMin: 100 * time.Millisecond,
+		RetryWaitMax: 200 * time.Millisecond,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err = rt.RoundTrip(req)
+	if err == nil {
+		t.Errorf("expected error, got nil")
+	} else if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestRetryErrorHandler(t *testing.T) {
+	t.Parallel()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	customErr := io.ErrUnexpectedEOF
+	handlerCalled := false
+
+	rt := &retryTransport{
+		Transport:    http.DefaultTransport,
+		MaxRetries:   1,
+		RetryWaitMin: 1 * time.Millisecond,
+		RetryWaitMax: 2 * time.Millisecond,
+		ErrorHandler: func(resp *http.Response, _ error, numTries uint) (*http.Response, error) {
+			handlerCalled = true
+			if numTries != 2 {
+				t.Errorf("expected 2 tries, got %d", numTries)
+			}
+			return resp, customErr
+		},
+	}
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	_, err = rt.RoundTrip(req)
+	if err != customErr {
+		t.Errorf("expected custom error, got %v", err)
+	}
+	if !handlerCalled {
+		t.Errorf("expected ErrorHandler to be called")
+	}
+}
+
+type testLogger struct {
+	messages []string
+}
+
+func (l *testLogger) Printf(format string, args ...any) {
+	l.messages = append(l.messages, fmt.Sprintf(format, args...))
+}
+
+type testLeveledLogger struct {
+	debugs []string
+	errors []string
+}
+
+func (l *testLeveledLogger) Error(msg string, keysAndValues ...any) {
+	l.errors = append(l.errors, fmt.Sprintf("%s %v", msg, keysAndValues))
+}
+
+func (l *testLeveledLogger) Info(_ string, _ ...any) {}
+
+func (l *testLeveledLogger) Debug(msg string, keysAndValues ...any) {
+	l.debugs = append(l.debugs, fmt.Sprintf("%s %v", msg, keysAndValues))
+}
+
+func (l *testLeveledLogger) Warn(_ string, _ ...any) {}
+
+func TestRetryTransportLogger(t *testing.T) {
+	t.Parallel()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	t.Run("Standard Logger", func(t *testing.T) {
+		logger := &testLogger{}
+		rt := &retryTransport{
+			Transport:    http.DefaultTransport,
+			MaxRetries:   1,
+			RetryWaitMin: 1 * time.Millisecond,
+			RetryWaitMax: 2 * time.Millisecond,
+			Logger:       logger,
+		}
+
+		req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+		if err != nil {
+			t.Fatalf("failed to create request: %v", err)
+		}
+		_, _ = rt.RoundTrip(req)
+
+		if len(logger.messages) < 2 {
+			t.Errorf("expected at least 2 log messages, got %d", len(logger.messages))
+		}
+	})
+
+	t.Run("Leveled Logger", func(t *testing.T) {
+		logger := &testLeveledLogger{}
+		rt := &retryTransport{
+			Transport:    http.DefaultTransport,
+			MaxRetries:   1,
+			RetryWaitMin: 1 * time.Millisecond,
+			RetryWaitMax: 2 * time.Millisecond,
+			Logger:       logger,
+		}
+
+		req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+		if err != nil {
+			t.Fatalf("failed to create request: %v", err)
+		}
+		_, _ = rt.RoundTrip(req)
+
+		if len(logger.debugs) < 2 {
+			t.Errorf("expected at least 2 debug messages, got %d", len(logger.debugs))
+		}
+	})
+}
+
+func TestRetryAfterHeader(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		headerFunc func() string
+	}{
+		{
+			name: "Seconds format",
+			headerFunc: func() string {
+				return "1"
+			},
+		},
+		{
+			name: "Date format",
+			headerFunc: func() string {
+				// Add 2 seconds to ensure truncation in http.TimeFormat
+				// still results in a wait of at least 1 second.
+				return time.Now().Add(2 * time.Second).UTC().Format(http.TimeFormat)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tryCount := 0
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				tryCount++
+				if tryCount == 1 {
+					w.Header().Set("Retry-After", tt.headerFunc())
+					w.WriteHeader(http.StatusTooManyRequests)
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer ts.Close()
+
+			rt := &retryTransport{
+				Transport:    http.DefaultTransport,
+				MaxRetries:   1,
+				RetryWaitMin: 1 * time.Millisecond,
+				RetryWaitMax: 2 * time.Second, // Increased to allow the 1s Retry-After header
+			}
+
+			req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+			if err != nil {
+				t.Fatalf("failed to create request: %v", err)
+			}
+
+			start := time.Now()
+			_, _ = rt.RoundTrip(req)
+			elapsed := time.Since(start)
+
+			if elapsed < 1*time.Second {
+				t.Errorf("expected to wait at least 1s due to Retry-After, but took %v", elapsed)
+			}
+			if tryCount != 2 {
+				t.Errorf("expected 2 tries, got %d", tryCount)
+			}
+		})
+	}
+}
+
+type testUnrecoverableTransport struct {
+	tries int
+}
+
+func (t *testUnrecoverableTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	t.tries++
+	return nil, fmt.Errorf("unsupported protocol scheme")
+}
+
+func TestUnrecoverableError(t *testing.T) {
+	t.Parallel()
+
+	transport := &testUnrecoverableTransport{}
+	rt := &retryTransport{
+		Transport:    transport,
+		MaxRetries:   3,
+		RetryWaitMin: 1 * time.Millisecond,
+		RetryWaitMax: 2 * time.Millisecond,
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "http://test", nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	_, err = rt.RoundTrip(req)
+
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	if transport.tries != 1 {
+		t.Errorf("expected 1 try for unrecoverable error, got %d", transport.tries)
+	}
+}
+
+func TestRetryGetBodyError(t *testing.T) {
+	t.Parallel()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(500)
+	}))
+	defer ts.Close()
+
+	rt := &retryTransport{
+		Transport:    http.DefaultTransport,
+		MaxRetries:   3,
+		RetryWaitMin: 1 * time.Millisecond,
+		RetryWaitMax: 2 * time.Millisecond,
+	}
+
+	req, err := http.NewRequest(http.MethodPost, ts.URL, bytes.NewBufferString("first body"))
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	expectedErr := fmt.Errorf("simulated GetBody error")
+	req.GetBody = func() (io.ReadCloser, error) {
+		return nil, expectedErr
+	}
+
+	_, err = rt.RoundTrip(req)
+	if err != expectedErr {
+		t.Errorf("expected %v, got %v", expectedErr, err)
+	}
+}
+
+type closeTrackingBody struct {
+	closed bool
+}
+
+func (b *closeTrackingBody) Read(_ []byte) (n int, err error) {
+	return 0, io.EOF
+}
+
+func (b *closeTrackingBody) Close() error {
+	b.closed = true
+	return nil
+}
+
+type mockTransport struct {
+	body *closeTrackingBody
+}
+
+func (m *mockTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	m.body = &closeTrackingBody{}
+	return &http.Response{
+		StatusCode: 500,
+		Body:       m.body,
+	}, nil
+}
+
+func TestRetryErrorHandlerClosesBody(t *testing.T) {
+	t.Parallel()
+
+	mt := &mockTransport{}
+	rt := &retryTransport{
+		Transport:    mt,
+		MaxRetries:   0,
+		RetryWaitMin: 1 * time.Millisecond,
+		RetryWaitMax: 2 * time.Millisecond,
+		ErrorHandler: func(_ *http.Response, _ error, _ uint) (*http.Response, error) {
+			// Deliberately return nil response to trigger the leak cleanup
+			return nil, fmt.Errorf("custom error")
+		},
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, "http://test", nil)
+	_, _ = rt.RoundTrip(req)
+
+	if mt.body == nil || !mt.body.closed {
+		t.Errorf("expected response body to be closed by transport when ErrorHandler drops it")
+	}
+}
+
+type mockContextTransport struct {
+	cancel context.CancelFunc
+}
+
+func (m *mockContextTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	m.cancel()
+	<-req.Context().Done()
+	return nil, fmt.Errorf("url error: %w", req.Context().Err())
+}
+
+func TestRetryContextErrorPreserved(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	rt := &retryTransport{
+		Transport:  &mockContextTransport{cancel: cancel},
+		MaxRetries: 3,
+	}
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://test", nil)
+
+	_, err := rt.RoundTrip(req)
+	if err == nil || !strings.Contains(err.Error(), "url error") {
+		t.Errorf("expected original error to be preserved, got %v", err)
+	}
+}
+
+func TestRetryContextCancelLeaksBody(t *testing.T) {
+	t.Parallel()
+
+	rt := &retryTransport{
+		Transport:  http.DefaultTransport,
+		MaxRetries: 3,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "http://test", nil)
+
+	tc := &closeTrackingBody{}
+	req.GetBody = func() (io.ReadCloser, error) {
+		return tc, nil
+	}
+	req.Body = tc
+
+	_, err := rt.RoundTrip(req)
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+
+	if !tc.closed {
+		t.Errorf("expected GetBody to be closed when returning early due to context cancellation")
+	}
+}
+
+func TestRetryContextCancelLeaksDynamicBody(t *testing.T) {
+	t.Parallel()
+
+	rt := &retryTransport{
+		Transport:  http.DefaultTransport,
+		MaxRetries: 3,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "http://test", nil)
+
+	tc1 := &closeTrackingBody{}
+	tc2 := &closeTrackingBody{}
+
+	callCount := 0
+	req.GetBody = func() (io.ReadCloser, error) {
+		callCount++
+		if callCount == 1 {
+			return tc2, nil
+		}
+		return nil, fmt.Errorf("should not be called more than once")
+	}
+	req.Body = tc1
+
+	_, err := rt.RoundTrip(req)
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+
+	if !tc1.closed {
+		t.Errorf("expected original Body (tc1) to be closed")
+	}
+	if !tc2.closed {
+		t.Errorf("expected cloned Body (tc2) to be closed when returning early")
+	}
+}


### PR DESCRIPTION
This implements a simple retrying transport with backoff, so that we can drop a few dependencies. This maintains full feature parity.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
