### PR TITLE
Validate the helm chart hash algorithm before it becomes a leaf

### DIFF
--- a/pkg/types/helm/v0.0.1/entry.go
+++ b/pkg/types/helm/v0.0.1/entry.go
@@ -261,6 +261,14 @@ func (v *V001Entry) Canonicalize(ctx context.Context) ([]byte, error) {
 	canonicalEntry.Chart.Hash.Algorithm = &algorithm
 	canonicalEntry.Chart.Hash.Value = &chartHash
 
+	// The algorithm comes verbatim out of the signed provenance, while the field it
+	// lands in is enum-constrained. Without this the create path will happily persist
+	// a leaf that the read path's own Validate then refuses, which breaks the
+	// canonicalization invariant that AssertCanonicalIdempotent checks for.
+	if err := canonicalEntry.Chart.Hash.Validate(strfmt.Default); err != nil {
+		return nil, &types.InputValidationError{Err: err}
+	}
+
 	canonicalEntry.Chart.Provenance = &models.HelmV001SchemaChartProvenance{}
 	canonicalEntry.Chart.Provenance.Signature = &models.HelmV001SchemaChartProvenanceSignature{}
 

--- a/pkg/types/helm/v0.0.1/entry_test.go
+++ b/pkg/types/helm/v0.0.1/entry_test.go
@@ -23,6 +23,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
+	"github.com/ProtonMail/go-crypto/openpgp/clearsign"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag/conv"
@@ -363,6 +366,110 @@ func TestInsertable(t *testing.T) {
 		t.Run(tc.caseDesc, func(t *testing.T) {
 			if ok, err := tc.entry.Insertable(); ok != tc.expectSuccess {
 				t.Errorf("unexpected result calling Insertable: %v", err)
+			}
+		})
+	}
+}
+
+// signedProvenance builds a clear-signed Helm provenance whose files: block records the chart
+// under the given "<algorithm>:<value>" pair, and returns it with the matching armored public key.
+func signedProvenance(t *testing.T, hashField string) (provenance []byte, publicKey []byte) {
+	t.Helper()
+
+	entity, err := openpgp.NewEntity("rekor test", "helm provenance", "rekor-test@example.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body := "apiVersion: v2\nname: test\nversion: 0.1.0\n\n...\nfiles:\n  test-0.1.0.tgz: " + hashField + "\n"
+
+	var provBuf bytes.Buffer
+	writer, err := clearsign.Encode(&provBuf, entity.PrivateKey, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writer.Write([]byte(body)); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var keyBuf bytes.Buffer
+	armorWriter, err := armor.Encode(&keyBuf, openpgp.PublicKeyType, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := entity.Serialize(armorWriter); err != nil {
+		t.Fatal(err)
+	}
+	if err := armorWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	return provBuf.Bytes(), keyBuf.Bytes()
+}
+
+// The chart hash algorithm is taken verbatim out of the signed provenance, but the field it is
+// copied into is enum-constrained to sha256. Without a check on the way in, Canonicalize produces
+// a leaf that the read path's own Validate then rejects.
+func TestCanonicalizeRejectsNonSchemaChartHashAlgorithm(t *testing.T) {
+	for _, tc := range []struct {
+		caseDesc     string
+		hashField    string
+		expectsError bool
+	}{
+		{
+			caseDesc:     "sha256, as the schema requires",
+			hashField:    "sha256:6dec7ea21e655d5796c1e214cfb75b73428b2abfa2e66c8f7bc64ff4a7b3b29f",
+			expectsError: false,
+		},
+		{
+			caseDesc:     "algorithm outside the schema enum",
+			hashField:    "not-a-hash-algorithm:../../etc/passwd",
+			expectsError: true,
+		},
+	} {
+		t.Run(tc.caseDesc, func(t *testing.T) {
+			provenanceBytes, publicKeyBytes := signedProvenance(t, tc.hashField)
+
+			v := &V001Entry{}
+			r := models.Helm{
+				APIVersion: conv.Pointer("0.0.1"),
+				Spec: models.HelmV001Schema{
+					PublicKey: &models.HelmV001SchemaPublicKey{
+						Content: (*strfmt.Base64)(&publicKeyBytes),
+					},
+					Chart: &models.HelmV001SchemaChart{
+						Provenance: &models.HelmV001SchemaChartProvenance{
+							Content: strfmt.Base64(provenanceBytes),
+						},
+					},
+				},
+			}
+
+			if err := v.Unmarshal(&r); err != nil {
+				t.Fatalf("unmarshal failed, so the test never reaches Canonicalize: %v", err)
+			}
+
+			canonicalized, err := v.Canonicalize(context.TODO())
+			if tc.expectsError {
+				if err == nil {
+					t.Fatalf("expected canonicalization to fail, got leaf: %s", canonicalized)
+				}
+				var validationErr *types.InputValidationError
+				if !errors.As(err, &validationErr) {
+					t.Errorf("expected a types.InputValidationError, got %T: %v", err, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("positive control failed to canonicalize: %v", err)
+			}
+
+			if len(canonicalized) == 0 {
+				t.Fatal("positive control produced an empty leaf")
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

`GetChartAlgorithmHash` (`pkg/types/helm/provenance.go:84-99`) splits the `files:` entry out of the clear-signed provenance and returns both halves verbatim:

```go
parts := strings.Split(value, ":")
if len(parts) != 2 {
    return "", "", errors.New("invalid hash found in Provenance file")
}
return parts[0], parts[1], nil
```

`Canonicalize` (`pkg/types/helm/v0.0.1/entry.go:254-262`) copies them straight into the canonical entry that becomes the Merkle leaf, and the algorithm is never re-checked. The field it lands in is enum-constrained: `HelmV001SchemaChartHash.Algorithm` is generated as `Required: true, Enum: ["sha256"]`.

The result is that the create path writes a leaf the read path then rejects. `logEntryFromLeaf` (`pkg/api/entries.go:146-155`) runs `types.UnmarshalEntry` over the persisted leaf, which calls `Validate(strfmt.Default)`, and that refuses the algorithm canonicalization just produced:

```
chart.chart.hash.chart.hash.algorithm in body should be one of [sha256]
```

The same value supplied directly in the proposed entry is refused at `CreateVersionedEntry`, so the provenance is the only route in. That asymmetry is the bug: one field, accepted through one door and rejected at the other.

This is the invariant `AssertCanonicalIdempotent` describes in `pkg/fuzz/fuzz_utils.go`, that bytes produced by `CanonicalizeEntry` must survive being re-parsed and re-canonicalized. The helm fuzz targets do not reach it: `FuzzHelmUnmarshalAndCanonicalize` skips when canonicalization fails, and random struct generation will not synthesise a valid clear-signed provenance plus matching key, while `FuzzHelmCreateProposedEntry` reaches a real provenance but never calls the assertion.

The fix validates the constructed hash against the generated model, so the enum stays the single source of truth rather than being restated.

## Release Note

Reject a helm entry whose provenance declares a chart hash algorithm outside the schema, instead of persisting a leaf that cannot be read back.

## Verification

A table test in `pkg/types/helm/v0.0.1/entry_test.go` generates a PGP key, clear-signs a provenance, and canonicalizes. The `sha256` row is the positive control and passes both before and after. The `not-a-hash-algorithm` row fails on main, printing the leaf that would have been written:

```
expected canonicalization to fail, got leaf: {"apiVersion":"0.0.1","spec":{"chart":{"hash":
{"algorithm":"not-a-hash-algorithm","value":"../../etc/passwd"}, ...
```

and passes with the change. `go test ./pkg/types/...` has no failures.

One thing I looked at and am deliberately not claiming: the value half is unconstrained by the schema and reaches the search index verbatim as `not-a-hash-algorithm:../../etc/passwd`. I checked the index writers and found no injection, since the redis client parameterises and `pkg/indexstorage/mysql/mysql.go:34` is a named-parameter prepared statement. It is key pollution, not injection.
