### PR TITLE
ensure invalid treeIDs always return with 400 errors

### DIFF
--- a/pkg/api/entries.go
+++ b/pkg/api/entries.go
@@ -713,10 +713,7 @@ func retrieveLogEntry(ctx context.Context, entryUUID string) (models.LogEntry, e
 
 	uuid, err := sharding.GetUUIDFromIDString(entryUUID)
 	if err != nil {
-		if len(entryUUID) == sharding.EntryIDHexStringLen {
-			return nil, &types.InputValidationError{Err: err}
-		}
-		return nil, sharding.ErrPlainUUID
+		return nil, &types.InputValidationError{Err: err}
 	}
 
 	// Get the tree ID and check that shard for the entry

--- a/pkg/api/entries_test.go
+++ b/pkg/api/entries_test.go
@@ -50,21 +50,28 @@ func TestRetrieveUUIDFromTree_UnconfiguredTreeID(t *testing.T) {
 	}
 }
 
-func TestGetLogEntryByUUIDHandler_InvalidTreeID(t *testing.T) {
-	invalidEntryID := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-
-	req := httptest.NewRequest("GET", "/api/v1/log/entries/"+invalidEntryID, nil)
-	params := entries.GetLogEntryByUUIDParams{
-		HTTPRequest: req,
-		EntryUUID:   invalidEntryID,
+func TestGetLogEntryByUUIDHandler_InvalidID(t *testing.T) {
+	tests := map[string]string{
+		"invalid tree ID": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		"malformed UUID":  "gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg",
 	}
 
-	responder := GetLogEntryByUUIDHandler(params)
+	for name, invalidID := range tests {
+		t.Run(name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/api/v1/log/entries/"+invalidID, nil)
+			params := entries.GetLogEntryByUUIDParams{
+				HTTPRequest: req,
+				EntryUUID:   invalidID,
+			}
 
-	recorder := httptest.NewRecorder()
-	responder.WriteResponse(recorder, runtime.JSONProducer())
+			responder := GetLogEntryByUUIDHandler(params)
 
-	if recorder.Code != http.StatusBadRequest {
-		t.Errorf("Expected status code %d (Bad Request), got %d", http.StatusBadRequest, recorder.Code)
+			recorder := httptest.NewRecorder()
+			responder.WriteResponse(recorder, runtime.JSONProducer())
+
+			if recorder.Code != http.StatusBadRequest {
+				t.Errorf("Expected status code %d (Bad Request), got %d", http.StatusBadRequest, recorder.Code)
+			}
+		})
 	}
 }


### PR DESCRIPTION
If we are unable to extract the treeId and UUID from the provided URI, we should always return a 400 error regardless of whatever the input length was. 